### PR TITLE
feat: add heartbeat_enabled and standby_mode config options

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,16 @@ recovery_key = "EsT... "
 # Where to store matrix-sdk state / crypto DB (default: ~/.local/share/sapphire-agent/matrix)
 # state_dir = "~/.local/share/sapphire-agent/matrix"
 
+# Disable heartbeat (day-boundary + cron) tasks. Useful for test
+# environments that share the same workspace to avoid duplicate tasks.
+# heartbeat_enabled = false
+
+# Cold-standby mode: only perform git sync — no channel listening,
+# no heartbeat, no HTTP server. The process stays alive for periodic
+# sync and shuts down on Ctrl-C. Manual switchover to active mode
+# by flipping this flag and restarting.
+# standby_mode = true
+
 # Directory containing AGENT.md and MEMORY.md.
 # Defaults to the same directory as this config file.
 # workspace_dir = "~/.config/sapphire-agent"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,16 @@ pub struct Config {
     /// Whether to compact MEMORY.md at the day boundary. Default: true.
     #[serde(default = "default_true")]
     pub memory_compaction_enabled: bool,
+    /// Whether to enable heartbeat (day-boundary + cron) tasks. Default: true.
+    /// Set to false in test environments to avoid duplicate heartbeat tasks
+    /// when both test and production instances share the same config.
+    #[serde(default = "default_true")]
+    pub heartbeat_enabled: bool,
+    /// Cold-standby mode: only perform git sync, skip channel listening and
+    /// heartbeat tasks. Useful for maintaining a backup node that stays in
+    /// sync without actively processing messages. Default: false.
+    #[serde(default)]
+    pub standby_mode: bool,
 }
 
 fn default_true() -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,8 @@ async fn main() -> Result<()> {
                 "  Day boundary hour : {}:00 local",
                 config.day_boundary_hour
             );
+            println!("  Heartbeat enabled : {}", config.heartbeat_enabled);
+            println!("  Standby mode      : {}", config.standby_mode);
             println!();
             let workspace_files = [
                 ("AGENTS.md / AGENT.md", vec!["AGENTS.md", "AGENT.md"]),
@@ -215,8 +217,16 @@ async fn main() -> Result<()> {
                 Arc::clone(&ws_state),
             ));
 
+            if config.standby_mode {
+                tracing::info!(
+                    "Standby mode enabled: git sync only, skipping channel and heartbeat"
+                );
+            }
+
             // ── Channel + Agent (Matrix or Discord, if configured) ──────────
-            if config.matrix.is_some() || config.discord.is_some() {
+            if !config.standby_mode
+                && (config.matrix.is_some() || config.discord.is_some())
+            {
                 let channel_name = if config.discord.is_some() {
                     "discord"
                 } else {
@@ -278,7 +288,11 @@ async fn main() -> Result<()> {
                     agent: Arc::clone(&agent),
                     default_room_id,
                 };
-                heartbeat.spawn();
+                if config.heartbeat_enabled {
+                    heartbeat.spawn();
+                } else {
+                    tracing::info!("Heartbeat disabled by config");
+                }
 
                 let agent_run = Arc::clone(&agent);
                 tokio::spawn(async move {
@@ -288,25 +302,35 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // ── HTTP API server ─────────────────────────────────────────────
-            let addr = bind
-                .or_else(|| {
-                    config
-                        .serve
-                        .as_ref()
-                        .map(|s| format!("{}:{}", s.host, s.port))
-                })
-                .unwrap_or_else(|| "127.0.0.1:9000".to_string());
+            if config.standby_mode {
+                // In standby mode, keep the process alive for periodic git
+                // sync only — no HTTP server, no channel, no heartbeat.
+                tracing::info!("Standby mode: waiting for shutdown signal (Ctrl-C)");
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("Failed to listen for Ctrl-C");
+                tracing::info!("Shutting down standby process");
+            } else {
+                // ── HTTP API server ─────────────────────────────────────────
+                let addr = bind
+                    .or_else(|| {
+                        config
+                            .serve
+                            .as_ref()
+                            .map(|s| format!("{}:{}", s.host, s.port))
+                    })
+                    .unwrap_or_else(|| "127.0.0.1:9000".to_string());
 
-            serve::run(
-                addr,
-                config,
-                provider,
-                workspace,
-                tool_set,
-                api_session_store,
-            )
-            .await?;
+                serve::run(
+                    addr,
+                    config,
+                    provider,
+                    workspace,
+                    tool_set,
+                    api_session_store,
+                )
+                .await?;
+            }
         }
         Command::Call { .. } => unreachable!(),
     }


### PR DESCRIPTION
## Summary

- Add `heartbeat_enabled` config option (default: `true`) to allow disabling heartbeat tasks (day-boundary + cron) independently. This prevents duplicate heartbeat triggers when a test instance shares the same workspace/config as production but targets different channels.
- Add `standby_mode` config option (default: `false`) for cold-standby deployments. When enabled, only periodic git sync runs — channel listening, heartbeat, and HTTP server are all skipped. The process stays alive via signal wait (Ctrl-C to shut down). No HTTP server means simpler health-check/proxy configuration for standby nodes.
- Both settings are shown in `verify` output and documented in `config.example.toml`.

## Test plan

- [ ] Set `heartbeat_enabled = false` and verify heartbeat tasks do not spawn while channel + HTTP server still work
- [ ] Set `standby_mode = true` and verify only git sync runs (no channel connection, no HTTP listener)
- [ ] Verify default behavior is unchanged (both options use safe defaults)
- [ ] Run `sapphire-agent verify` and confirm new fields are displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)