### PR TITLE
feat: built-in MCP client for external server tool integration

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -288,7 +288,14 @@ impl Agent {
 
         let _ = self.channel.start_typing(&incoming.room_id).await;
 
-        let tool_specs = self.tools.as_ref().map(|t| t.specs().to_vec());
+        // Refresh MCP tools if any server signalled a change.
+        if let Some(tools) = &self.tools {
+            tools.refresh_if_needed().await;
+        }
+        let tool_specs = match &self.tools {
+            Some(t) => Some(t.specs().await),
+            None => None,
+        };
 
         // Tool-calling loop
         let mut accumulated_text: Vec<String> = Vec::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,47 @@ fn default_serve_port() -> u16 {
 pub struct ToolsConfig {
     /// Tavily API key for `web_search`. If absent the tool is not registered.
     pub tavily_api_key: Option<String>,
+    /// External MCP servers to connect to. Each server's tools are registered
+    /// with the naming convention `mcp__<name>__<tool_name>`.
+    #[serde(default)]
+    pub mcp_servers: Vec<McpServerConfig>,
+}
+
+/// Configuration for a single external MCP server.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpServerConfig {
+    /// Human-readable name (used in tool prefix: `mcp__<name>__<tool>`).
+    pub name: String,
+    /// Transport configuration.
+    #[serde(flatten)]
+    pub transport: McpTransportConfig,
+}
+
+/// Transport configuration for connecting to an MCP server.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum McpTransportConfig {
+    /// Streamable HTTP transport.
+    #[serde(rename = "http")]
+    Http {
+        /// Server URL (e.g. `http://localhost:3000/mcp`).
+        url: String,
+        /// Optional API key / bearer token.
+        #[serde(default)]
+        api_key: Option<String>,
+    },
+    /// stdio transport — spawn a child process and communicate via stdin/stdout.
+    #[serde(rename = "stdio")]
+    Stdio {
+        /// Command to execute (e.g. `"npx"`, `"uvx"`, `"/path/to/server"`).
+        command: String,
+        /// Command arguments.
+        #[serde(default)]
+        args: Vec<String>,
+        /// Additional environment variables passed to the child process.
+        #[serde(default)]
+        env: std::collections::HashMap<String, String>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod daily_log;
 mod heartbeat;
 mod heartbeat_config;
+mod mcp_client;
 mod memory_compaction;
 mod provider;
 mod serve;
@@ -199,10 +200,14 @@ async fn main() -> Result<()> {
             }
 
             // ── Tools ───────────────────────────────────────────────────────
-            let tool_set = Arc::new(tools::default_tool_set(
-                Arc::clone(&ws_state),
-                config.tools.tavily_api_key.clone(),
-            ));
+            let tool_set = Arc::new(
+                tools::default_tool_set(
+                    Arc::clone(&ws_state),
+                    config.tools.tavily_api_key.clone(),
+                    &config.tools.mcp_servers,
+                )
+                .await,
+            );
 
             // ── Session store base directory ────────────────────────────────
             let sessions_base = config.resolved_sessions_dir(&workspace_dir);

--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -13,9 +13,12 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
-use tracing::{info, warn};
-use transport::{HttpTransport, McpTransport, ServerRequestHandler, StdioTransport};
+use tracing::{debug, info, warn};
+use transport::{
+    HttpTransport, McpTransport, NotificationHandler, ServerRequestHandler, StdioTransport,
+};
 
 // ---------------------------------------------------------------------------
 // Remote tool metadata
@@ -38,6 +41,8 @@ pub struct McpClient {
     transport: Box<dyn McpTransport>,
     workspace_root: String,
     request_id: Mutex<u64>,
+    /// Set to `true` when the server sends `notifications/tools/list_changed`.
+    tools_changed: Arc<AtomicBool>,
 }
 
 impl McpClient {
@@ -57,7 +62,19 @@ impl McpClient {
             transport,
             workspace_root: workspace_root.to_string(),
             request_id: Mutex::new(1),
+            tools_changed: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// The server name (used as the tool namespace prefix).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Check and clear the `tools_changed` flag.
+    /// Returns `true` if the tool list has changed since the last check.
+    pub fn take_tools_changed(&self) -> bool {
+        self.tools_changed.swap(false, Ordering::Relaxed)
     }
 
     /// Get the next request ID.
@@ -85,7 +102,6 @@ impl McpClient {
                     })
                 }
                 "elicitation/create" => {
-                    // Auto-accept with the message echoed back.
                     let message = params
                         .get("message")
                         .and_then(|v| v.as_str())
@@ -117,6 +133,19 @@ impl McpClient {
         })
     }
 
+    /// Build the notification handler that watches for `tools/list_changed`.
+    fn notification_handler(&self) -> NotificationHandler {
+        let tools_changed = Arc::clone(&self.tools_changed);
+        let name = self.name.clone();
+        Arc::new(move |method: &str, _params: &Value| {
+            debug!("MCP '{name}': notification: {method}");
+            if method == "notifications/tools/list_changed" {
+                info!("MCP '{name}': tool list changed, will refresh");
+                tools_changed.store(true, Ordering::Relaxed);
+            }
+        })
+    }
+
     /// Send a JSON-RPC request through the transport.
     async fn send(&self, method: &str, params: Value) -> Result<Value> {
         let id = self.next_id().await;
@@ -127,8 +156,12 @@ impl McpClient {
             "params": params,
         });
 
-        let handler = self.server_request_handler();
-        let response = self.transport.request(&body, &handler).await?;
+        let req_handler = self.server_request_handler();
+        let notif_handler = self.notification_handler();
+        let response = self
+            .transport
+            .request(&body, &req_handler, &notif_handler)
+            .await?;
 
         if let Some(err) = response.get("error") {
             let msg = err["message"].as_str().unwrap_or("unknown error");
@@ -165,14 +198,16 @@ impl McpClient {
         );
 
         // Send initialized notification (no id, no response expected).
-        // For stdio, we write directly; for HTTP we send as a POST.
         let notification = json!({
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         });
-        // Best-effort notification — ignore errors.
-        let handler = self.server_request_handler();
-        let _ = self.transport.request(&notification, &handler).await;
+        let req_handler = self.server_request_handler();
+        let notif_handler = self.notification_handler();
+        let _ = self
+            .transport
+            .request(&notification, &req_handler, &notif_handler)
+            .await;
 
         Ok(())
     }
@@ -267,16 +302,38 @@ impl Tool for McpTool {
 }
 
 // ---------------------------------------------------------------------------
-// Factory: connect to configured MCP servers and collect their tools
+// Factory helpers
 // ---------------------------------------------------------------------------
 
-/// Connect to all configured MCP servers and return their tools wrapped as
-/// local `Tool` implementations.
+/// Build `McpTool` instances from a connected client's tool list.
+pub fn build_tools_for_client(client: &Arc<McpClient>, remote_tools: Vec<RemoteToolSpec>) -> Vec<Box<dyn Tool>> {
+    remote_tools
+        .into_iter()
+        .map(|rt| {
+            let tool_name = format!("mcp__{}__{}", client.name(), rt.name);
+            Box::new(McpTool {
+                client: Arc::clone(client),
+                spec: ToolSpec {
+                    name: Cow::Owned(tool_name),
+                    description: Cow::Owned(rt.description),
+                    input_schema: rt.input_schema,
+                },
+                remote_tool_name: rt.name,
+            }) as Box<dyn Tool>
+        })
+        .collect()
+}
+
+/// Connect to all configured MCP servers.  Returns `(tools, clients)`.
+///
+/// The clients are needed later to check `tools_changed` and refresh the
+/// tool set dynamically via `ToolSet::refresh_if_needed`.
 pub async fn create_mcp_tools(
     configs: &[McpServerConfig],
     workspace_root: &str,
-) -> Vec<Box<dyn Tool>> {
+) -> (Vec<Box<dyn Tool>>, Vec<Arc<McpClient>>) {
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+    let mut clients: Vec<Arc<McpClient>> = Vec::new();
 
     for config in configs {
         let client = match McpClient::new(config, workspace_root).await {
@@ -294,24 +351,15 @@ pub async fn create_mcp_tools(
 
         match client.list_tools().await {
             Ok(remote_tools) => {
-                for rt in remote_tools {
-                    let tool_name = format!("mcp__{}__{}", config.name, rt.name);
-                    tools.push(Box::new(McpTool {
-                        client: Arc::clone(&client),
-                        spec: ToolSpec {
-                            name: Cow::Owned(tool_name),
-                            description: Cow::Owned(rt.description),
-                            input_schema: rt.input_schema,
-                        },
-                        remote_tool_name: rt.name,
-                    }));
-                }
+                tools.extend(build_tools_for_client(&client, remote_tools));
             }
             Err(e) => {
                 warn!("MCP '{}': failed to list tools: {e:#}", config.name);
             }
         }
+
+        clients.push(client);
     }
 
-    tools
+    (tools, clients)
 }

--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -1,0 +1,317 @@
+//! Built-in MCP client for connecting to external MCP servers.
+//!
+//! Each configured MCP server's tools are registered in the agent's `ToolSet`
+//! using the naming convention `mcp__<server_name>__<tool_name>`.
+
+pub mod transport;
+
+use crate::config::{McpServerConfig, McpTransportConfig};
+use crate::provider::ToolSpec;
+use crate::tools::Tool;
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::borrow::Cow;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+use transport::{HttpTransport, McpTransport, ServerRequestHandler, StdioTransport};
+
+// ---------------------------------------------------------------------------
+// Remote tool metadata
+// ---------------------------------------------------------------------------
+
+/// A tool specification retrieved from a remote MCP server.
+pub struct RemoteToolSpec {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+// ---------------------------------------------------------------------------
+// MCP Client
+// ---------------------------------------------------------------------------
+
+/// Client for a single external MCP server.
+pub struct McpClient {
+    name: String,
+    transport: Box<dyn McpTransport>,
+    workspace_root: String,
+    request_id: Mutex<u64>,
+}
+
+impl McpClient {
+    /// Create a new client and establish the transport.
+    pub async fn new(config: &McpServerConfig, workspace_root: &str) -> Result<Self> {
+        let transport: Box<dyn McpTransport> = match &config.transport {
+            McpTransportConfig::Http { url, api_key } => {
+                Box::new(HttpTransport::new(url.clone(), api_key.clone()))
+            }
+            McpTransportConfig::Stdio { command, args, env } => {
+                Box::new(StdioTransport::new(command, args, env).await?)
+            }
+        };
+
+        Ok(Self {
+            name: config.name.clone(),
+            transport,
+            workspace_root: workspace_root.to_string(),
+            request_id: Mutex::new(1),
+        })
+    }
+
+    /// Get the next request ID.
+    async fn next_id(&self) -> u64 {
+        let mut id = self.request_id.lock().await;
+        let current = *id;
+        *id += 1;
+        current
+    }
+
+    /// Build the server-request handler that handles Elicitation, Roots, and
+    /// Sampling callbacks from the MCP server.
+    fn server_request_handler(&self) -> ServerRequestHandler {
+        let workspace_root = self.workspace_root.clone();
+        Arc::new(move |method: &str, params: &Value| -> Value {
+            match method {
+                "roots/list" => {
+                    json!({
+                        "result": {
+                            "roots": [{
+                                "uri": format!("file://{workspace_root}"),
+                                "name": "workspace"
+                            }]
+                        }
+                    })
+                }
+                "elicitation/create" => {
+                    // Auto-accept with the message echoed back.
+                    let message = params
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    json!({
+                        "result": {
+                            "action": "accept",
+                            "content": message
+                        }
+                    })
+                }
+                "sampling/createMessage" => {
+                    json!({
+                        "error": {
+                            "code": -32601,
+                            "message": "Sampling is not supported by this client"
+                        }
+                    })
+                }
+                _ => {
+                    json!({
+                        "error": {
+                            "code": -32601,
+                            "message": format!("Unknown method: {method}")
+                        }
+                    })
+                }
+            }
+        })
+    }
+
+    /// Send a JSON-RPC request through the transport.
+    async fn send(&self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id().await;
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let handler = self.server_request_handler();
+        let response = self.transport.request(&body, &handler).await?;
+
+        if let Some(err) = response.get("error") {
+            let msg = err["message"].as_str().unwrap_or("unknown error");
+            let code = err["code"].as_i64().unwrap_or(-1);
+            bail!("MCP server error {code}: {msg}");
+        }
+
+        Ok(response.get("result").cloned().unwrap_or(Value::Null))
+    }
+
+    /// Initialize the MCP session (handshake).
+    pub async fn connect(&self) -> Result<()> {
+        let params = json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {
+                "roots": { "listChanged": false },
+                "elicitation": {}
+            },
+            "clientInfo": {
+                "name": "sapphire-agent",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        });
+
+        let result = self.send("initialize", params).await?;
+        info!(
+            "MCP '{}': connected (server: {})",
+            self.name,
+            result
+                .get("serverInfo")
+                .and_then(|s| s.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("unknown")
+        );
+
+        // Send initialized notification (no id, no response expected).
+        // For stdio, we write directly; for HTTP we send as a POST.
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        });
+        // Best-effort notification — ignore errors.
+        let handler = self.server_request_handler();
+        let _ = self.transport.request(&notification, &handler).await;
+
+        Ok(())
+    }
+
+    /// List tools available on the remote MCP server.
+    pub async fn list_tools(&self) -> Result<Vec<RemoteToolSpec>> {
+        let result = self.send("tools/list", json!({})).await?;
+        let tools = result
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let specs: Vec<RemoteToolSpec> = tools
+            .into_iter()
+            .filter_map(|t| {
+                let name = t.get("name")?.as_str()?.to_string();
+                let description = t
+                    .get("description")
+                    .and_then(|d| d.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let input_schema = t.get("inputSchema").cloned().unwrap_or(json!({}));
+                Some(RemoteToolSpec {
+                    name,
+                    description,
+                    input_schema,
+                })
+            })
+            .collect();
+
+        info!("MCP '{}': found {} tools", self.name, specs.len());
+        Ok(specs)
+    }
+
+    /// Call a tool on the remote MCP server.
+    pub async fn call_tool(&self, name: &str, arguments: &Value) -> Result<Value> {
+        let params = json!({
+            "name": name,
+            "arguments": arguments,
+        });
+        self.send("tools/call", params).await
+    }
+
+    /// Shut down the transport.
+    pub async fn shutdown(&self) -> Result<()> {
+        self.transport.shutdown().await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// McpTool — wraps a single remote tool as a local Tool impl
+// ---------------------------------------------------------------------------
+
+/// A Tool implementation that delegates to a remote MCP server.
+pub struct McpTool {
+    client: Arc<McpClient>,
+    spec: ToolSpec,
+    remote_tool_name: String,
+}
+
+#[async_trait]
+impl Tool for McpTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, input: &serde_json::Value) -> Result<String> {
+        let result = self.client.call_tool(&self.remote_tool_name, input).await?;
+
+        // MCP tools/call returns { content: [...] } where each item has
+        // type "text" with a text field.  Concatenate all text content.
+        if let Some(contents) = result.get("content").and_then(|c| c.as_array()) {
+            let texts: Vec<&str> = contents
+                .iter()
+                .filter_map(|c| {
+                    if c.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        c.get("text").and_then(|t| t.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !texts.is_empty() {
+                return Ok(texts.join("\n"));
+            }
+        }
+
+        // Fallback: pretty-print the raw result.
+        Ok(serde_json::to_string_pretty(&result)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory: connect to configured MCP servers and collect their tools
+// ---------------------------------------------------------------------------
+
+/// Connect to all configured MCP servers and return their tools wrapped as
+/// local `Tool` implementations.
+pub async fn create_mcp_tools(
+    configs: &[McpServerConfig],
+    workspace_root: &str,
+) -> Vec<Box<dyn Tool>> {
+    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+
+    for config in configs {
+        let client = match McpClient::new(config, workspace_root).await {
+            Ok(c) => Arc::new(c),
+            Err(e) => {
+                warn!("MCP '{}': failed to create client: {e:#}", config.name);
+                continue;
+            }
+        };
+
+        if let Err(e) = client.connect().await {
+            warn!("MCP '{}': failed to connect: {e:#}", config.name);
+            continue;
+        }
+
+        match client.list_tools().await {
+            Ok(remote_tools) => {
+                for rt in remote_tools {
+                    let tool_name = format!("mcp__{}__{}", config.name, rt.name);
+                    tools.push(Box::new(McpTool {
+                        client: Arc::clone(&client),
+                        spec: ToolSpec {
+                            name: Cow::Owned(tool_name),
+                            description: Cow::Owned(rt.description),
+                            input_schema: rt.input_schema,
+                        },
+                        remote_tool_name: rt.name,
+                    }));
+                }
+            }
+            Err(e) => {
+                warn!("MCP '{}': failed to list tools: {e:#}", config.name);
+            }
+        }
+    }
+
+    tools
+}

--- a/src/mcp_client/transport.rs
+++ b/src/mcp_client/transport.rs
@@ -1,0 +1,344 @@
+//! MCP transport abstraction — HTTP (Streamable HTTP) and stdio.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// Transport trait
+// ---------------------------------------------------------------------------
+
+/// Callback invoked when the server sends a JSON-RPC request (with `id` and
+/// `method`) back to the client during an ongoing request.  The callback
+/// returns the JSON-RPC response object to send back.
+pub type ServerRequestHandler = Arc<dyn Fn(&str, &Value) -> Value + Send + Sync>;
+
+#[async_trait]
+pub trait McpTransport: Send + Sync {
+    /// Send a JSON-RPC request and receive the final response.
+    ///
+    /// For HTTP, the response may arrive as a single JSON body **or** as an
+    /// SSE stream containing interleaved server-initiated requests.  For stdio
+    /// the response arrives as newline-delimited JSON on stdout.
+    ///
+    /// `on_server_request` is called for any server-initiated request that
+    /// arrives before the final response.  The returned value is sent back to
+    /// the server.
+    async fn request(
+        &self,
+        body: &Value,
+        on_server_request: &ServerRequestHandler,
+    ) -> Result<Value>;
+
+    /// Gracefully shut down the transport (close connection / kill child).
+    async fn shutdown(&self) -> Result<()>;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP (Streamable HTTP) transport
+// ---------------------------------------------------------------------------
+
+pub struct HttpTransport {
+    url: String,
+    api_key: Option<String>,
+    http: reqwest::Client,
+    session_id: Mutex<Option<String>>,
+}
+
+impl HttpTransport {
+    pub fn new(url: String, api_key: Option<String>) -> Self {
+        Self {
+            url,
+            api_key,
+            http: reqwest::Client::new(),
+            session_id: Mutex::new(None),
+        }
+    }
+
+    /// Build a POST request with standard headers.
+    fn build_request(&self, body: &Value, session_id: &Option<String>) -> reqwest::RequestBuilder {
+        let mut req = self
+            .http
+            .post(&self.url)
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream");
+
+        if let Some(key) = &self.api_key {
+            req = req.header("authorization", format!("Bearer {key}"));
+        }
+        if let Some(sid) = session_id {
+            req = req.header("mcp-session-id", sid.as_str());
+        }
+        req.json(body)
+    }
+
+    /// Send a JSON-RPC response back to the server (for server-initiated requests).
+    async fn send_response(
+        &self,
+        response: &Value,
+        session_id: &Option<String>,
+    ) -> Result<()> {
+        let mut req = self
+            .http
+            .post(&self.url)
+            .header("content-type", "application/json");
+        if let Some(sid) = session_id {
+            req = req.header("mcp-session-id", sid.as_str());
+        }
+        req.json(response)
+            .send()
+            .await
+            .context("Failed to send response to MCP server")?;
+        Ok(())
+    }
+
+    /// Parse an SSE `data:` line into JSON.
+    fn parse_sse_data(raw: &str) -> Option<Value> {
+        let data_line = raw.lines().find(|l| l.starts_with("data:"))?;
+        let data = data_line.strip_prefix("data:").unwrap_or("").trim();
+        serde_json::from_str(data).ok()
+    }
+}
+
+#[async_trait]
+impl McpTransport for HttpTransport {
+    async fn request(
+        &self,
+        body: &Value,
+        on_server_request: &ServerRequestHandler,
+    ) -> Result<Value> {
+        let session_id = self.session_id.lock().await.clone();
+        let resp = self
+            .build_request(body, &session_id)
+            .send()
+            .await
+            .context("Failed to send request to MCP server")?;
+
+        // Capture session id from response header.
+        if let Some(sid) = resp.headers().get("mcp-session-id") {
+            if let Ok(s) = sid.to_str() {
+                *self.session_id.lock().await = Some(s.to_string());
+            }
+        }
+
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        if content_type.contains("text/event-stream") {
+            // SSE stream — read events until we get the final result.
+            let current_sid = self.session_id.lock().await.clone();
+            let req_id = body.get("id").cloned().unwrap_or(Value::Null);
+            let mut stream = resp.bytes_stream();
+            let mut buf = String::new();
+
+            loop {
+                match stream.next().await {
+                    None => bail!("SSE stream ended without a final result"),
+                    Some(Err(e)) => bail!("SSE stream error: {e}"),
+                    Some(Ok(chunk)) => {
+                        buf.push_str(&String::from_utf8_lossy(&chunk));
+                        while let Some(pos) = buf.find("\n\n") {
+                            let raw = buf[..pos].to_string();
+                            buf.drain(..pos + 2);
+
+                            let Some(data) = Self::parse_sse_data(&raw) else {
+                                continue;
+                            };
+
+                            // Server-initiated request: has both `id` and `method`.
+                            if data.get("method").is_some()
+                                && data.get("id").is_some()
+                                && data.get("result").is_none()
+                            {
+                                let method = data["method"].as_str().unwrap_or("");
+                                let params =
+                                    data.get("params").cloned().unwrap_or(Value::Null);
+                                let mut response = on_server_request(method, &params);
+                                // Attach the request id.
+                                if let Value::Object(ref mut map) = response {
+                                    map.insert(
+                                        "id".to_string(),
+                                        data["id"].clone(),
+                                    );
+                                    map.entry("jsonrpc".to_string())
+                                        .or_insert_with(|| json!("2.0"));
+                                }
+                                if let Err(e) =
+                                    self.send_response(&response, &current_sid).await
+                                {
+                                    warn!("Failed to send server-request response: {e}");
+                                }
+                                continue;
+                            }
+
+                            // Final result or error for our request.
+                            if data.get("id") == Some(&req_id)
+                                && (data.get("result").is_some()
+                                    || data.get("error").is_some())
+                            {
+                                return Ok(data);
+                            }
+
+                            // Notification (no id) — log and skip.
+                            debug!("SSE notification: {data}");
+                        }
+                    }
+                }
+            }
+        } else {
+            // Plain JSON response.
+            let data: Value = resp.json().await.context("Failed to parse JSON response")?;
+            Ok(data)
+        }
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        // HTTP transport is stateless per-request; nothing to shut down.
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stdio transport
+// ---------------------------------------------------------------------------
+
+pub struct StdioTransport {
+    stdin: Mutex<tokio::process::ChildStdin>,
+    reader: Mutex<BufReader<tokio::process::ChildStdout>>,
+    child: Mutex<tokio::process::Child>,
+}
+
+impl StdioTransport {
+    pub async fn new(
+        command: &str,
+        args: &[String],
+        env: &HashMap<String, String>,
+    ) -> Result<Self> {
+        let mut cmd = tokio::process::Command::new(command);
+        cmd.args(args)
+            .envs(env)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+
+        let mut child = cmd.spawn().with_context(|| {
+            format!("Failed to spawn MCP server process: {command}")
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to open stdin of child process"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to open stdout of child process"))?;
+
+        Ok(Self {
+            stdin: Mutex::new(stdin),
+            reader: Mutex::new(BufReader::new(stdout)),
+            child: Mutex::new(child),
+        })
+    }
+}
+
+#[async_trait]
+impl McpTransport for StdioTransport {
+    async fn request(
+        &self,
+        body: &Value,
+        on_server_request: &ServerRequestHandler,
+    ) -> Result<Value> {
+        let req_id = body.get("id").cloned().unwrap_or(Value::Null);
+
+        // Write the request as a single JSON line to stdin.
+        {
+            let mut stdin = self.stdin.lock().await;
+            let mut line = serde_json::to_string(body)?;
+            line.push('\n');
+            stdin
+                .write_all(line.as_bytes())
+                .await
+                .context("Failed to write to MCP server stdin")?;
+            stdin.flush().await?;
+        }
+
+        // Read lines from stdout until we get the matching response.
+        let mut reader = self.reader.lock().await;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let n = reader
+                .read_line(&mut line)
+                .await
+                .context("Failed to read from MCP server stdout")?;
+            if n == 0 {
+                bail!("MCP server process closed stdout unexpectedly");
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let data: Value = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(e) => {
+                    debug!("Ignoring non-JSON line from MCP server: {e}");
+                    continue;
+                }
+            };
+
+            // Server-initiated request: has both `id` and `method`.
+            if data.get("method").is_some()
+                && data.get("id").is_some()
+                && data.get("result").is_none()
+            {
+                let method = data["method"].as_str().unwrap_or("");
+                let params = data.get("params").cloned().unwrap_or(Value::Null);
+                let mut response = on_server_request(method, &params);
+                if let Value::Object(ref mut map) = response {
+                    map.insert("id".to_string(), data["id"].clone());
+                    map.entry("jsonrpc".to_string())
+                        .or_insert_with(|| json!("2.0"));
+                }
+                // Send response back via stdin.
+                let mut stdin = self.stdin.lock().await;
+                let mut resp_line = serde_json::to_string(&response)?;
+                resp_line.push('\n');
+                stdin.write_all(resp_line.as_bytes()).await?;
+                stdin.flush().await?;
+                continue;
+            }
+
+            // Final result or error for our request.
+            if data.get("id") == Some(&req_id)
+                && (data.get("result").is_some() || data.get("error").is_some())
+            {
+                return Ok(data);
+            }
+
+            // Notification — log and skip.
+            debug!("stdio notification: {data}");
+        }
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Drop stdin to signal the child, then kill it.
+        drop(self.stdin.lock().await);
+        let mut child = self.child.lock().await;
+        let _ = child.kill().await;
+        Ok(())
+    }
+}

--- a/src/mcp_client/transport.rs
+++ b/src/mcp_client/transport.rs
@@ -19,6 +19,10 @@ use tracing::{debug, warn};
 /// returns the JSON-RPC response object to send back.
 pub type ServerRequestHandler = Arc<dyn Fn(&str, &Value) -> Value + Send + Sync>;
 
+/// Callback invoked when the server sends a JSON-RPC notification (no `id`,
+/// has `method`).  Used to detect `notifications/tools/list_changed` etc.
+pub type NotificationHandler = Arc<dyn Fn(&str, &Value) + Send + Sync>;
+
 #[async_trait]
 pub trait McpTransport: Send + Sync {
     /// Send a JSON-RPC request and receive the final response.
@@ -30,10 +34,13 @@ pub trait McpTransport: Send + Sync {
     /// `on_server_request` is called for any server-initiated request that
     /// arrives before the final response.  The returned value is sent back to
     /// the server.
+    ///
+    /// `on_notification` is called for any notification (no `id`, has `method`).
     async fn request(
         &self,
         body: &Value,
         on_server_request: &ServerRequestHandler,
+        on_notification: &NotificationHandler,
     ) -> Result<Value>;
 
     /// Gracefully shut down the transport (close connection / kill child).
@@ -112,6 +119,7 @@ impl McpTransport for HttpTransport {
         &self,
         body: &Value,
         on_server_request: &ServerRequestHandler,
+        on_notification: &NotificationHandler,
     ) -> Result<Value> {
         let session_id = self.session_id.lock().await.clone();
         let resp = self
@@ -189,8 +197,13 @@ impl McpTransport for HttpTransport {
                                 return Ok(data);
                             }
 
-                            // Notification (no id) — log and skip.
-                            debug!("SSE notification: {data}");
+                            // Notification (no id) — dispatch to handler.
+                            if let Some(method) = data.get("method").and_then(|m| m.as_str()) {
+                                let params = data.get("params").cloned().unwrap_or(Value::Null);
+                                on_notification(method, &params);
+                            } else {
+                                debug!("SSE notification (unrecognized): {data}");
+                            }
                         }
                     }
                 }
@@ -258,6 +271,7 @@ impl McpTransport for StdioTransport {
         &self,
         body: &Value,
         on_server_request: &ServerRequestHandler,
+        on_notification: &NotificationHandler,
     ) -> Result<Value> {
         let req_id = body.get("id").cloned().unwrap_or(Value::Null);
 
@@ -329,8 +343,13 @@ impl McpTransport for StdioTransport {
                 return Ok(data);
             }
 
-            // Notification — log and skip.
-            debug!("stdio notification: {data}");
+            // Notification — dispatch to handler.
+            if let Some(method) = data.get("method").and_then(|m| m.as_str()) {
+                let params = data.get("params").cloned().unwrap_or(Value::Null);
+                on_notification(method, &params);
+            } else {
+                debug!("stdio message (unrecognized): {data}");
+            }
         }
     }
 

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -302,8 +302,8 @@ impl Provider for AnthropicProvider {
             specs
                 .iter()
                 .map(|s| ApiToolSpec {
-                    name: s.name,
-                    description: s.description,
+                    name: &s.name,
+                    description: &s.description,
                     input_schema: &s.input_schema,
                 })
                 .collect()

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
 
 // ---------------------------------------------------------------------------
 // Tool definitions
@@ -11,8 +12,8 @@ use serde_json::Value;
 /// Tool specification passed to the LLM.
 #[derive(Debug, Clone)]
 pub struct ToolSpec {
-    pub name: &'static str,
-    pub description: &'static str,
+    pub name: Cow<'static, str>,
+    pub description: Cow<'static, str>,
     pub input_schema: Value,
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -474,8 +474,9 @@ async fn run_turn(
         warn!("Failed to persist user message: {e}");
     }
 
-    // 5. Tool-calling loop
-    let tool_specs = state.tools.specs().to_vec();
+    // 5. Tool-calling loop — refresh MCP tools if any server signalled a change.
+    state.tools.refresh_if_needed().await;
+    let tool_specs = state.tools.specs().await;
     let mut accumulated_text: Vec<String> = Vec::new();
     let final_text = loop {
         let round = history

--- a/src/tools/builtin_tools.rs
+++ b/src/tools/builtin_tools.rs
@@ -46,11 +46,11 @@ impl ReadFileTool {
     pub fn new() -> Self {
         Self {
             spec: ToolSpec {
-                name: "read_file",
+                name: "read_file".into(),
                 description: "Read a file from the filesystem with optional line-based pagination. \
                     Returns lines prefixed with their 1-indexed line number in 'N|content' format. \
                     Use offset and limit for large files. \
-                    Cannot read binary files or device paths (/dev/, /proc/).",
+                    Cannot read binary files or device paths (/dev/, /proc/).".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -159,11 +159,11 @@ impl WriteFileTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "write_file",
+                name: "write_file".into(),
                 description: "Write content to a file, completely replacing its existing content. \
                     Creates the file and any missing parent directories automatically. \
                     When the target file is inside the workspace, the search index is updated automatically. \
-                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.).",
+                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.).".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -254,10 +254,10 @@ impl DeleteFileTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "delete_file",
+                name: "delete_file".into(),
                 description: "Delete a file from the filesystem. \
                     When the file is inside the workspace, it is also removed from the search index automatically. \
-                    Cannot delete directories.",
+                    Cannot delete directories.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -320,12 +320,12 @@ impl TerminalTool {
         Self {
             workspace_root,
             spec: ToolSpec {
-                name: "terminal",
+                name: "terminal".into(),
                 description: "Execute a shell command and return its output. \
                     Returns stdout, stderr, and exit code. \
                     The default working directory is the workspace root. \
                     Use the timeout parameter for long-running commands (default 60 s, max 600 s). \
-                    Not suitable for interactive commands or persistent daemons.",
+                    Not suitable for interactive commands or persistent daemons.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -425,9 +425,9 @@ impl WebSearchTool {
         Self {
             api_key,
             spec: ToolSpec {
-                name: "web_search",
+                name: "web_search".into(),
                 description: "Search the web for up-to-date information using Tavily. \
-                    Returns titles, URLs, and short content excerpts for the top results.",
+                    Returns titles, URLs, and short content excerpts for the top results.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,10 +2,13 @@ pub mod builtin_tools;
 pub mod workspace_tools;
 
 use crate::config::McpServerConfig;
+use crate::mcp_client::{self, McpClient, build_tools_for_client};
 use crate::provider::{ToolCall, ToolSpec};
 use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
 
 /// A tool the agent can invoke.
 #[async_trait]
@@ -18,24 +21,38 @@ pub trait Tool: Send + Sync {
 }
 
 /// A collection of tools with their specs.
+///
+/// Tools and specs are behind a `RwLock` so that MCP server tool lists can be
+/// refreshed at runtime when a `notifications/tools/list_changed` is received.
 pub struct ToolSet {
+    inner: RwLock<ToolSetInner>,
+    /// MCP clients whose `tools_changed` flag is checked before each turn.
+    mcp_clients: Vec<Arc<McpClient>>,
+}
+
+struct ToolSetInner {
     tools: Vec<Box<dyn Tool>>,
     specs: Vec<ToolSpec>,
 }
 
 impl ToolSet {
-    pub fn new(tools: Vec<Box<dyn Tool>>) -> Self {
+    pub fn new(tools: Vec<Box<dyn Tool>>, mcp_clients: Vec<Arc<McpClient>>) -> Self {
         let specs = tools.iter().map(|t| t.spec().clone()).collect();
-        Self { tools, specs }
+        Self {
+            inner: RwLock::new(ToolSetInner { tools, specs }),
+            mcp_clients,
+        }
     }
 
-    pub fn specs(&self) -> &[ToolSpec] {
-        &self.specs
+    /// Return a snapshot of the current tool specs.
+    pub async fn specs(&self) -> Vec<ToolSpec> {
+        self.inner.read().await.specs.clone()
     }
 
     /// Execute a tool call; returns a human-readable result string.
     pub async fn execute(&self, call: &ToolCall) -> String {
-        for tool in &self.tools {
+        let inner = self.inner.read().await;
+        for tool in &inner.tools {
             if tool.spec().name == call.name {
                 return match tool.execute(&call.input).await {
                     Ok(result) => result,
@@ -44,6 +61,45 @@ impl ToolSet {
             }
         }
         format!("Unknown tool: {}", call.name)
+    }
+
+    /// Check all MCP clients for `tools_changed` flags and refresh their
+    /// tools if needed.  Should be called before each LLM turn.
+    pub async fn refresh_if_needed(&self) {
+        for client in &self.mcp_clients {
+            if !client.take_tools_changed() {
+                continue;
+            }
+
+            info!("MCP '{}': refreshing tool list", client.name());
+            match client.list_tools().await {
+                Ok(remote_tools) => {
+                    let new_tools = build_tools_for_client(client, remote_tools);
+                    let prefix = format!("mcp__{}__", client.name());
+
+                    let mut inner = self.inner.write().await;
+
+                    // Remove old tools for this server.
+                    inner.tools.retain(|t| !t.spec().name.starts_with(&prefix));
+                    inner.specs.retain(|s| !s.name.starts_with(&prefix));
+
+                    // Add refreshed tools.
+                    for tool in new_tools {
+                        inner.specs.push(tool.spec().clone());
+                        inner.tools.push(tool);
+                    }
+
+                    info!(
+                        "MCP '{}': tool list refreshed ({} total tools)",
+                        client.name(),
+                        inner.tools.len()
+                    );
+                }
+                Err(e) => {
+                    warn!("MCP '{}': failed to refresh tools: {e:#}", client.name());
+                }
+            }
+        }
     }
 }
 
@@ -88,12 +144,14 @@ pub async fn default_tool_set(
     }
 
     // External MCP server tools
+    let mut mcp_clients = Vec::new();
     if !mcp_servers.is_empty() {
         let workspace_root_str = workspace_root.to_string_lossy();
-        let mcp_tools =
-            crate::mcp_client::create_mcp_tools(mcp_servers, &workspace_root_str).await;
+        let (mcp_tools, clients) =
+            mcp_client::create_mcp_tools(mcp_servers, &workspace_root_str).await;
         tools.extend(mcp_tools);
+        mcp_clients = clients;
     }
 
-    ToolSet::new(tools)
+    ToolSet::new(tools, mcp_clients)
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,7 @@
 pub mod builtin_tools;
 pub mod workspace_tools;
 
+use crate::config::McpServerConfig;
 use crate::provider::{ToolCall, ToolSpec};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -49,9 +50,12 @@ impl ToolSet {
 /// Build the default tool set backed by a sapphire-workspace WorkspaceState.
 ///
 /// `tavily_api_key`: if provided, the `web_search` tool is included.
-pub fn default_tool_set(
+/// `mcp_servers`: external MCP servers whose tools are registered with the
+/// naming convention `mcp__<name>__<tool_name>`.
+pub async fn default_tool_set(
     state: Arc<Mutex<sapphire_workspace::WorkspaceState>>,
     tavily_api_key: Option<String>,
+    mcp_servers: &[McpServerConfig],
 ) -> ToolSet {
     use builtin_tools::*;
     use workspace_tools::*;
@@ -76,11 +80,19 @@ pub fn default_tool_set(
         Box::new(ReadFileTool::new()),
         Box::new(WriteFileTool::new(Arc::clone(&state))),
         Box::new(DeleteFileTool::new(Arc::clone(&state))),
-        Box::new(TerminalTool::new(workspace_root)),
+        Box::new(TerminalTool::new(workspace_root.clone())),
     ];
 
     if let Some(key) = tavily_api_key {
         tools.push(Box::new(WebSearchTool::new(key)));
+    }
+
+    // External MCP server tools
+    if !mcp_servers.is_empty() {
+        let workspace_root_str = workspace_root.to_string_lossy();
+        let mcp_tools =
+            crate::mcp_client::create_mcp_tools(mcp_servers, &workspace_root_str).await;
+        tools.extend(mcp_tools);
     }
 
     ToolSet::new(tools)

--- a/src/tools/workspace_tools.rs
+++ b/src/tools/workspace_tools.rs
@@ -160,8 +160,8 @@ impl MemoryAddTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "memory_add",
-                description: Box::leak(description.into_boxed_str()),
+                name: "memory_add".into(),
+                description: description.into(),
                 input_schema: memory_entry_schema(true),
             },
         }
@@ -210,10 +210,10 @@ impl MemoryUpdateTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "memory_update",
+                name: "memory_update".into(),
                 description: "Overwrite an existing memory entry at \
                     memory/<category>/<slug>.md. Fails if the file does not exist \
-                    (use memory_add to create it).",
+                    (use memory_add to create it).".into(),
                 input_schema: memory_entry_schema(true),
             },
         }
@@ -263,7 +263,7 @@ impl MemoryAppendTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "memory_append",
+                name: "memory_append".into(),
                 description: "Append content to the end of a memory entry at \
                     memory/<category>/<slug>.md, creating the file if it does \
                     not exist. Cheaper than memory_read + memory_update when you \
@@ -271,7 +271,7 @@ impl MemoryAppendTool {
                     A blank line is inserted between the existing body and the \
                     new content; add your own Markdown heading if you want a \
                     section break. Frontmatter counters (updated_at) are \
-                    maintained automatically.",
+                    maintained automatically.".into(),
                 input_schema: memory_entry_schema(true),
             },
         }
@@ -341,12 +341,12 @@ impl MemoryReadTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "memory_read",
+                name: "memory_read".into(),
                 description: "Read a memory entry at memory/<category>/<slug>.md \
                     and return its body. Side effect: updates the file's \
                     frontmatter (last_read_at = now, read_count += 1) so that \
                     recency and frequency can inform future weighting. \
-                    Use workspace_read instead for a non-tracking read.",
+                    Use workspace_read instead for a non-tracking read.".into(),
                 input_schema: memory_entry_schema(false),
             },
         }
@@ -392,8 +392,8 @@ impl MemoryRemoveTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "memory_remove",
-                description: "Delete a memory entry at memory/<category>/<slug>.md.",
+                name: "memory_remove".into(),
+                description: "Delete a memory entry at memory/<category>/<slug>.md.".into(),
                 input_schema: memory_entry_schema(false),
             },
         }
@@ -433,9 +433,9 @@ impl WorkspaceReadTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "workspace_read",
+                name: "workspace_read".into(),
                 description: "Read the contents of a file in the workspace \
-                    (path relative to workspace root, e.g. \"notes/2025-01.md\").",
+                    (path relative to workspace root, e.g. \"notes/2025-01.md\").".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -480,9 +480,9 @@ impl WorkspaceWriteTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "workspace_write",
+                name: "workspace_write".into(),
                 description: "Write content to a file in the workspace \
-                    (creates or overwrites). Path is relative to workspace root.",
+                    (creates or overwrites). Path is relative to workspace root.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -534,12 +534,12 @@ impl WorkspaceSearchTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "workspace_search",
+                name: "workspace_search".into(),
                 description: "Search across all indexed files in the workspace. \
                     Two modes are available: \
                     'fts' (full-text / BM25, always available) and \
                     'semantic' (vector similarity, requires an embedder to be configured — falls back to fts if unavailable). \
-                    Returns matching file titles and paths.",
+                    Returns matching file titles and paths.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -643,9 +643,9 @@ impl WorkspaceSyncTool {
         Self {
             state,
             spec: ToolSpec {
-                name: "workspace_sync",
+                name: "workspace_sync".into(),
                 description: "Sync the workspace: index all files and, if a git \
-                    remote is configured, commit and push changes.",
+                    remote is configured, commit and push changes.".into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {}


### PR DESCRIPTION
## Summary

- Add built-in MCP client that connects to external MCP servers and exposes their tools to the agent's LLM using `mcp__<server>__<tool>` naming (Claude Code convention)
- Support both **Streamable HTTP** and **stdio** (child process) transports via `McpTransport` trait abstraction
- Implement MCP client capabilities: **Roots** (returns workspace dir), **Elicitation** (auto-accept), **Sampling** (stub/unsupported)
- Handle `notifications/tools/list_changed` for dynamic tool refresh — `ToolSet` uses `RwLock` and checks MCP clients before each LLM turn
- Change `ToolSpec` fields from `&'static str` to `Cow<'static, str>` to support dynamic MCP tool names

## Configuration

```toml
# stdio transport
[[tools.mcp_servers]]
name = "filesystem"
type = "stdio"
command = "npx"
args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]

# HTTP transport
[[tools.mcp_servers]]
name = "remote-api"
type = "http"
url = "http://localhost:3000/mcp"
api_key = "sk-xxx"
```

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] Existing functionality unaffected (no MCP servers configured = no change)
- [ ] Configure a stdio MCP server (e.g. `@modelcontextprotocol/server-filesystem`) and verify tools are listed on startup
- [ ] Verify LLM can call MCP tools and receive results
- [ ] Configure an HTTP MCP server and verify connection + tool calls
- [ ] Verify `notifications/tools/list_changed` triggers tool list refresh

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)