### PR TITLE
fix: read [sync] from agent config with workspace defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use sapphire_workspace::SyncConfig;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -43,6 +44,13 @@ pub struct Config {
     /// sync without actively processing messages. Default: false.
     #[serde(default)]
     pub standby_mode: bool,
+    /// Workspace sync configuration.
+    ///
+    /// The workspace-level config (`{workspace_dir}/.sapphire-agent/config.toml`)
+    /// provides shared defaults. This per-user `[sync]` section, when present,
+    /// takes precedence — allowing each user to override the workspace defaults.
+    #[serde(default)]
+    pub sync: Option<SyncConfig>,
 }
 
 fn default_true() -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,8 +164,13 @@ async fn main() -> Result<()> {
             let sw_workspace = SwWorkspace::resolve(&APP_CTX, Some(&workspace_dir))
                 .context("Failed to resolve sapphire-workspace")?;
             // Load the workspace config so we can read sync_interval_minutes.
-            let ws_config =
+            // Workspace config provides shared defaults; the per-user agent
+            // config [sync] section takes precedence when present.
+            let mut ws_config =
                 WorkspaceConfig::load_from(&sw_workspace.config_path()).unwrap_or_default();
+            if let Some(agent_sync) = &config.sync {
+                ws_config.sync = agent_sync.clone();
+            }
             let ws_sync_interval = ws_config.sync.sync_interval();
             let ws_state =
                 WorkspaceState::open(sw_workspace).context("Failed to open WorkspaceState")?;


### PR DESCRIPTION
## Summary
- The `[sync]` section in the agent config (`~/.config/sapphire-agent/config.toml`) was silently ignored because the `Config` struct had no `sync` field — periodic workspace sync never started even when configured
- Add `sync: Option<SyncConfig>` to agent `Config` so that `[sync]` is properly parsed
- Workspace-level config (`.sapphire-agent/config.toml` inside the workspace dir) serves as shared defaults; per-user agent config overrides when present

## Test plan
- [ ] Start sapphire-agent with `[sync] sync_interval_minutes = 10` in agent config only (no workspace config) — verify periodic sync starts
- [ ] Start with `[sync]` in both agent and workspace config with different intervals — verify agent config takes precedence
- [ ] Start with `[sync]` only in workspace config — verify it still works (backward compat)
- [ ] Start with no `[sync]` anywhere — verify no periodic sync (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)