### PR TITLE
feat: context compression for long sessions

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,6 @@
 use crate::channel::{Channel, OutgoingMessage};
 use crate::config::Config;
+use crate::context_compression::maybe_compress;
 use crate::provider::{ChatMessage, ContentPart, Provider, ToolCall};
 use crate::session::{ConversationKey, SessionStore, local_date_for_timestamp};
 use crate::tools::ToolSet;
@@ -297,6 +298,9 @@ impl Agent {
             None => None,
         };
 
+        // Context compression config
+        let compression_config = &self.config.compression;
+
         // Tool-calling loop
         let mut accumulated_text: Vec<String> = Vec::new();
         let final_text = loop {
@@ -322,6 +326,32 @@ impl Agent {
                 warn!("Reached max tool rounds ({MAX_TOOL_ROUNDS}), stopping");
                 break Some(accumulated_text.join("\n\n"));
             }
+
+            // Check if context compression is needed
+            let messages = match maybe_compress(
+                &*self.provider,
+                system_with_context.as_deref(),
+                &messages,
+                &compression_config,
+            )
+            .await
+            {
+                Ok(Some(compressed)) => {
+                    // Replace in-memory history with compressed version
+                    *self
+                        .history
+                        .lock()
+                        .await
+                        .entry(key.clone())
+                        .or_default() = compressed.clone();
+                    compressed
+                }
+                Ok(None) => messages,
+                Err(e) => {
+                    warn!("Context compression failed, continuing with full history: {e}");
+                    messages
+                }
+            };
 
             let response = self
                 .provider

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,9 @@ pub struct Config {
     #[serde(default)]
     pub discord: Option<DiscordConfig>,
     pub anthropic: AnthropicConfig,
+    /// Context compression configuration.
+    #[serde(default)]
+    pub compression: CompressionConfig,
     /// Tool configuration (search APIs, etc.).
     #[serde(default)]
     pub tools: ToolsConfig,
@@ -175,12 +178,54 @@ pub struct AnthropicConfig {
     pub system_prompt: Option<String>,
 }
 
+/// Context compression configuration (provider-agnostic).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompressionConfig {
+    /// Whether context compression is enabled. Default: true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Context window size in tokens. Defaults to 200,000.
+    #[serde(default = "default_context_window")]
+    pub context_window: usize,
+    /// Fraction of context window at which compression triggers (0.0–1.0).
+    /// Defaults to 0.80.
+    #[serde(default = "default_compression_threshold")]
+    pub threshold: f64,
+    /// Number of recent messages to preserve verbatim during compression.
+    /// Defaults to 20.
+    #[serde(default = "default_preserve_recent")]
+    pub preserve_recent: usize,
+}
+
+impl Default for CompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            context_window: default_context_window(),
+            threshold: default_compression_threshold(),
+            preserve_recent: default_preserve_recent(),
+        }
+    }
+}
+
 fn default_model() -> String {
     "claude-opus-4-6".to_string()
 }
 
 fn default_max_tokens() -> u32 {
     8192
+}
+
+fn default_context_window() -> usize {
+    200_000
+}
+
+fn default_compression_threshold() -> f64 {
+    0.80
+}
+
+fn default_preserve_recent() -> usize {
+    20
 }
 
 impl Config {

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -1,0 +1,306 @@
+//! Context compression: summarize older messages when conversation approaches
+//! the model's context window limit.
+//!
+//! Strategy:
+//! 1. Estimate token count of system prompt + messages
+//! 2. If above threshold (default 80% of context window), compress
+//! 3. Keep the most recent N messages verbatim
+//! 4. Summarize everything before that into a single user message
+//! 5. Return the compressed history
+
+use crate::config::CompressionConfig;
+use crate::provider::{ChatMessage, ContentPart, Provider, Role};
+use tracing::{info, warn};
+
+/// Rough token estimate for a string.
+///
+/// Uses a simple heuristic: ~4 characters per token for ASCII,
+/// ~1.5 characters per token for non-ASCII (CJK, etc.).
+pub fn estimate_tokens(text: &str) -> usize {
+    let mut ascii_chars = 0usize;
+    let mut non_ascii_chars = 0usize;
+    for ch in text.chars() {
+        if ch.is_ascii() {
+            ascii_chars += 1;
+        } else {
+            non_ascii_chars += 1;
+        }
+    }
+    // Rough estimate: ASCII ~4 chars/token, non-ASCII ~1.5 chars/token
+    let ascii_tokens = ascii_chars / 4;
+    let non_ascii_tokens = (non_ascii_chars * 2 + 2) / 3; // ceil(n * 2/3)
+    ascii_tokens + non_ascii_tokens
+}
+
+/// Estimate the total token usage for a system prompt + message history.
+pub fn estimate_total_tokens(system: Option<&str>, messages: &[ChatMessage]) -> usize {
+    let system_tokens = system.map(|s| estimate_tokens(s)).unwrap_or(0);
+    let message_tokens: usize = messages.iter().map(|m| estimate_message_tokens(m)).sum();
+    // Add a small overhead for message framing (~4 tokens per message)
+    system_tokens + message_tokens + messages.len() * 4
+}
+
+/// Estimate tokens for a single ChatMessage.
+fn estimate_message_tokens(msg: &ChatMessage) -> usize {
+    msg.parts
+        .iter()
+        .map(|p| match p {
+            ContentPart::Text(t) => estimate_tokens(t),
+            ContentPart::ToolUse { name, input, .. } => {
+                estimate_tokens(name) + estimate_tokens(&input.to_string())
+            }
+            ContentPart::ToolResult { content, .. } => estimate_tokens(content),
+        })
+        .sum()
+}
+
+/// Check whether compression is needed and, if so, compress the history.
+///
+/// Returns `Ok(None)` if no compression was needed.
+/// Returns `Ok(Some(compressed))` with the new message history if compressed.
+pub async fn maybe_compress(
+    provider: &dyn Provider,
+    system: Option<&str>,
+    messages: &[ChatMessage],
+    config: &CompressionConfig,
+) -> anyhow::Result<Option<Vec<ChatMessage>>> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    let total_tokens = estimate_total_tokens(system, messages);
+    let threshold_tokens = (config.context_window as f64 * config.threshold) as usize;
+
+    if total_tokens < threshold_tokens {
+        return Ok(None);
+    }
+
+    info!(
+        "Context compression triggered: ~{total_tokens} tokens estimated \
+         (threshold: {threshold_tokens}, window: {})",
+        config.context_window
+    );
+
+    // Find the split point: keep the most recent `preserve_recent` messages,
+    // but ensure we don't split in the middle of a tool-call/result pair.
+    let split = find_safe_split_point(messages, config.preserve_recent);
+
+    if split == 0 {
+        // Nothing to compress — all messages are in the "recent" window
+        return Ok(None);
+    }
+
+    let to_summarize = &messages[..split];
+    let to_keep = &messages[split..];
+
+    // Generate a summary of the older messages
+    let summary = generate_summary(provider, to_summarize).await?;
+
+    info!(
+        "Compressed {} messages into summary ({} → ~{} tokens)",
+        split,
+        estimate_total_tokens(None, to_summarize),
+        estimate_tokens(&summary),
+    );
+
+    // Build the compressed history: summary message + recent messages
+    let mut compressed = Vec::with_capacity(1 + to_keep.len());
+    compressed.push(ChatMessage {
+        role: Role::User,
+        parts: vec![ContentPart::Text(format!(
+            "[Context Summary — earlier messages were compressed]\n\n{summary}"
+        ))],
+    });
+    // Insert a placeholder assistant acknowledgment so that the message
+    // sequence alternates correctly (user → assistant → user → …).
+    compressed.push(ChatMessage::assistant(
+        "Understood. I have the context from our earlier conversation.",
+    ));
+    compressed.extend_from_slice(to_keep);
+
+    Ok(Some(compressed))
+}
+
+/// Find a safe split point that doesn't break tool-call/result pairs.
+///
+/// We want to keep at least `preserve_recent` messages at the end,
+/// but if the boundary lands between a tool-use assistant message and
+/// its corresponding tool-result user message, we move the boundary
+/// earlier to keep the pair together.
+fn find_safe_split_point(messages: &[ChatMessage], preserve_recent: usize) -> usize {
+    if messages.len() <= preserve_recent {
+        return 0;
+    }
+
+    let mut split = messages.len() - preserve_recent;
+
+    // If the message at `split` is a tool-result (user message with ToolResult parts),
+    // move split back to include the preceding assistant tool-use message.
+    while split > 0 {
+        let msg = &messages[split];
+        let is_tool_result = msg.role == Role::User
+            && msg
+                .parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::ToolResult { .. }));
+        if is_tool_result {
+            split -= 1;
+        } else {
+            break;
+        }
+    }
+
+    // Also check: if the message just before split is an assistant message
+    // with tool_use, include it in the "keep" side to maintain the pair.
+    if split > 0 {
+        let prev = &messages[split - 1];
+        let has_tool_use = prev.role == Role::Assistant
+            && prev
+                .parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::ToolUse { .. }));
+        if has_tool_use {
+            // The message at split should be the tool result — keep the pair together
+            // by not moving split further.
+        }
+    }
+
+    split
+}
+
+/// Generate a concise summary of a sequence of messages using the LLM.
+async fn generate_summary(
+    provider: &dyn Provider,
+    messages: &[ChatMessage],
+) -> anyhow::Result<String> {
+    // Build a textual representation of the messages to summarize
+    let mut transcript = String::new();
+    for msg in messages {
+        let role_label = match msg.role {
+            Role::User => "User",
+            Role::Assistant => "Assistant",
+        };
+        for part in &msg.parts {
+            match part {
+                ContentPart::Text(t) => {
+                    transcript.push_str(&format!("{role_label}: {t}\n\n"));
+                }
+                ContentPart::ToolUse { name, .. } => {
+                    transcript.push_str(&format!("{role_label}: [Called tool: {name}]\n\n"));
+                }
+                ContentPart::ToolResult { content, .. } => {
+                    // Truncate long tool results to keep the summary prompt manageable
+                    let truncated = if content.len() > 500 {
+                        format!("{}... (truncated)", &content[..500])
+                    } else {
+                        content.clone()
+                    };
+                    transcript.push_str(&format!("{role_label}: [Tool result: {truncated}]\n\n"));
+                }
+            }
+        }
+    }
+
+    // Cap the transcript to avoid exceeding context on the summary call itself
+    let max_transcript_chars = 50_000;
+    if transcript.len() > max_transcript_chars {
+        transcript.truncate(max_transcript_chars);
+        transcript.push_str("\n... (transcript truncated for summarization)");
+    }
+
+    let prompt = format!(
+        "Summarize the following conversation concisely. \
+         Preserve key information: decisions made, code context, task state, \
+         important facts, and any instructions or preferences expressed. \
+         Focus on information that would be needed to continue the conversation. \
+         Write the summary in the same language(s) used in the conversation.\n\n\
+         ---\n\n{transcript}"
+    );
+
+    let summary_messages = vec![ChatMessage::user(&prompt)];
+    let response = provider.chat(None, &summary_messages, None).await?;
+
+    match response.text {
+        Some(text) if !text.is_empty() => Ok(text),
+        _ => {
+            warn!("Summary generation returned empty response");
+            Ok("(Earlier conversation context was compressed but summary generation failed.)".into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_tokens_ascii() {
+        // "hello world" = 11 chars, ~2-3 tokens
+        let tokens = estimate_tokens("hello world");
+        assert!(tokens > 0);
+        assert!(tokens < 10);
+    }
+
+    #[test]
+    fn test_estimate_tokens_cjk() {
+        // 6 CJK characters, ~4 tokens
+        let tokens = estimate_tokens("こんにちは世界");
+        assert!(tokens > 0);
+    }
+
+    #[test]
+    fn test_estimate_tokens_mixed() {
+        let tokens = estimate_tokens("Hello こんにちは World");
+        assert!(tokens > 0);
+    }
+
+    #[test]
+    fn test_find_safe_split_point_basic() {
+        let messages = vec![
+            ChatMessage::user("msg1"),
+            ChatMessage::assistant("msg2"),
+            ChatMessage::user("msg3"),
+            ChatMessage::assistant("msg4"),
+            ChatMessage::user("msg5"),
+            ChatMessage::assistant("msg6"),
+        ];
+        let split = find_safe_split_point(&messages, 2);
+        assert_eq!(split, 4);
+    }
+
+    #[test]
+    fn test_find_safe_split_preserves_all_when_few() {
+        let messages = vec![
+            ChatMessage::user("msg1"),
+            ChatMessage::assistant("msg2"),
+        ];
+        let split = find_safe_split_point(&messages, 5);
+        assert_eq!(split, 0);
+    }
+
+    #[test]
+    fn test_find_safe_split_avoids_breaking_tool_pair() {
+        use serde_json::json;
+
+        let messages = vec![
+            ChatMessage::user("start"),
+            ChatMessage::assistant("thinking"),
+            ChatMessage::user("question"),
+            ChatMessage::assistant_with_tools(
+                None,
+                vec![crate::provider::ToolCall {
+                    id: "t1".into(),
+                    name: "search".into(),
+                    input: json!({}),
+                }],
+            ),
+            ChatMessage::tool_results(vec![("t1".into(), "result".into())]),
+            ChatMessage::assistant("final answer"),
+        ];
+
+        // preserve_recent=2 would normally split at index 4 (tool result),
+        // but it should move back to not break the tool pair.
+        let split = find_safe_split_point(&messages, 2);
+        assert!(split <= 3, "split should be at or before the tool-use message");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod agent;
 mod call;
 mod channel;
 mod config;
+mod context_compression;
 mod daily_log;
 mod heartbeat;
 mod heartbeat_config;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -6,6 +6,7 @@
 //! Session management follows the MCP standard: `Mcp-Session-Id` request header.
 
 use crate::config::Config;
+use crate::context_compression::maybe_compress;
 use crate::provider::{ChatMessage, ContentPart, Provider};
 use crate::session::{ConversationKey, SessionStore};
 use crate::tools::ToolSet;
@@ -477,6 +478,7 @@ async fn run_turn(
     // 5. Tool-calling loop — refresh MCP tools if any server signalled a change.
     state.tools.refresh_if_needed().await;
     let tool_specs = state.tools.specs().await;
+    let compression_config = &state.config.compression;
     let mut accumulated_text: Vec<String> = Vec::new();
     let final_text = loop {
         let round = history
@@ -491,6 +493,24 @@ async fn run_turn(
         if round >= MAX_TOOL_ROUNDS {
             warn!("Reached max tool rounds ({MAX_TOOL_ROUNDS})");
             break None;
+        }
+
+        // Check if context compression is needed
+        match maybe_compress(
+            &*state.provider,
+            system.as_deref(),
+            &history,
+            &compression_config,
+        )
+        .await
+        {
+            Ok(Some(compressed)) => {
+                history = compressed;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!("Context compression failed, continuing with full history: {e}");
+            }
         }
 
         let response = state


### PR DESCRIPTION
## Summary

- Add automatic context compression when estimated token usage exceeds the context window threshold (default 80% of 200k tokens)
- Summarize older messages via the LLM while preserving the most recent N messages (default 20) verbatim
- Safe split-point logic ensures tool-call/result pairs are never broken across the compression boundary
- Provider-agnostic `[compression]` config section with `enabled`, `context_window`, `threshold`, and `preserve_recent` fields — all optional with sensible defaults
- Integrated into both channel-based (`agent.rs`) and HTTP API (`serve.rs`) conversation flows
- 6 unit tests for token estimation and split-point logic

## Configuration

```toml
[compression]
enabled = true          # default
context_window = 200000 # default, in tokens
threshold = 0.80        # default, fraction of context window
preserve_recent = 20    # default, number of recent messages to keep verbatim
```

No config changes required — all fields have defaults. Set `enabled = false` to disable.

## Test plan

- [x] `cargo check` passes with no new warnings
- [x] `cargo test --bin sapphire-agent context_compression` — 6/6 tests pass
- [ ] Manual test: run a long session and verify compression triggers at threshold
- [ ] Verify compressed history produces coherent follow-up responses

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)