### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-12
+
+### Added
+
+- **MCP client** — built-in MCP client for integrating external tool servers,
+  with support for `notifications/tools/list_changed` to dynamically refresh
+  the tool list at runtime.
+- **Context compression** — automatically compresses the conversation when the
+  session approaches the context window limit, keeping sessions alive longer.
+- **Heartbeat config** — `heartbeat_enabled` and `standby_mode` options in the
+  agent config to pause or suspend background heartbeat tasks without
+  restarting.
+- **Crate split** — `sapphire-agent-api` (shared types + SSE client) and
+  `sapphire-call` (standalone CLI client) extracted into their own workspace
+  crates so they can be published and used independently.
+- **Dependabot** — automated dependency update PRs with grouped Cargo patch
+  updates on Fridays and auto-merge for patch-level bumps.
+
+### Changed
+
+- **`sapphire-workspace` 0.5.0 → 0.8.0** — picks up upstream improvements to
+  file indexing, vector search, and git sync.
+- **`reedline` upgraded to 0.47** — handles the new non-exhaustive `Signal`
+  enum without warnings.
+- **Memory tools** — `MemoryTool` redesigned into per-file entry tools with
+  frontmatter tracking for finer-grained read/write control.
+
+### Fixed
+
+- `[sync]` config is now read from the agent config file rather than only from
+  the workspace config, so sync settings specified in `config.toml` are
+  actually honoured.
+
 ## [0.1.0] - 2026-04-09
 
 Initial release of `sapphire-agent` — a personal AI assistant built around the
@@ -38,4 +71,5 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.2.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.2.0
 [0.1.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/sapphire-agent-api", "crates/sapphire-call"]
 
 [package]
 name = "sapphire-agent"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "A personal AI assistant agent with Matrix/Discord channels, Anthropic backend, and a sapphire-workspace memory layer"
 license = "MIT OR Apache-2.0"
@@ -105,7 +105,7 @@ sapphire-workspace = { version = "0.8.0", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.2.0" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-agent-api/Cargo.toml
+++ b/crates/sapphire-agent-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-agent-api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Client library and shared types for sapphire-agent"
 license = "MIT OR Apache-2.0"

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Standalone CLI client for sapphire-agent"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.2.0" }
 
 # Async runtime
 tokio = { version = "1.50", default-features = false, features = [


### PR DESCRIPTION
## Summary

- Bump all crate versions from `0.1.0` to `0.2.0`
- Add CHANGELOG entry for v0.2.0

## What's in this release

### Added
- Built-in MCP client with dynamic tool refresh via `notifications/tools/list_changed`
- Context compression when the session approaches the context window limit
- `heartbeat_enabled` and `standby_mode` config options
- `sapphire-agent-api` and `sapphire-call` workspace crates (crate split)
- Dependabot config with grouped Cargo patch updates and auto-merge

### Changed
- `sapphire-workspace` upgraded 0.5.0 → 0.8.0
- `reedline` upgraded to 0.47 (non-exhaustive `Signal` fix)
- `MemoryTool` redesigned into per-file entry tools with frontmatter tracking

### Fixed
- `[sync]` config is now read from the agent config, not only the workspace config

## Release process

Merging this PR will trigger the `release` workflow, which will:
1. Create and push tag `v0.2.0`
2. Build binaries for Linux x86\_64, Linux aarch64, and macOS aarch64
3. Create a GitHub release with generated notes and binary assets
4. Publish `sapphire-agent` to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)