### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-13
+
+### Fixed
+
+- **`sapphire-workspace` 0.8.0 → 0.8.1** — fixes git sync push not working
+  due to a bug in `sapphire-sync` where the push step was silently skipped.
+
 ## [0.2.0] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "grain-id"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f35d7887ef1f86198ac521290e87c07e81a75d03623f49e430f4c95212d0991"
+checksum = "d65b473737e221d1e4cb42ebff477cc8b436ce141da13c39b2c198f4159fd2b1"
 dependencies = [
  "prost-build",
  "rand 0.10.1",
@@ -3331,16 +3331,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -5546,9 +5545,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5584,9 +5583,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -5846,9 +5845,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -6112,7 +6111,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -6132,7 +6131,7 @@ dependencies = [
  "rand 0.9.3",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6536,7 +6535,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -6864,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -6955,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6997,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7008,9 +7007,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d369d570d92c3ce2683ebc8746d9ca938a503e02df5ff435f9bdcf7f9fe6e57"
+checksum = "59ca84d99b7765b10ad953e807d446efd3e1a4334f376ae9e7b0dcccf27e9344"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7026,22 +7025,23 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485cacfc214c21b76a3040f680e26f66d3d4e808fa22e82979be5277b7aeba3c"
+checksum = "d4608abffd1b47b2aad94768791dd8c1b9a79f7614ba634979b5427a454e0e8e"
 dependencies = [
  "dirs 5.0.1",
  "git2",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e12489ac2e45d0ba8549538f7a4704df1fe869e8c1c4136254d5fe76f957e"
+checksum = "b201cfc43b44309ebc5ebd26436ec2f91453bc0f13e63ef1868357d056e6bac3"
 dependencies = [
  "dirs 5.0.1",
  "indexmap 2.14.0",
@@ -8184,7 +8184,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -8574,7 +8574,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8596,7 +8596,7 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/sapphire-agent-api", "crates/sapphire-call"]
 
 [package]
 name = "sapphire-agent"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A personal AI assistant agent with Matrix/Discord channels, Anthropic backend, and a sapphire-workspace memory layer"
 license = "MIT OR Apache-2.0"
@@ -99,7 +99,7 @@ uuid = { version = "1", features = ["v7"] }
 
 # Workspace: file indexing, FTS, vector search, git sync
 # lancedb-store is gated behind the "lancedb-store" feature (default on)
-sapphire-workspace = { version = "0.8.0", default-features = false }
+sapphire-workspace = { version = "0.8.1", default-features = false }
 
 # Human-readable session IDs for API sessions
 grain-id = { version = "0.14", features = ["serde"] }

--- a/crates/sapphire-agent-api/Cargo.toml
+++ b/crates/sapphire-agent-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-agent-api"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Client library and shared types for sapphire-agent"
 license = "MIT OR Apache-2.0"

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Standalone CLI client for sapphire-agent"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.2.0" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.2.1" }
 
 # Async runtime
 tokio = { version = "1.50", default-features = false, features = [


### PR DESCRIPTION
## Summary
- Bump sapphire-workspace 0.8.0 → 0.8.1 (sapphire-sync 0.8.1) to fix git sync push silently not working
- Bump crate versions to 0.2.1

## Test plan
- [x] `cargo run -- serve` で起動し、periodic sync でコミット+プッシュが両方動作することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)