### PR TITLE
chore: consolidate workspace config, improve release workflow, add install scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
           - os: ubuntu-24.04-arm
             binary: sapphire-agent
             asset_name: sapphire-agent-linux-aarch64
+          - os: windows-latest
+            binary: sapphire-agent.exe
+            asset_name: sapphire-agent-windows-x86_64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -84,7 +87,7 @@ jobs:
           files: artifacts/*
 
   publish:
-    needs: [prepare, release]
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -95,5 +98,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
-      - name: Publish sapphire-agent to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish workspace crates to crates.io
+        run: cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,39 @@
 [workspace]
 members = [".", "crates/sapphire-agent-api", "crates/sapphire-call"]
 
-[package]
-name = "sapphire-agent"
+[workspace.dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "rustls-tls",
+    "stream",
+] }
+serde_json = "1.0"
+tokio = { version = "1.50", default-features = false, features = [
+    "rt-multi-thread",
+    "macros",
+] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "fmt",
+    "ansi",
+    "env-filter",
+] }
+
+[workspace.package]
 version = "0.2.1"
 edition = "2024"
-description = "A personal AI assistant agent with Matrix/Discord channels, Anthropic backend, and a sapphire-workspace memory layer"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
+
+[package]
+name = "sapphire-agent"
+version.workspace = true
+edition.workspace = true
+description = "A personal AI assistant agent with Matrix/Discord channels, Anthropic backend, and a sapphire-workspace memory layer"
+license.workspace = true
+repository.workspace = true
 homepage = "https://github.com/fluo10/sapphire-agent"
 keywords = ["ai", "agent", "anthropic", "matrix", "discord"]
 categories = ["command-line-utilities"]
@@ -26,9 +52,7 @@ git-sync = ["sapphire-workspace/git-sync"]
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.50", default-features = false, features = [
-    "rt-multi-thread",
-    "macros",
+tokio = { workspace = true, features = [
     "time",
     "sync",
     "fs",
@@ -37,12 +61,7 @@ tokio = { version = "1.50", default-features = false, features = [
 ] }
 
 # HTTP client (Anthropic API + tool HTTP calls)
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "rustls-tls",
-    "stream",
-    "blocking",
-] }
+reqwest = { workspace = true, features = ["blocking"] }
 
 # Matrix client + E2EE
 matrix-sdk = { version = "0.16", default-features = false, features = [
@@ -54,7 +73,7 @@ matrix-sdk = { version = "0.16", default-features = false, features = [
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json.workspace = true
 
 # Config (TOML)
 toml = "1.0"
@@ -66,24 +85,20 @@ serde_yaml = "0.9"
 cron = "0.16"
 
 # Error handling
-anyhow = "1.0"
+anyhow.workspace = true
 
 # Async traits
 async-trait = "0.1"
 
 # Futures utilities (SSE streaming)
-futures-util = "0.3"
+futures-util.workspace = true
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "fmt",
-    "ansi",
-    "env-filter",
-] }
+tracing-subscriber.workspace = true
 
 # CLI
-clap = { version = "4.5", features = ["derive"] }
+clap.workspace = true
 
 # XDG directories for config/data paths
 directories = "6.0"
@@ -105,7 +120,7 @@ sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.2.0" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.2.1" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-agent-api/Cargo.toml
+++ b/crates/sapphire-agent-api/Cargo.toml
@@ -1,27 +1,23 @@
 [package]
 name = "sapphire-agent-api"
-version = "0.2.1"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "Client library and shared types for sapphire-agent"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/fluo10/sapphire-agent"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "rustls-tls",
-    "stream",
-] }
+reqwest.workspace = true
 
 # Serialization
-serde_json = "1.0"
+serde_json.workspace = true
 
 # Error handling
-anyhow = "1.0"
+anyhow.workspace = true
 
 # Futures utilities (SSE streaming)
-futures-util = "0.3"
+futures-util.workspace = true
 
 # Readline for the REPL (CJK-safe input, history, cursor movement)
 reedline = "0.47"

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sapphire-call"
-version = "0.2.1"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "Standalone CLI client for sapphire-agent"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/fluo10/sapphire-agent"
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "sapphire-call"
@@ -14,20 +14,13 @@ path = "src/main.rs"
 sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.2.1" }
 
 # Async runtime
-tokio = { version = "1.50", default-features = false, features = [
-    "rt-multi-thread",
-    "macros",
-] }
+tokio.workspace = true
 
 # CLI
-clap = { version = "4.5", features = ["derive"] }
+clap.workspace = true
 
 # Error handling
-anyhow = "1.0"
+anyhow.workspace = true
 
 # Logging
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "fmt",
-    "ansi",
-    "env-filter",
-] }
+tracing-subscriber.workspace = true

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'fluo10/sapphire-agent'
+$InstallDir = Join-Path $HOME '.local\bin'
+$Binary = 'sapphire-agent'
+
+$Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+$Version = $Release.tag_name
+if (-not $Version) {
+    Write-Error 'Failed to fetch latest version.'
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+$Asset = "$Binary-windows-x86_64.exe"
+$Url = "https://github.com/$Repo/releases/download/$Version/$Asset"
+$Dest = Join-Path $InstallDir "$Binary.exe"
+
+Write-Host "Installing $Binary $Version to $InstallDir..."
+Invoke-WebRequest -Uri $Url -OutFile $Dest
+Write-Host "Done! $Dest installed."
+
+$UserPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable('PATH', "$InstallDir;$UserPath", 'User')
+    Write-Host ""
+    Write-Host "Added $InstallDir to your PATH. Restart your terminal to apply."
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+REPO="fluo10/sapphire-agent"
+INSTALL_DIR="${HOME}/.local/bin"
+BINARY="sapphire-agent"
+
+case "$(uname -s)" in
+  Linux*)  OS="linux" ;;
+  Darwin*) OS="macos" ;;
+  *) echo "error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64)        ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *) echo "error: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION=$(curl -sf "https://api.github.com/repos/${REPO}/releases/latest" \
+  | awk -F'"' '/"tag_name"/{print $4; exit}')
+
+if [ -z "$VERSION" ]; then
+  echo "error: failed to fetch latest version" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+
+ASSET="${BINARY}-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+printf "Installing %s %s (%s/%s) to %s...\n" "$BINARY" "$VERSION" "$OS" "$ARCH" "$INSTALL_DIR"
+
+TMP=$(mktemp)
+curl -fsSL "$URL" -o "$TMP"
+chmod +x "$TMP"
+mv "$TMP" "${INSTALL_DIR}/${BINARY}"
+
+echo "Done! ${INSTALL_DIR}/${BINARY} installed."
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    printf "\nNote: %s is not in PATH. Add to your shell profile:\n" "$INSTALL_DIR"
+    printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Unify `version`, `edition`, `license`, `repository` into `[workspace.package]` and reference via `field.workspace = true` in each crate
- Consolidate 7 shared dependencies (`anyhow`, `clap`, `futures-util`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`) into `[workspace.dependencies]`
- Fix `sapphire-agent-api` dependency version mismatch (0.2.0 → 0.2.1)
- Add Windows (`windows-latest`) build target to the release workflow matrix
- Switch `cargo publish` to `--workspace` so all crates (including `sapphire-agent-api` and `sapphire-call`) are published
- Run the `publish` job in parallel with `build`/`release` (`needs: prepare` only) since they are independent
- Add `install.sh` (Linux/macOS) and `install.ps1` (Windows) for downloading pre-built binaries from GitHub Releases

## Test plan
- [x] `cargo check --workspace` passes with no new warnings
- [ ] Verify release workflow produces Windows binary on next release
- [ ] Test `install.sh` against a published release

🤖 Generated with [Claude Code](https://claude.com/claude-code)