### PR TITLE
fix(matrix): auto-reconnect sync loop on disconnect

### DIFF
--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -191,12 +191,29 @@ impl Channel for MatrixChannel {
         });
 
         info!("Starting Matrix sync loop...");
-        client
-            .sync(SyncSettings::default().timeout(std::time::Duration::from_secs(30)))
-            .await
-            .context("Matrix sync loop exited with error")?;
-
-        Ok(())
+        let sync_settings = SyncSettings::default().timeout(std::time::Duration::from_secs(30));
+        let min_backoff = std::time::Duration::from_secs(1);
+        let max_backoff = std::time::Duration::from_secs(300);
+        let stable_threshold = std::time::Duration::from_secs(60);
+        let mut backoff = min_backoff;
+        loop {
+            let started = std::time::Instant::now();
+            match client.sync(sync_settings.clone()).await {
+                Ok(()) => {
+                    warn!("Matrix sync loop exited without error; reconnecting in {backoff:?}");
+                }
+                Err(e) => {
+                    warn!("Matrix sync loop exited with error: {e}; reconnecting in {backoff:?}");
+                }
+            }
+            tokio::time::sleep(backoff).await;
+            if started.elapsed() >= stable_threshold {
+                backoff = min_backoff;
+            } else {
+                backoff = (backoff * 2).min(max_backoff);
+            }
+            info!("Reconnecting Matrix sync loop...");
+        }
     }
 
     async fn start_typing(&self, room_id: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- Previously, `MatrixChannel::listen` called `client.sync()` once and returned on the first error, which closed the incoming-message channel and effectively shut the agent down until restart.
- Wrap the sync call in a retry loop with exponential backoff (1s → capped at 5m) so the Matrix channel recovers from transient disconnects.
- Reset the backoff when a sync stays healthy for at least 60 seconds, so a long-running connection that eventually drops reconnects quickly instead of inheriting stale backoff.

## Test plan
- [ ] Start the agent against a live Matrix homeserver and confirm normal messages still flow.
- [ ] Simulate a disconnect (e.g. drop network / restart homeserver) and verify the agent logs a reconnect attempt and resumes receiving messages without a process restart.
- [ ] Confirm repeated immediate failures back off (1s, 2s, 4s, …) up to the 5m cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)