### PR TITLE
Carry session context across restarts via summary instead of raw history

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,6 @@
 use crate::channel::{Channel, OutgoingMessage};
 use crate::config::Config;
-use crate::context_compression::maybe_compress;
+use crate::context_compression::{generate_summary, maybe_compress};
 use crate::provider::{ChatMessage, ContentPart, Provider, ToolCall};
 use crate::session::{ConversationKey, SessionStore, local_date_for_timestamp};
 use crate::tools::ToolSet;
@@ -35,6 +35,8 @@ pub struct Agent {
     tools: Option<Arc<ToolSet>>,
     session_store: Arc<SessionStore>,
     /// In-memory conversation history, keyed by (room_id, thread_id).
+    /// Starts empty on process startup; raw history from disk is never reloaded
+    /// (see `restart_summaries` for how prior context is carried across restarts).
     history: Mutex<HashMap<ConversationKey, Vec<ChatMessage>>>,
     /// Maps each ConversationKey to its current active session file (ULID string).
     active_sessions: Mutex<HashMap<ConversationKey, String>>,
@@ -42,6 +44,14 @@ pub struct Agent {
     snapshots: Mutex<HashMap<ConversationKey, SystemSnapshot>>,
     /// Background prefetch cache: workspace search results for the next turn.
     prefetch_cache: Mutex<HashMap<ConversationKey, String>>,
+    /// Compacted recap of the prior run per ConversationKey. Injected into the
+    /// system prompt on the first message after restart, then consumed.
+    restart_summaries: Mutex<HashMap<ConversationKey, String>>,
+    /// Active sessions whose on-disk history has no `SummaryLine` yet (e.g.
+    /// server crashed before graceful shutdown). `bootstrap()` synthesizes a
+    /// summary from these raw messages and moves the result into
+    /// `restart_summaries`.
+    pending_fallback: Mutex<HashMap<ConversationKey, Vec<ChatMessage>>>,
 }
 
 impl Agent {
@@ -53,8 +63,13 @@ impl Agent {
         tools: Option<Arc<ToolSet>>,
         session_store: Arc<SessionStore>,
     ) -> Self {
-        let (history, active_sessions) = session_store.load_all();
-        info!("Loaded {} session(s) from disk", active_sessions.len());
+        let (active_sessions, summaries, fallback) = session_store.load_all();
+        info!(
+            "Loaded {} session(s) from disk ({} with summary, {} awaiting fallback summarization)",
+            active_sessions.len(),
+            summaries.len(),
+            fallback.len(),
+        );
         Self {
             config,
             channel,
@@ -62,10 +77,102 @@ impl Agent {
             workspace,
             tools,
             session_store,
-            history: Mutex::new(history),
+            history: Mutex::new(HashMap::new()),
             active_sessions: Mutex::new(active_sessions),
             snapshots: Mutex::new(HashMap::new()),
             prefetch_cache: Mutex::new(HashMap::new()),
+            restart_summaries: Mutex::new(summaries),
+            pending_fallback: Mutex::new(fallback),
+        }
+    }
+
+    /// Drain `pending_fallback` and synthesize summaries for any active session
+    /// whose prior run did not produce a `SummaryLine` (e.g. crash). Each
+    /// generated summary is appended to the JSONL file and placed into
+    /// `restart_summaries` for the next turn.
+    pub async fn bootstrap(self: &Arc<Self>) {
+        let pending: Vec<(ConversationKey, Vec<ChatMessage>)> = {
+            let mut map = self.pending_fallback.lock().await;
+            map.drain().collect()
+        };
+
+        if pending.is_empty() {
+            return;
+        }
+
+        info!(
+            "Bootstrap: synthesizing summaries for {} session(s) without a SummaryLine",
+            pending.len()
+        );
+
+        for (key, messages) in pending {
+            if messages.len() < 2 {
+                continue;
+            }
+            let session_id = {
+                let sessions = self.active_sessions.lock().await;
+                match sessions.get(&key) {
+                    Some(id) if !id.is_empty() => id.clone(),
+                    _ => continue,
+                }
+            };
+            match generate_summary(&*self.provider, &messages).await {
+                Ok(summary) if !summary.trim().is_empty() => {
+                    if let Err(e) = self.session_store.append_summary(&session_id, &summary) {
+                        warn!("Failed to persist fallback summary for {session_id}: {e}");
+                    }
+                    self.restart_summaries
+                        .lock()
+                        .await
+                        .insert(key, summary);
+                }
+                Ok(_) => warn!("Fallback summary for {session_id} was empty; skipping"),
+                Err(e) => warn!("Fallback summary generation failed for {session_id}: {e:#}"),
+            }
+        }
+    }
+
+    /// Summarize each active session's current in-memory history and persist
+    /// the result to disk. Called on graceful shutdown so the next process
+    /// can pick up where this one left off.
+    async fn summarize_on_shutdown(&self) {
+        let snapshot: Vec<(ConversationKey, String, Vec<ChatMessage>)> = {
+            let history = self.history.lock().await;
+            let sessions = self.active_sessions.lock().await;
+            history
+                .iter()
+                .filter_map(|(key, msgs)| {
+                    if msgs.len() < 2 {
+                        return None;
+                    }
+                    let sid = sessions.get(key)?.clone();
+                    if sid.is_empty() {
+                        return None;
+                    }
+                    Some((key.clone(), sid, msgs.clone()))
+                })
+                .collect()
+        };
+
+        if snapshot.is_empty() {
+            return;
+        }
+
+        info!(
+            "Graceful shutdown: summarizing {} active session(s)",
+            snapshot.len()
+        );
+
+        for (_key, session_id, messages) in snapshot {
+            match generate_summary(&*self.provider, &messages).await {
+                Ok(summary) if !summary.trim().is_empty() => {
+                    if let Err(e) = self.session_store.append_summary(&session_id, &summary) {
+                        warn!("Failed to persist shutdown summary for {session_id}: {e}");
+                    }
+                }
+                Ok(_) => warn!("Shutdown summary for {session_id} was empty; skipping"),
+                Err(e) => warn!("Shutdown summary generation failed for {session_id}: {e:#}"),
+            }
         }
     }
 
@@ -134,6 +241,7 @@ impl Agent {
             }
         }
 
+        self.summarize_on_shutdown().await;
         listen_handle.abort();
         Ok(())
     }
@@ -162,8 +270,22 @@ impl Agent {
     }
 
     /// Persist `msg` to the session store. No-op if session creation failed.
+    ///
+    /// Messages containing `ToolUse` or `ToolResult` parts are intentionally
+    /// skipped: tool payloads can be arbitrarily large (file contents, etc.)
+    /// and we never reload raw history across restarts, so persisting them
+    /// would only bloat the JSONL. Context survives via compaction summaries.
     fn persist(&self, session_id: &str, msg: &ChatMessage) {
         if session_id.is_empty() {
+            return;
+        }
+        let has_tool_parts = msg.parts.iter().any(|p| {
+            matches!(
+                p,
+                ContentPart::ToolUse { .. } | ContentPart::ToolResult { .. }
+            )
+        });
+        if has_tool_parts {
             return;
         }
         if let Err(e) = self.session_store.append(session_id, msg) {
@@ -275,6 +397,25 @@ impl Agent {
             (sys, _) => sys,
         };
 
+        // First-turn-after-restart injection: if a compacted recap of the
+        // prior run exists for this conversation, paste it into the system
+        // prompt and consume the entry. Raw history is never reloaded across
+        // restarts, so this summary is the sole bridge.
+        let system_with_context = {
+            let restart_summary = self.restart_summaries.lock().await.remove(&key);
+            match (system_with_context, restart_summary) {
+                (sys, Some(summary)) if !summary.trim().is_empty() => {
+                    let base = sys.unwrap_or_default();
+                    Some(format!(
+                        "{base}\n\n---\n\n<prior-session-recap>\nサーバー再起動のため直前のやり取り自体は失われています。\
+                         以下は前回セッションの要約です。これと今回の発言のみを頼りに応答してください。\
+                         必要なら「再起動直後で記憶が曖昧」と率直に述べて構いません。\n\n{summary}\n</prior-session-recap>"
+                    ))
+                }
+                (sys, _) => sys,
+            }
+        };
+
         // Append user message
         {
             let msg = ChatMessage::user(&incoming.content);
@@ -336,15 +477,21 @@ impl Agent {
             )
             .await
             {
-                Ok(Some(compressed)) => {
+                Ok(Some(result)) => {
                     // Replace in-memory history with compressed version
                     *self
                         .history
                         .lock()
                         .await
                         .entry(key.clone())
-                        .or_default() = compressed.clone();
-                    compressed
+                        .or_default() = result.compressed.clone();
+                    if let Err(e) = self
+                        .session_store
+                        .append_summary(&session_id, &result.summary)
+                    {
+                        warn!("Failed to persist compaction summary: {e}");
+                    }
+                    result.compressed
                 }
                 Ok(None) => messages,
                 Err(e) => {

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -54,16 +54,23 @@ fn estimate_message_tokens(msg: &ChatMessage) -> usize {
         .sum()
 }
 
+/// Outcome of a compression attempt.
+pub struct CompressionResult {
+    pub compressed: Vec<ChatMessage>,
+    pub summary: String,
+}
+
 /// Check whether compression is needed and, if so, compress the history.
 ///
 /// Returns `Ok(None)` if no compression was needed.
-/// Returns `Ok(Some(compressed))` with the new message history if compressed.
+/// Returns `Ok(Some(CompressionResult))` with the new message history and the
+/// raw summary text (to be persisted as a `SummaryLine`) if compressed.
 pub async fn maybe_compress(
     provider: &dyn Provider,
     system: Option<&str>,
     messages: &[ChatMessage],
     config: &CompressionConfig,
-) -> anyhow::Result<Option<Vec<ChatMessage>>> {
+) -> anyhow::Result<Option<CompressionResult>> {
     if !config.enabled {
         return Ok(None);
     }
@@ -81,19 +88,15 @@ pub async fn maybe_compress(
         config.context_window
     );
 
-    // Find the split point: keep the most recent `preserve_recent` messages,
-    // but ensure we don't split in the middle of a tool-call/result pair.
     let split = find_safe_split_point(messages, config.preserve_recent);
 
     if split == 0 {
-        // Nothing to compress — all messages are in the "recent" window
         return Ok(None);
     }
 
     let to_summarize = &messages[..split];
     let to_keep = &messages[split..];
 
-    // Generate a summary of the older messages
     let summary = generate_summary(provider, to_summarize).await?;
 
     info!(
@@ -103,7 +106,6 @@ pub async fn maybe_compress(
         estimate_tokens(&summary),
     );
 
-    // Build the compressed history: summary message + recent messages
     let mut compressed = Vec::with_capacity(1 + to_keep.len());
     compressed.push(ChatMessage {
         role: Role::User,
@@ -111,14 +113,15 @@ pub async fn maybe_compress(
             "[Context Summary — earlier messages were compressed]\n\n{summary}"
         ))],
     });
-    // Insert a placeholder assistant acknowledgment so that the message
-    // sequence alternates correctly (user → assistant → user → …).
     compressed.push(ChatMessage::assistant(
         "Understood. I have the context from our earlier conversation.",
     ));
     compressed.extend_from_slice(to_keep);
 
-    Ok(Some(compressed))
+    Ok(Some(CompressionResult {
+        compressed,
+        summary,
+    }))
 }
 
 /// Find a safe split point that doesn't break tool-call/result pairs.
@@ -169,7 +172,11 @@ fn find_safe_split_point(messages: &[ChatMessage], preserve_recent: usize) -> us
 }
 
 /// Generate a concise summary of a sequence of messages using the LLM.
-async fn generate_summary(
+///
+/// Tool-call and tool-result parts are rendered as plain-text placeholders,
+/// so the input need not be tool-paired — safe to call on raw, potentially
+/// incomplete history loaded from disk at startup.
+pub async fn generate_summary(
     provider: &dyn Provider,
     messages: &[ChatMessage],
 ) -> anyhow::Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,7 @@ async fn main() -> Result<()> {
                     Some(Arc::clone(&tool_set)),
                     Arc::clone(&channel_session_store),
                 ));
+                agent.bootstrap().await;
 
                 // ── Heartbeat (day-boundary + cron loops) ───────────────────
                 let default_room_id =

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -6,7 +6,7 @@
 //! Session management follows the MCP standard: `Mcp-Session-Id` request header.
 
 use crate::config::Config;
-use crate::context_compression::maybe_compress;
+use crate::context_compression::{generate_summary, maybe_compress};
 use crate::provider::{ChatMessage, ContentPart, Provider};
 use crate::session::{ConversationKey, SessionStore};
 use crate::tools::ToolSet;
@@ -122,19 +122,52 @@ pub async fn run(
     let app = Router::new()
         .route("/mcp", post(mcp_post).get(mcp_get))
         .layer(tower_http::cors::CorsLayer::permissive())
-        .with_state(state);
+        .with_state(Arc::clone(&state));
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("sapphire-agent: API server listening on http://{addr}");
+    let shutdown_state = Arc::clone(&state);
     axum::serve(listener, app)
-        .with_graceful_shutdown(async {
+        .with_graceful_shutdown(async move {
             if let Err(e) = tokio::signal::ctrl_c().await {
                 error!("Failed to install Ctrl-C handler: {e}");
             }
             info!("HTTP server shutting down...");
         })
         .await?;
+    summarize_all_sessions(&shutdown_state).await;
     Ok(())
+}
+
+/// Summarize every in-memory API session and append a `SummaryLine` so the
+/// next process can recover context without replaying raw history.
+async fn summarize_all_sessions(state: &Arc<ServeState>) {
+    let snapshot: Vec<(String, Vec<ChatMessage>)> = {
+        let sessions = state.sessions.lock().await;
+        sessions
+            .iter()
+            .filter(|(_, msgs)| msgs.len() >= 2)
+            .map(|(sid, msgs)| (sid.clone(), msgs.clone()))
+            .collect()
+    };
+    if snapshot.is_empty() {
+        return;
+    }
+    info!(
+        "Graceful shutdown: summarizing {} API session(s)",
+        snapshot.len()
+    );
+    for (session_id, messages) in snapshot {
+        match generate_summary(&*state.provider, &messages).await {
+            Ok(summary) if !summary.trim().is_empty() => {
+                if let Err(e) = state.api_session_store.append_summary(&session_id, &summary) {
+                    warn!("Failed to persist shutdown summary for {session_id}: {e}");
+                }
+            }
+            Ok(_) => warn!("Shutdown summary for {session_id} was empty; skipping"),
+            Err(e) => warn!("Shutdown summary generation failed for {session_id}: {e:#}"),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -504,8 +537,14 @@ async fn run_turn(
         )
         .await
         {
-            Ok(Some(compressed)) => {
-                history = compressed;
+            Ok(Some(result)) => {
+                history = result.compressed;
+                if let Err(e) = state
+                    .api_session_store
+                    .append_summary(&session_id, &result.summary)
+                {
+                    warn!("Failed to persist compaction summary: {e}");
+                }
             }
             Ok(None) => {}
             Err(e) => {
@@ -543,9 +582,10 @@ async fn run_turn(
                 }
                 let msg = ChatMessage::assistant_with_tools(resp.text.clone(), tool_calls.clone());
                 history.push(msg.clone());
-                if let Err(e) = state.api_session_store.append(&session_id, &msg) {
-                    warn!("Failed to persist tool-call message: {e}");
-                }
+                // Tool_use messages are intentionally not persisted: they
+                // can be arbitrarily large and we never reload raw tool
+                // history across restarts anyway (compaction summaries cover
+                // the semantic context).
 
                 // Notify client of each tool starting
                 for call in &tool_calls {
@@ -582,9 +622,8 @@ async fn run_turn(
 
                 let result_msg = ChatMessage::tool_results(results);
                 history.push(result_msg.clone());
-                if let Err(e) = state.api_session_store.append(&session_id, &result_msg) {
-                    warn!("Failed to persist tool results: {e}");
-                }
+                // Tool_result payloads are not persisted — see the matching
+                // tool_use branch above for rationale.
             }
         }
     };

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,6 +91,18 @@ struct TitleLine {
     session_title: String,
 }
 
+/// Compacted recap of a session, appended whenever an in-memory compression
+/// fires and on graceful shutdown. Restart uses the latest `SummaryLine` to
+/// inject context into the system prompt without replaying the raw (and
+/// potentially tool-unpaired) message history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryLine {
+    pub summary_at: DateTime<Utc>,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub up_to_timestamp: Option<DateTime<Utc>>,
+}
+
 // ---------------------------------------------------------------------------
 // SessionStore
 // ---------------------------------------------------------------------------
@@ -208,6 +220,21 @@ impl SessionStore {
         Ok(())
     }
 
+    /// Append a compaction summary to the session file.
+    pub fn append_summary(&self, session_id: &str, summary: &str) -> anyhow::Result<()> {
+        let line = serde_json::to_string(&SummaryLine {
+            summary_at: Utc::now(),
+            summary: summary.to_string(),
+            up_to_timestamp: None,
+        })?;
+        let path = self.session_path(session_id);
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        writeln!(file, "{line}")?;
+        drop(file);
+        self.notify_updated(&path);
+        Ok(())
+    }
+
     /// Close a session by appending a `closed_at` marker.
     /// The session becomes inactive; future messages create a new session.
     pub fn close_session(&self, session_id: &str) -> anyhow::Result<()> {
@@ -227,19 +254,35 @@ impl SessionStore {
     /// For each `ConversationKey`, picks the latest ULID-ordered session that
     /// does **not** have a `closed_at` marker (i.e. is still active).
     ///
-    /// Returns `(history, active_session_ids)`.
+    /// Raw message history is intentionally NOT reconstructed into in-memory
+    /// history: Anthropic's API requires paired tool_use/tool_result, and we
+    /// skip persisting tool messages to disk, so reloading would break that
+    /// invariant. Instead, callers get:
+    ///
+    /// - `active`: which session file is current per conversation
+    /// - `summaries`: the latest `SummaryLine` per conversation (when present)
+    /// - `fallback_messages`: raw `ChatMessage` list for active sessions that
+    ///   have NO summary yet — Agent bootstrap uses these to synthesize a
+    ///   summary on startup (e.g. after a crash that skipped graceful shutdown)
     pub fn load_all(
         &self,
     ) -> (
-        HashMap<ConversationKey, Vec<ChatMessage>>,
         HashMap<ConversationKey, String>,
+        HashMap<ConversationKey, String>,
+        HashMap<ConversationKey, Vec<ChatMessage>>,
     ) {
-        type SessionEntry = (String, ConversationKey, Vec<StoredMessage>, bool);
+        type SessionEntry = (
+            String,
+            ConversationKey,
+            Vec<StoredMessage>,
+            bool,
+            Option<String>,
+        );
         let mut entries: Vec<SessionEntry> = Vec::new();
 
         let dir = match fs::read_dir(&self.sessions_dir) {
             Ok(d) => d,
-            Err(_) => return (HashMap::new(), HashMap::new()),
+            Err(_) => return (HashMap::new(), HashMap::new(), HashMap::new()),
         };
 
         for entry in dir.flatten() {
@@ -252,30 +295,43 @@ impl SessionStore {
                 None => continue,
             };
 
-            if let Some((meta, messages, is_closed)) = load_session_file(&path) {
+            if let Some((meta, messages, is_closed, summary)) = load_session_file(&path) {
                 let key: ConversationKey = (meta.room_id.clone(), meta.thread_id.clone());
-                entries.push((stem, key, messages, is_closed));
+                entries.push((stem, key, messages, is_closed, summary.map(|s| s.summary)));
             }
         }
 
-        // Sort by session_id (ULID ⟹ time-ordered, lexicographic)
         entries.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let mut history: HashMap<ConversationKey, Vec<ChatMessage>> = HashMap::new();
         let mut active: HashMap<ConversationKey, String> = HashMap::new();
+        let mut summaries: HashMap<ConversationKey, String> = HashMap::new();
+        let mut fallback: HashMap<ConversationKey, Vec<ChatMessage>> = HashMap::new();
 
-        for (session_id, key, messages, is_closed) in entries {
+        for (session_id, key, messages, is_closed, summary) in entries {
             if !is_closed {
-                let chat_messages = messages
-                    .into_iter()
-                    .map(|m| m.into_chat_message())
-                    .collect();
-                history.insert(key.clone(), chat_messages);
-                active.insert(key, session_id);
+                active.insert(key.clone(), session_id);
+                match summary {
+                    Some(s) => {
+                        summaries.insert(key.clone(), s);
+                        fallback.remove(&key);
+                    }
+                    None => {
+                        summaries.remove(&key);
+                        if !messages.is_empty() {
+                            let chat_messages: Vec<ChatMessage> = messages
+                                .into_iter()
+                                .map(|m| m.into_chat_message())
+                                .collect();
+                            fallback.insert(key, chat_messages);
+                        } else {
+                            fallback.remove(&key);
+                        }
+                    }
+                }
             }
         }
 
-        (history, active)
+        (active, summaries, fallback)
     }
 
     /// List metadata for all sessions in this store (used by API for session listing).
@@ -287,7 +343,7 @@ impl SessionStore {
         let mut metas: Vec<SessionMeta> = dir
             .flatten()
             .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("jsonl"))
-            .filter_map(|e| load_session_file(&e.path()).map(|(meta, _, _)| meta))
+            .filter_map(|e| load_session_file(&e.path()).map(|(meta, _, _, _)| meta))
             .collect();
         metas.sort_by_key(|m| m.created_at);
         metas
@@ -297,7 +353,7 @@ impl SessionStore {
     /// Returns None if the file doesn't exist or is malformed.
     pub fn load_session(&self, session_id: &str) -> Option<Vec<ChatMessage>> {
         let path = self.session_path(session_id);
-        let (_, messages, _) = load_session_file(&path)?;
+        let (_, messages, _, _) = load_session_file(&path)?;
         Some(
             messages
                 .into_iter()
@@ -323,7 +379,7 @@ impl SessionStore {
         let path = self.session_path(session_id);
         if path.exists() {
             // Return existing public_id if the file already existed
-            let pub_id = load_session_file(&path).and_then(|(meta, _, _)| meta.public_id);
+            let pub_id = load_session_file(&path).and_then(|(meta, _, _, _)| meta.public_id);
             return Ok(pub_id);
         }
         let public_id = if channel == "api" {
@@ -370,7 +426,7 @@ impl SessionStore {
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
-            if let Some((meta, _, _)) = load_session_file(&path) {
+            if let Some((meta, _, _, _)) = load_session_file(&path) {
                 if meta.public_id.as_deref() == Some(public_id) {
                     return Some(meta.session_id);
                 }
@@ -413,7 +469,7 @@ impl SessionStore {
                 }
             }
 
-            if let Some((meta, messages, _)) = load_session_file(&path) {
+            if let Some((meta, messages, _, _)) = load_session_file(&path) {
                 let day_messages: Vec<StoredMessage> = messages
                     .into_iter()
                     .filter(|m| m.timestamp >= day_start && m.timestamp < day_end)
@@ -446,7 +502,7 @@ impl SessionStore {
                 continue;
             }
 
-            if let Some((_, messages, _)) = load_session_file(&path) {
+            if let Some((_, messages, _, _)) = load_session_file(&path) {
                 for msg in messages {
                     let local_ts = msg.timestamp.with_timezone(&Local);
                     let date = local_date_for_timestamp(local_ts, boundary_hour);
@@ -509,21 +565,21 @@ pub fn local_date_for_timestamp(local_ts: DateTime<Local>, boundary_hour: u8) ->
 
 /// Parse a single session `.jsonl` file.
 ///
-/// Returns `(meta, messages, is_closed)` or `None` if the file is unreadable
-/// or has a malformed first line.
-///
-/// Messages are returned as `StoredMessage` (with timestamps preserved).
-fn load_session_file(path: &Path) -> Option<(SessionMeta, Vec<StoredMessage>, bool)> {
+/// Returns `(meta, messages, is_closed, latest_summary)` or `None` if the
+/// file is unreadable or has a malformed first line.
+fn load_session_file(
+    path: &Path,
+) -> Option<(SessionMeta, Vec<StoredMessage>, bool, Option<SummaryLine>)> {
     let file = fs::File::open(path).ok()?;
     let mut lines = BufReader::new(file).lines();
 
-    // First line must be the meta object
     let first = lines.next()?.ok()?;
     let meta_line: MetaLine = serde_json::from_str(first.trim()).ok()?;
     let mut meta = meta_line.meta;
 
     let mut messages = Vec::new();
     let mut is_closed = false;
+    let mut latest_summary: Option<SummaryLine> = None;
 
     for raw in lines.flatten() {
         let raw = raw.trim().to_string();
@@ -543,6 +599,13 @@ fn load_session_file(path: &Path) -> Option<(SessionMeta, Vec<StoredMessage>, bo
             is_closed = true;
         } else if let Some(title) = value.get("session_title").and_then(|v| v.as_str()) {
             meta.title = Some(title.to_string());
+        } else if value.get("summary_at").is_some() {
+            match serde_json::from_value::<SummaryLine>(value) {
+                Ok(s) => latest_summary = Some(s),
+                Err(e) => {
+                    warn!("Skipping malformed summary in {}: {e}", path.display());
+                }
+            }
         } else if value.get("timestamp").is_some() {
             match serde_json::from_value::<StoredMessage>(value) {
                 Ok(stored) => messages.push(stored),
@@ -553,5 +616,5 @@ fn load_session_file(path: &Path) -> Option<(SessionMeta, Vec<StoredMessage>, bo
         }
     }
 
-    Some((meta, messages, is_closed))
+    Some((meta, messages, is_closed, latest_summary))
 }


### PR DESCRIPTION
## Summary

- Stop reloading raw message history on restart. Tool payloads (file contents, search results) can be arbitrarily large, and partial reloads risk breaking Anthropic's `tool_use`/`tool_result` pairing requirement.
- Compaction now appends a `SummaryLine` to the JSONL. Graceful shutdown force-summarizes every active session; if the process crashed before that, `Agent::bootstrap()` synthesizes a summary from the surviving raw messages at next startup.
- On the first turn after restart, the most recent summary is injected into the system prompt as `<prior-session-recap>` so the LLM retains rough context without replaying history.
- Tool-bearing messages (`ToolUse` / `ToolResult` parts) are no longer persisted.

## Design notes

- **Why drop raw reload**: reloading a log with tool messages stripped leaves dangling `tool_use` entries without their paired `tool_result`, which Anthropic rejects. Summary-only reload sidesteps this entirely.
- **Fallback at bootstrap**: for sessions on disk that never got a summary (e.g. SIGKILL before graceful shutdown ran), `generate_summary` is re-used on the raw loaded messages. It formats tool parts as plain-text placeholders and sends a single user message, so unpaired tool parts are fine.
- **Daily log**: unaffected. `sessions_for_day` still returns raw `StoredMessage`s with timestamps and ignores `SummaryLine`; compaction only appends — never rewrites prior messages — so historical text is preserved on disk for day-scoped summarization.

## Files touched

- `src/session.rs` — `SummaryLine` type, `append_summary()`, `load_session_file` returns latest summary, `load_all` returns `(active, summaries, fallback_messages)` instead of in-memory history.
- `src/context_compression.rs` — `maybe_compress` returns `CompressionResult { compressed, summary }`; `generate_summary` made `pub`.
- `src/agent.rs` — `restart_summaries` / `pending_fallback` fields, `bootstrap()` and `summarize_on_shutdown()`, `persist()` skips tool-bearing messages, system prompt gets `<prior-session-recap>` block when a summary is pending.
- `src/serve.rs` — API server mirrors the same persistence rules and runs `summarize_all_sessions()` after graceful HTTP shutdown.
- `src/main.rs` — calls `agent.bootstrap().await` after construction.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (9 tests pass)
- [ ] Manual: run a Matrix/Discord session that exceeds the compaction threshold; confirm a `summary_at` line appears in the JSONL and no `ToolUse`/`ToolResult` rows are written.
- [ ] Manual: Ctrl-C the running agent, restart it, send a new message; confirm the assistant references prior context via the injected `<prior-session-recap>` and can acknowledge grogginess naturally.
- [ ] Manual: simulate a crash (SIGKILL) before any compaction, then restart; verify `Agent::bootstrap()` logs fallback summarization and appends a `SummaryLine` post-hoc.
- [ ] Manual: generate a daily log for a day that spans a compaction event; confirm the log uses the raw per-message text (not the summary).