### PR TITLE
feat(session): configurable day-boundary policy and Matrix multi-room

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,9 @@ homeserver = "https://matrix.example.com"
 access_token = "syt_..."
 user_id = "@bot:example.com"
 device_id = "DEVICEID"
-room_id = "!roomid:example.com"
+# Rooms to listen in. Accepts either an array (preferred) or a single string
+# via the legacy `room_id` key.
+room_ids = ["!roomid:example.com"]
 # Messages from users not in this list are silently ignored.
 # Leave empty ([]) to allow all users.
 allowed_users = ["@you:example.com"]
@@ -25,6 +27,16 @@ recovery_key = "EsT... "
 # Directory containing AGENT.md and MEMORY.md.
 # Defaults to the same directory as this config file.
 # workspace_dir = "~/.config/sapphire-agent"
+
+# Day-boundary session policy. One of:
+#   "reset"   — close the session; next message starts a new one (legacy default)
+#   "compact" — keep the session; force-summarize prior-day history into a stub
+#   "none"    — no day-boundary action
+# session_policy = "compact"
+
+# Per-room overrides. Keys are room_ids; values may set session_policy.
+# [rooms."!roomid:example.com"]
+# session_policy = "reset"
 
 [anthropic]
 api_key = "sk-ant-..."

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,7 @@
 use crate::channel::{Channel, OutgoingMessage};
-use crate::config::Config;
+use crate::config::{Config, SessionPolicy};
 use crate::context_compression::{generate_summary, maybe_compress};
-use crate::provider::{ChatMessage, ContentPart, Provider, ToolCall};
+use crate::provider::{ChatMessage, ContentPart, Provider, Role, ToolCall};
 use crate::session::{ConversationKey, SessionStore, local_date_for_timestamp};
 use crate::tools::ToolSet;
 use crate::workspace::Workspace;
@@ -52,6 +52,10 @@ pub struct Agent {
     /// summary from these raw messages and moves the result into
     /// `restart_summaries`.
     pending_fallback: Mutex<HashMap<ConversationKey, Vec<ChatMessage>>>,
+    /// Local date on which the last day-boundary action fired for each key.
+    /// Prevents re-firing within the same day for policies that don't rotate
+    /// the session file (Compact, None).
+    boundary_handled: Mutex<HashMap<ConversationKey, NaiveDate>>,
 }
 
 impl Agent {
@@ -83,6 +87,7 @@ impl Agent {
             prefetch_cache: Mutex::new(HashMap::new()),
             restart_summaries: Mutex::new(summaries),
             pending_fallback: Mutex::new(fallback),
+            boundary_handled: Mutex::new(HashMap::new()),
         }
     }
 
@@ -293,11 +298,17 @@ impl Agent {
         }
     }
 
-    /// If the active session for `key` started on a different local day,
-    /// close it and clear the in-memory state so a new session is created.
-    async fn maybe_reset_session(&self, key: &ConversationKey) {
+    /// Dispatch the configured day-boundary action for `key` when the local
+    /// date on the active session file is older than today. Each policy is
+    /// idempotent within a day via `boundary_handled`.
+    async fn maybe_handle_day_boundary(&self, key: &ConversationKey) {
         let boundary = self.config.day_boundary_hour;
         let today = local_date_for_timestamp(Local::now(), boundary);
+        let policy = self.config.session_policy_for(&key.0);
+
+        if policy == SessionPolicy::None {
+            return;
+        }
 
         let session_id = {
             let sessions = self.active_sessions.lock().await;
@@ -312,18 +323,98 @@ impl Agent {
             .sessions_dir
             .join(format!("{session_id}.jsonl"));
 
-        if read_session_date(&session_path, boundary) < today {
-            info!("Day boundary crossed for {key:?}; resetting session");
-
-            if let Err(e) = self.session_store.close_session(&session_id) {
-                warn!("Failed to close session {session_id}: {e}");
-            }
-
-            self.history.lock().await.remove(key);
-            self.active_sessions.lock().await.remove(key);
-            self.snapshots.lock().await.remove(key);
-            self.prefetch_cache.lock().await.remove(key);
+        if read_session_date(&session_path, boundary) >= today {
+            return;
         }
+
+        // Idempotence: don't re-fire within the same local day if we already
+        // handled it (only relevant for policies that don't rotate the file).
+        {
+            let handled = self.boundary_handled.lock().await;
+            if handled.get(key).copied() == Some(today) {
+                return;
+            }
+        }
+
+        match policy {
+            SessionPolicy::Reset => {
+                info!("Day boundary crossed for {key:?}; resetting session");
+
+                if let Err(e) = self.session_store.close_session(&session_id) {
+                    warn!("Failed to close session {session_id}: {e}");
+                }
+
+                self.history.lock().await.remove(key);
+                self.active_sessions.lock().await.remove(key);
+                self.snapshots.lock().await.remove(key);
+                self.prefetch_cache.lock().await.remove(key);
+                // Reset rotates the session file, so no need to mark handled;
+                // the new session will have today's created_at.
+            }
+            SessionPolicy::Compact => {
+                self.compact_at_boundary(key, &session_id).await;
+                self.boundary_handled
+                    .lock()
+                    .await
+                    .insert(key.clone(), today);
+            }
+            SessionPolicy::None => unreachable!(),
+        }
+    }
+
+    /// Force-summarize the current in-memory history for `key` and replace
+    /// it with a summary stub so the session can keep growing into the new
+    /// day without re-sending stale context to the model.
+    async fn compact_at_boundary(&self, key: &ConversationKey, session_id: &str) {
+        let messages = {
+            let history = self.history.lock().await;
+            history.get(key).cloned().unwrap_or_default()
+        };
+
+        // Nothing to compact if history is empty or already just a stub.
+        let has_real_content = messages.iter().any(|m| {
+            m.parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::Text(t) if !t.is_empty()))
+        });
+        if messages.len() < 2 || !has_real_content {
+            return;
+        }
+
+        info!("Day boundary crossed for {key:?}; compacting session {session_id}");
+
+        let summary = match generate_summary(&*self.provider, &messages).await {
+            Ok(s) if !s.trim().is_empty() => s,
+            Ok(_) => {
+                warn!("Boundary summary for {session_id} was empty; skipping");
+                return;
+            }
+            Err(e) => {
+                warn!("Boundary summary generation failed for {session_id}: {e:#}");
+                return;
+            }
+        };
+
+        if let Err(e) = self.session_store.append_summary(session_id, &summary) {
+            warn!("Failed to persist boundary summary for {session_id}: {e}");
+        }
+
+        let stub = vec![
+            ChatMessage {
+                role: Role::User,
+                parts: vec![ContentPart::Text(format!(
+                    "[Context Summary — prior-day messages were compacted]\n\n{summary}"
+                ))],
+            },
+            ChatMessage::assistant(
+                "Understood. I have the context from the prior day's conversation.",
+            ),
+        ];
+
+        self.history.lock().await.insert(key.clone(), stub);
+        // Refresh the system prompt snapshot so it rebuilds with today's date.
+        self.snapshots.lock().await.remove(key);
+        self.prefetch_cache.lock().await.remove(key);
     }
 
     // -----------------------------------------------------------------------
@@ -380,8 +471,8 @@ impl Agent {
 
         let key: ConversationKey = (incoming.room_id.clone(), incoming.thread_id.clone());
 
-        // Check for day boundary → maybe reset session + snapshot
-        self.maybe_reset_session(&key).await;
+        // Check for day boundary → dispatch configured session policy
+        self.maybe_handle_day_boundary(&key).await;
 
         let session_id = self.get_or_create_session(&key).await;
 

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -25,7 +25,7 @@ pub struct MatrixChannel {
     access_token: String,
     user_id: String,
     device_id: String,
-    room_id: String,
+    room_ids: HashSet<String>,
     allowed_users: HashSet<String>,
     recovery_key: Option<String>,
     state_dir: PathBuf,
@@ -37,7 +37,7 @@ impl std::fmt::Debug for MatrixChannel {
         f.debug_struct("MatrixChannel")
             .field("homeserver", &self.homeserver)
             .field("user_id", &self.user_id)
-            .field("room_id", &self.room_id)
+            .field("room_ids", &self.room_ids)
             .finish_non_exhaustive()
     }
 }
@@ -49,7 +49,7 @@ impl MatrixChannel {
             access_token: cfg.access_token.clone(),
             user_id: cfg.user_id.clone(),
             device_id: cfg.device_id.clone(),
-            room_id: cfg.room_id.clone(),
+            room_ids: cfg.room_ids.iter().cloned().collect(),
             allowed_users: cfg.allowed_users.iter().cloned().collect(),
             recovery_key: cfg.recovery_key.clone(),
             state_dir: cfg.resolved_state_dir(),
@@ -138,7 +138,7 @@ impl Channel for MatrixChannel {
 
     async fn listen(&self, tx: mpsc::Sender<IncomingMessage>) -> Result<()> {
         let client = self.get_or_init_client().await?;
-        let room_id_str = self.room_id.clone();
+        let allowed_rooms = self.room_ids.clone();
         let allowed_users = self.allowed_users.clone();
         let bot_user_id = self.user_id.clone();
 
@@ -146,12 +146,13 @@ impl Channel for MatrixChannel {
             let tx = tx.clone();
             move |event: OriginalSyncRoomMessageEvent, room: matrix_sdk::Room| {
                 let tx = tx.clone();
-                let room_id_str = room_id_str.clone();
+                let allowed_rooms = allowed_rooms.clone();
                 let allowed_users = allowed_users.clone();
                 let bot_user_id = bot_user_id.clone();
 
                 async move {
-                    if room.room_id().as_str() != room_id_str {
+                    let room_id_str = room.room_id().as_str().to_string();
+                    if !allowed_rooms.contains(&room_id_str) {
                         return;
                     }
                     if event.sender.as_str() == bot_user_id {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use sapphire_workspace::SyncConfig;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -31,6 +32,13 @@ pub struct Config {
     /// Used for session resets and daily log generation. Default: 0 (midnight).
     #[serde(default)]
     pub day_boundary_hour: u8,
+    /// Default session policy applied at the day boundary. Can be overridden
+    /// per room via `[rooms."<id>"]`. Default: `reset` (back-compat).
+    #[serde(default)]
+    pub session_policy: SessionPolicy,
+    /// Per-room overrides keyed by `room_id`.
+    #[serde(default)]
+    pub rooms: HashMap<String, RoomConfig>,
     /// Whether to generate a daily log at the day boundary. Default: true.
     #[serde(default = "default_true")]
     pub daily_log_enabled: bool,
@@ -58,6 +66,31 @@ pub struct Config {
 
 fn default_true() -> bool {
     true
+}
+
+/// Action taken at the day boundary for a given conversation.
+///
+/// - `Reset`: close the session and clear in-memory caches (legacy behavior).
+///   The next message starts a fresh session; prior-run summary is injected via
+///   `restart_summaries`.
+/// - `Compact`: keep the same session alive, but force-summarize the current
+///   in-memory history and replace it with a summary stub. The SummaryLine is
+///   appended to the session JSONL. Session continuity is preserved.
+/// - `None`: no day-boundary action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionPolicy {
+    #[default]
+    Reset,
+    Compact,
+    None,
+}
+
+/// Per-room configuration overrides.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct RoomConfig {
+    /// Override the day-boundary session policy for this room.
+    pub session_policy: Option<SessionPolicy>,
 }
 
 /// Configuration for the HTTP API server (serve command).
@@ -131,7 +164,11 @@ pub struct MatrixConfig {
     pub access_token: String,
     pub user_id: String,
     pub device_id: String,
-    pub room_id: String,
+    /// Rooms the bot listens to. Accepts either a TOML array
+    /// (`room_ids = ["!a:srv", "!b:srv"]`) or — for backward compatibility —
+    /// a single string key named `room_id`.
+    #[serde(default, alias = "room_id", deserialize_with = "deserialize_room_ids")]
+    pub room_ids: Vec<String>,
     #[serde(default)]
     pub allowed_users: Vec<String>,
     /// E2EE recovery key (optional)
@@ -141,7 +178,31 @@ pub struct MatrixConfig {
     pub state_dir: Option<String>,
 }
 
+/// Accept either `"!a:srv"` (legacy single string) or `["!a:srv", "!b:srv"]`
+/// for the `room_ids` / legacy `room_id` field.
+fn deserialize_room_ids<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+    match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(s) => Ok(vec![s]),
+        OneOrMany::Many(v) => Ok(v),
+    }
+}
+
 impl MatrixConfig {
+    /// Primary room — first configured room. Used as the default target for
+    /// heartbeat tasks that don't name a specific room.
+    pub fn primary_room_id(&self) -> Option<&str> {
+        self.room_ids.first().map(|s| s.as_str())
+    }
+
     pub fn resolved_state_dir(&self) -> PathBuf {
         if let Some(dir) = &self.state_dir {
             PathBuf::from(shellexpand::tilde(dir).as_ref())
@@ -258,6 +319,15 @@ impl Config {
         } else {
             workspace_dir.join("sessions")
         }
+    }
+
+    /// Resolve the session policy for a given `room_id`, falling back to the
+    /// global default when no room-specific override is set.
+    pub fn session_policy_for(&self, room_id: &str) -> SessionPolicy {
+        self.rooms
+            .get(room_id)
+            .and_then(|r| r.session_policy)
+            .unwrap_or(self.session_policy)
     }
 
     /// Resolve the default config path: `~/.config/sapphire-agent/config.toml`

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
                 println!("  Channel           : matrix");
                 println!("  Matrix homeserver : {}", m.homeserver);
                 println!("  Matrix user_id    : {}", m.user_id);
-                println!("  Matrix room_id    : {}", m.room_id);
+                println!("  Matrix rooms      : {:?}", m.room_ids);
             } else if let Some(d) = &config.discord {
                 println!("  Channel           : discord");
                 println!("  Discord channels  : {:?}", d.channel_ids);
@@ -270,17 +270,16 @@ async fn main() -> Result<()> {
                 agent.bootstrap().await;
 
                 // ── Heartbeat (day-boundary + cron loops) ───────────────────
-                let default_room_id =
-                    config
-                        .matrix
-                        .as_ref()
-                        .map(|m| m.room_id.clone())
-                        .or_else(|| {
-                            config
-                                .discord
-                                .as_ref()
-                                .and_then(|d| d.channel_ids.first().cloned())
-                        });
+                let default_room_id = config
+                    .matrix
+                    .as_ref()
+                    .and_then(|m| m.primary_room_id().map(str::to_string))
+                    .or_else(|| {
+                        config
+                            .discord
+                            .as_ref()
+                            .and_then(|d| d.channel_ids.first().cloned())
+                    });
                 let heartbeat = Heartbeat {
                     workspace_dir: workspace_dir.clone(),
                     day_boundary_hour: config.day_boundary_hour,


### PR DESCRIPTION
## Summary
- 日境界でのセッション挙動を `session_policy` で切替可能に: `reset`（従来）/ `compact`（セッション継続＋サマリ注入）/ `none`。`[rooms.\"<id>\"]` でルーム別にオーバーライドできる。
- Matrix の `room_id` を `room_ids` 配列化し、複数ルーム対応。旧 `room_id = \"…\"` も serde alias + カスタム deserializer で受理するので既存 config は破壊されない。Discord の `channel_ids` と構造が揃った。
- デイリーログ生成は据え置き: [`sessions_for_day`](src/session.rs#L442-L487) がメッセージ単位の timestamp で振り分けているため、`compact` でセッションを閉じなくても日付またぎのメッセージは正しく当日のログに分配される。

## 動作メモ
- `compact` 時は `generate_summary` → `append_summary` で SummaryLine を追記し、in-memory 履歴を要約スタブに置換。`boundary_handled` マップで同日内の再発火を防止。
- `RoomConfig` のキーはチャンネル種別を区別せず、`IncomingMessage.room_id` にそのまま入る文字列（Matrix: `!abc:server`、Discord: channel_id）で照合。
- デフォルト `session_policy` は `reset` を据え置き（後方互換）。切替はユーザが config で `compact` に変更する想定。

## Test plan
- [x] `cargo build` — pass
- [x] `cargo test` — 9/9 pass
- [ ] 実運用 config を `session_policy = \"compact\"` に切り替え、日境界をまたいだ翌朝に SummaryLine が JSONL に追記されていることを確認
- [ ] `room_ids` 配列に複数ルームを設定し、それぞれ別ルームから投げたメッセージが `IncomingMessage.room_id` に正しく反映されること
- [ ] 旧 `room_id = \"…\"` 単一文字列形式でもパース可能なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)