### PR TITLE
feat(mcp): add manual reconnect tool for MCP servers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,14 +197,12 @@ async fn main() -> Result<()> {
             }
 
             // ── Tools ───────────────────────────────────────────────────────
-            let tool_set = Arc::new(
-                tools::default_tool_set(
-                    Arc::clone(&ws_state),
-                    config.tools.tavily_api_key.clone(),
-                    &config.tools.mcp_servers,
-                )
-                .await,
-            );
+            let tool_set = tools::default_tool_set(
+                Arc::clone(&ws_state),
+                config.tools.tavily_api_key.clone(),
+                &config.tools.mcp_servers,
+            )
+            .await;
 
             // ── Session store base directory ────────────────────────────────
             let sessions_base = config.resolved_sessions_dir(&workspace_dir);

--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -38,7 +38,8 @@ pub struct RemoteToolSpec {
 /// Client for a single external MCP server.
 pub struct McpClient {
     name: String,
-    transport: Box<dyn McpTransport>,
+    config: McpServerConfig,
+    transport: tokio::sync::RwLock<Arc<dyn McpTransport>>,
     workspace_root: String,
     request_id: Mutex<u64>,
     /// Set to `true` when the server sends `notifications/tools/list_changed`.
@@ -48,22 +49,57 @@ pub struct McpClient {
 impl McpClient {
     /// Create a new client and establish the transport.
     pub async fn new(config: &McpServerConfig, workspace_root: &str) -> Result<Self> {
-        let transport: Box<dyn McpTransport> = match &config.transport {
-            McpTransportConfig::Http { url, api_key } => {
-                Box::new(HttpTransport::new(url.clone(), api_key.clone()))
-            }
-            McpTransportConfig::Stdio { command, args, env } => {
-                Box::new(StdioTransport::new(command, args, env).await?)
-            }
-        };
+        let transport = Self::build_transport(&config.transport).await?;
 
         Ok(Self {
             name: config.name.clone(),
-            transport,
+            config: config.clone(),
+            transport: tokio::sync::RwLock::new(transport),
             workspace_root: workspace_root.to_string(),
             request_id: Mutex::new(1),
             tools_changed: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Build a new transport instance from the config.
+    async fn build_transport(
+        transport: &McpTransportConfig,
+    ) -> Result<Arc<dyn McpTransport>> {
+        Ok(match transport {
+            McpTransportConfig::Http { url, api_key } => {
+                Arc::new(HttpTransport::new(url.clone(), api_key.clone()))
+            }
+            McpTransportConfig::Stdio { command, args, env } => {
+                Arc::new(StdioTransport::new(command, args, env).await?)
+            }
+        })
+    }
+
+    /// Tear down the existing transport and establish a fresh one.
+    ///
+    /// The request-id counter resets to 1 (the new session starts fresh).
+    /// On failure the old transport is already gone; the caller may retry.
+    pub async fn reconnect(&self) -> Result<()> {
+        info!("MCP '{}': reconnecting", self.name);
+
+        // Shut down the old transport first so we don't leak a child process
+        // if the new transport fails to spawn.
+        {
+            let old = self.transport.read().await.clone();
+            if let Err(e) = old.shutdown().await {
+                warn!("MCP '{}': shutdown during reconnect failed: {e:#}", self.name);
+            }
+        }
+
+        let new_transport = Self::build_transport(&self.config.transport)
+            .await
+            .with_context(|| format!("MCP '{}': failed to build new transport", self.name))?;
+        *self.transport.write().await = new_transport;
+        *self.request_id.lock().await = 1;
+        self.tools_changed.store(false, Ordering::Relaxed);
+
+        self.connect().await?;
+        Ok(())
     }
 
     /// The server name (used as the tool namespace prefix).
@@ -158,8 +194,8 @@ impl McpClient {
 
         let req_handler = self.server_request_handler();
         let notif_handler = self.notification_handler();
-        let response = self
-            .transport
+        let transport = self.transport.read().await.clone();
+        let response = transport
             .request(&body, &req_handler, &notif_handler)
             .await?;
 
@@ -204,8 +240,8 @@ impl McpClient {
         });
         let req_handler = self.server_request_handler();
         let notif_handler = self.notification_handler();
-        let _ = self
-            .transport
+        let transport = self.transport.read().await.clone();
+        let _ = transport
             .request(&notification, &req_handler, &notif_handler)
             .await;
 
@@ -254,7 +290,8 @@ impl McpClient {
 
     /// Shut down the transport.
     pub async fn shutdown(&self) -> Result<()> {
-        self.transport.shutdown().await
+        let transport = self.transport.read().await.clone();
+        transport.shutdown().await
     }
 }
 

--- a/src/tools/builtin_tools.rs
+++ b/src/tools/builtin_tools.rs
@@ -1,11 +1,11 @@
 use crate::provider::ToolSpec;
-use crate::tools::Tool;
+use crate::tools::{Tool, ToolSet};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use sapphire_workspace::WorkspaceState;
 use serde_json::json;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -505,5 +505,70 @@ impl Tool for WebSearchTool {
             .collect();
 
         Ok(lines.join("\n\n"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// mcp_reconnect — tear down and re-establish an MCP server connection
+// ---------------------------------------------------------------------------
+
+pub struct McpReconnectTool {
+    spec: ToolSpec,
+    tool_set: Weak<ToolSet>,
+}
+
+impl McpReconnectTool {
+    pub fn new(tool_set: Weak<ToolSet>) -> Self {
+        Self {
+            spec: ToolSpec {
+                name: "mcp_reconnect".into(),
+                description:
+                    "Reconnect to a configured MCP server (stdio or HTTP) and refresh its tool list. \
+                     Use this when an MCP server has crashed, disconnected, or is being restarted \
+                     during testing — tools registered under `mcp__<server>__*` become usable again \
+                     without restarting the agent."
+                        .into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "string",
+                            "description": "Name of the MCP server to reconnect (as configured in tools.mcp_servers)."
+                        }
+                    },
+                    "required": ["server"]
+                }),
+            },
+            tool_set,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpReconnectTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, input: &serde_json::Value) -> Result<String> {
+        let server = input
+            .get("server")
+            .and_then(|v| v.as_str())
+            .context("Missing required field: server")?;
+
+        let tool_set = self
+            .tool_set
+            .upgrade()
+            .context("ToolSet has been dropped; cannot reconnect")?;
+
+        let known = tool_set.mcp_server_names();
+        if !known.iter().any(|n| n == server) {
+            anyhow::bail!(
+                "unknown MCP server '{server}'. Configured servers: [{}]",
+                known.join(", ")
+            );
+        }
+
+        tool_set.reconnect_mcp_server(server).await
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -70,36 +70,58 @@ impl ToolSet {
             if !client.take_tools_changed() {
                 continue;
             }
-
-            info!("MCP '{}': refreshing tool list", client.name());
-            match client.list_tools().await {
-                Ok(remote_tools) => {
-                    let new_tools = build_tools_for_client(client, remote_tools);
-                    let prefix = format!("mcp__{}__", client.name());
-
-                    let mut inner = self.inner.write().await;
-
-                    // Remove old tools for this server.
-                    inner.tools.retain(|t| !t.spec().name.starts_with(&prefix));
-                    inner.specs.retain(|s| !s.name.starts_with(&prefix));
-
-                    // Add refreshed tools.
-                    for tool in new_tools {
-                        inner.specs.push(tool.spec().clone());
-                        inner.tools.push(tool);
-                    }
-
-                    info!(
-                        "MCP '{}': tool list refreshed ({} total tools)",
-                        client.name(),
-                        inner.tools.len()
-                    );
-                }
-                Err(e) => {
-                    warn!("MCP '{}': failed to refresh tools: {e:#}", client.name());
-                }
+            if let Err(e) = self.refresh_client_tools(client).await {
+                warn!("MCP '{}': failed to refresh tools: {e:#}", client.name());
             }
         }
+    }
+
+    /// Re-list a client's tools and swap them into the ToolSet.
+    async fn refresh_client_tools(&self, client: &Arc<McpClient>) -> Result<()> {
+        info!("MCP '{}': refreshing tool list", client.name());
+        let remote_tools = client.list_tools().await?;
+        let new_tools = build_tools_for_client(client, remote_tools);
+        let prefix = format!("mcp__{}__", client.name());
+
+        let mut inner = self.inner.write().await;
+        inner.tools.retain(|t| !t.spec().name.starts_with(&prefix));
+        inner.specs.retain(|s| !s.name.starts_with(&prefix));
+        for tool in new_tools {
+            inner.specs.push(tool.spec().clone());
+            inner.tools.push(tool);
+        }
+        info!(
+            "MCP '{}': tool list refreshed ({} total tools)",
+            client.name(),
+            inner.tools.len()
+        );
+        Ok(())
+    }
+
+    /// Names of configured MCP servers (for tool discovery / error messages).
+    pub fn mcp_server_names(&self) -> Vec<String> {
+        self.mcp_clients.iter().map(|c| c.name().to_string()).collect()
+    }
+
+    /// Reconnect one MCP server by name and refresh its tool list.
+    /// Returns a human-readable status summary.
+    pub async fn reconnect_mcp_server(&self, name: &str) -> Result<String> {
+        let client = self
+            .mcp_clients
+            .iter()
+            .find(|c| c.name() == name)
+            .ok_or_else(|| anyhow::anyhow!("unknown MCP server: {name}"))?;
+
+        client.reconnect().await?;
+        self.refresh_client_tools(client).await?;
+        Ok(format!("Reconnected MCP server '{name}' and refreshed its tools."))
+    }
+
+    /// Register an additional tool after construction.
+    pub async fn register_tool(&self, tool: Box<dyn Tool>) {
+        let mut inner = self.inner.write().await;
+        inner.specs.push(tool.spec().clone());
+        inner.tools.push(tool);
     }
 }
 
@@ -112,7 +134,7 @@ pub async fn default_tool_set(
     state: Arc<Mutex<sapphire_workspace::WorkspaceState>>,
     tavily_api_key: Option<String>,
     mcp_servers: &[McpServerConfig],
-) -> ToolSet {
+) -> Arc<ToolSet> {
     use builtin_tools::*;
     use workspace_tools::*;
 
@@ -153,5 +175,13 @@ pub async fn default_tool_set(
         mcp_clients = clients;
     }
 
-    ToolSet::new(tools, mcp_clients)
+    let tool_set = Arc::new(ToolSet::new(tools, mcp_clients));
+
+    // Register the reconnect tool only if at least one MCP server is configured.
+    if !mcp_servers.is_empty() {
+        let reconnect = Box::new(builtin_tools::McpReconnectTool::new(Arc::downgrade(&tool_set)));
+        tool_set.register_tool(reconnect).await;
+    }
+
+    tool_set
 }


### PR DESCRIPTION
## Summary
- Add a new `mcp_reconnect` builtin tool that tears down and re-establishes a single MCP server connection (stdio or HTTP) and refreshes its advertised tool list — so an agent can recover from a crashed / restarted MCP server without killing the whole process.
- Refactor `McpClient` to retain its config and hold the transport behind an `RwLock<Arc<dyn McpTransport>>`, enabling atomic swap on reconnect. Request-id and `tools_changed` flags reset on reconnect.
- Extract the tool-refresh logic in `ToolSet` so the `notifications/tools/list_changed` path and the manual reconnect path share it.

## Motivation
When developing / testing a custom MCP server (especially stdio), the server process may crash or be restarted frequently. Without a reconnect path, the agent itself had to be restarted each time, which broke the "ask the agent to test your MCP server" workflow. The new tool is registered only when at least one MCP server is configured.

## Design notes
- `McpReconnectTool` holds `Weak<ToolSet>` to avoid a reference cycle (`ToolSet` owns the tool).
- `default_tool_set` now returns `Arc<ToolSet>` so the tool can be registered post-wrap.
- On reconnect failure the old transport is already shut down; the stored transport is whatever was successfully installed (caller may retry).
- No automatic reconnect was intentionally not added — during MCP-server testing, silent retries can mask real bugs.

## Test plan
- [x] `cargo check` — clean (only pre-existing warnings)
- [x] `cargo test` — 9/9 pass
- [ ] Manually exercise `mcp_reconnect` against a stdio MCP server that is killed mid-session
- [ ] Manually exercise against an HTTP MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)