### PR TITLE
feat(workspace): inject previous day's daily log into system prompt

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -486,7 +486,10 @@ impl Agent {
 
         let system_prompt = self
             .workspace
-            .build_system_prompt(self.config.anthropic.system_prompt.as_deref())
+            .build_system_prompt(
+                self.config.anthropic.system_prompt.as_deref(),
+                self.config.day_boundary_hour,
+            )
             .await;
 
         self.snapshots.lock().await.insert(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -496,7 +496,10 @@ async fn run_turn(
     let system = {
         let sp = state
             .workspace
-            .build_system_prompt(state.config.anthropic.system_prompt.as_deref())
+            .build_system_prompt(
+                state.config.anthropic.system_prompt.as_deref(),
+                state.config.day_boundary_hour,
+            )
             .await;
         if sp.is_empty() { None } else { Some(sp) }
     };

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -93,7 +93,8 @@ impl Workspace {
     /// Build the full system prompt:
     /// 1. Base system_prompt from config (if any)
     /// 2. Each workspace file that exists, in openclaw order
-    pub async fn build_system_prompt(&self, base: Option<&str>) -> String {
+    /// 3. Previous day's daily log (if it exists)
+    pub async fn build_system_prompt(&self, base: Option<&str>, boundary_hour: u8) -> String {
         let mut parts: Vec<String> = Vec::new();
 
         if let Some(b) = base.filter(|s| !s.is_empty()) {
@@ -113,6 +114,24 @@ impl Workspace {
             if let Some((filename, content)) = self.read_first_existing(def.candidates).await {
                 debug!("Injecting workspace file: {filename}");
                 parts.push(format!("{}\n\n{content}", def.heading));
+            }
+        }
+
+        // Inject the previous day's daily log (if it exists) so the agent has
+        // awareness of yesterday's topics, decisions, and unresolved items.
+        let today = crate::session::local_date_for_timestamp(now_local, boundary_hour);
+        if let Some(yesterday) = today.pred_opt() {
+            let log_path = self
+                .dir
+                .join("memory")
+                .join("daily")
+                .join(format!("{yesterday}.md"));
+            if let Ok(content) = std::fs::read_to_string(&log_path) {
+                if !content.trim().is_empty() {
+                    let truncated = truncate_chars(&content, MAX_FILE_CHARS);
+                    debug!("Injecting yesterday's daily log: {yesterday}");
+                    parts.push(format!("# Yesterday's Log\n\n{truncated}"));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- `build_system_prompt()` に `boundary_hour: u8` パラメータを追加
- `memory/daily/YYYY-MM-DD.md`（前日分）が存在する場合、システムプロンプトの末尾に `# Yesterday's Log` として自動注入
- ファイルが存在しない場合（初回起動日・オフライン日）は何も追加しない

## Motivation

デイリーログは毎日生成されていたが、エージェント自身はその内容を参照できていなかった。
この変更により、前日の会話の要点（決定事項・未解決事項など）を毎朝自動的に把握できるようになる。
システムプロンプトは1日1回しか再構築されない (`SystemSnapshot`) ため、パフォーマンスへの影響はない。

## Test plan

- [ ] デイリーログが存在する状態でエージェントを起動し、「昨日何を話したか覚えてる？」と聞いて前日ログの内容を参照した回答が返ることを確認
- [ ] デイリーログが存在しない日（初回起動など）でエラーが出ないことを確認
- [ ] `RUST_LOG=debug` で `Injecting yesterday's daily log: YYYY-MM-DD` ログが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)