### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-15
+
+### Added
+
+- **Daily log injection** — previous day's daily log is now injected into the
+  system prompt at session start, giving the agent continuity from yesterday's
+  activity without loading raw history.
+- **MCP manual reconnect** — new `mcp_reconnect` built-in tool lets the agent
+  manually reconnect to an MCP server that has dropped without restarting the
+  whole process.
+- **Configurable day-boundary policy** — `session.day_boundary` option controls
+  whether and how a new session is opened at midnight; defaults to the previous
+  rolling behavior.
+- **Matrix multi-room** — multiple Matrix rooms can now be configured with
+  independent session state.
+- **Install scripts** — `install.sh` (Unix) and `install.ps1` (Windows) added
+  for installing pre-built binaries without Cargo.
+
+### Changed
+
+- **Session context on restart** — sessions now carry a generated summary into
+  the next session rather than replaying raw message history, keeping the
+  context window usage predictable after long-running sessions.
+- **Workspace config consolidation** — workspace-level settings are now merged
+  from the agent `config.toml` so a separate workspace config file is no longer
+  required.
+- **Release workflow** — GitHub Actions release workflow improved for more
+  reliable artifact publishing.
+
+### Fixed
+
+- **Matrix sync reconnect** — the Matrix sync loop now auto-reconnects on
+  network disconnect instead of silently stopping.
+- **Bootstrap room filter** — fallback summarization is skipped for rooms that
+  have no agent config, preventing spurious errors on startup.
+
 ## [0.2.1] - 2026-04-13
 
 ### Fixed
@@ -78,5 +114,7 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.3.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.0
+[0.2.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.2.1
 [0.2.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.2.0
 [0.1.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -120,7 +120,7 @@ sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.2.1" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.0" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.2.1" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.0" }
 
 # Async runtime
 tokio.workspace = true

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -171,10 +171,7 @@ impl Agent {
                     if let Err(e) = self.session_store.append_summary(&session_id, &summary) {
                         warn!("Failed to persist fallback summary for {session_id}: {e}");
                     }
-                    self.restart_summaries
-                        .lock()
-                        .await
-                        .insert(key, summary);
+                    self.restart_summaries.lock().await.insert(key, summary);
                 }
                 Ok(_) => warn!("Fallback summary for {session_id} was empty; skipping"),
                 Err(e) => warn!("Fallback summary generation failed for {session_id}: {e:#}"),
@@ -618,12 +615,8 @@ impl Agent {
             {
                 Ok(Some(result)) => {
                     // Replace in-memory history with compressed version
-                    *self
-                        .history
-                        .lock()
-                        .await
-                        .entry(key.clone())
-                        .or_default() = result.compressed.clone();
+                    *self.history.lock().await.entry(key.clone()).or_default() =
+                        result.compressed.clone();
                     if let Err(e) = self
                         .session_store
                         .append_summary(&session_id, &result.summary)

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -231,7 +231,10 @@ pub async fn generate_summary(
         Some(text) if !text.is_empty() => Ok(text),
         _ => {
             warn!("Summary generation returned empty response");
-            Ok("(Earlier conversation context was compressed but summary generation failed.)".into())
+            Ok(
+                "(Earlier conversation context was compressed but summary generation failed.)"
+                    .into(),
+            )
         }
     }
 }
@@ -277,10 +280,7 @@ mod tests {
 
     #[test]
     fn test_find_safe_split_preserves_all_when_few() {
-        let messages = vec![
-            ChatMessage::user("msg1"),
-            ChatMessage::assistant("msg2"),
-        ];
+        let messages = vec![ChatMessage::user("msg1"), ChatMessage::assistant("msg2")];
         let split = find_safe_split_point(&messages, 5);
         assert_eq!(split, 0);
     }
@@ -308,6 +308,9 @@ mod tests {
         // preserve_recent=2 would normally split at index 4 (tool result),
         // but it should move back to not break the tool pair.
         let split = find_safe_split_point(&messages, 2);
-        assert!(split <= 3, "split should be at or before the tool-use message");
+        assert!(
+            split <= 3,
+            "split should be at or before the tool-use message"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,9 +224,7 @@ async fn main() -> Result<()> {
             }
 
             // ── Channel + Agent (Matrix or Discord, if configured) ──────────
-            if !config.standby_mode
-                && (config.matrix.is_some() || config.discord.is_some())
-            {
+            if !config.standby_mode && (config.matrix.is_some() || config.discord.is_some()) {
                 let channel_name = if config.discord.is_some() {
                     "discord"
                 } else {

--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -62,9 +62,7 @@ impl McpClient {
     }
 
     /// Build a new transport instance from the config.
-    async fn build_transport(
-        transport: &McpTransportConfig,
-    ) -> Result<Arc<dyn McpTransport>> {
+    async fn build_transport(transport: &McpTransportConfig) -> Result<Arc<dyn McpTransport>> {
         Ok(match transport {
             McpTransportConfig::Http { url, api_key } => {
                 Arc::new(HttpTransport::new(url.clone(), api_key.clone()))
@@ -87,7 +85,10 @@ impl McpClient {
         {
             let old = self.transport.read().await.clone();
             if let Err(e) = old.shutdown().await {
-                warn!("MCP '{}': shutdown during reconnect failed: {e:#}", self.name);
+                warn!(
+                    "MCP '{}': shutdown during reconnect failed: {e:#}",
+                    self.name
+                );
             }
         }
 
@@ -138,10 +139,7 @@ impl McpClient {
                     })
                 }
                 "elicitation/create" => {
-                    let message = params
-                        .get("message")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
+                    let message = params.get("message").and_then(|v| v.as_str()).unwrap_or("");
                     json!({
                         "result": {
                             "action": "accept",
@@ -343,7 +341,10 @@ impl Tool for McpTool {
 // ---------------------------------------------------------------------------
 
 /// Build `McpTool` instances from a connected client's tool list.
-pub fn build_tools_for_client(client: &Arc<McpClient>, remote_tools: Vec<RemoteToolSpec>) -> Vec<Box<dyn Tool>> {
+pub fn build_tools_for_client(
+    client: &Arc<McpClient>,
+    remote_tools: Vec<RemoteToolSpec>,
+) -> Vec<Box<dyn Tool>> {
     remote_tools
         .into_iter()
         .map(|rt| {

--- a/src/mcp_client/transport.rs
+++ b/src/mcp_client/transport.rs
@@ -86,11 +86,7 @@ impl HttpTransport {
     }
 
     /// Send a JSON-RPC response back to the server (for server-initiated requests).
-    async fn send_response(
-        &self,
-        response: &Value,
-        session_id: &Option<String>,
-    ) -> Result<()> {
+    async fn send_response(&self, response: &Value, session_id: &Option<String>) -> Result<()> {
         let mut req = self
             .http
             .post(&self.url)
@@ -169,21 +165,15 @@ impl McpTransport for HttpTransport {
                                 && data.get("result").is_none()
                             {
                                 let method = data["method"].as_str().unwrap_or("");
-                                let params =
-                                    data.get("params").cloned().unwrap_or(Value::Null);
+                                let params = data.get("params").cloned().unwrap_or(Value::Null);
                                 let mut response = on_server_request(method, &params);
                                 // Attach the request id.
                                 if let Value::Object(ref mut map) = response {
-                                    map.insert(
-                                        "id".to_string(),
-                                        data["id"].clone(),
-                                    );
+                                    map.insert("id".to_string(), data["id"].clone());
                                     map.entry("jsonrpc".to_string())
                                         .or_insert_with(|| json!("2.0"));
                                 }
-                                if let Err(e) =
-                                    self.send_response(&response, &current_sid).await
-                                {
+                                if let Err(e) = self.send_response(&response, &current_sid).await {
                                     warn!("Failed to send server-request response: {e}");
                                 }
                                 continue;
@@ -191,8 +181,7 @@ impl McpTransport for HttpTransport {
 
                             // Final result or error for our request.
                             if data.get("id") == Some(&req_id)
-                                && (data.get("result").is_some()
-                                    || data.get("error").is_some())
+                                && (data.get("result").is_some() || data.get("error").is_some())
                             {
                                 return Ok(data);
                             }
@@ -244,9 +233,9 @@ impl StdioTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null());
 
-        let mut child = cmd.spawn().with_context(|| {
-            format!("Failed to spawn MCP server process: {command}")
-        })?;
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("Failed to spawn MCP server process: {command}"))?;
 
         let stdin = child
             .stdin

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -160,7 +160,10 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
     for (session_id, messages) in snapshot {
         match generate_summary(&*state.provider, &messages).await {
             Ok(summary) if !summary.trim().is_empty() => {
-                if let Err(e) = state.api_session_store.append_summary(&session_id, &summary) {
+                if let Err(e) = state
+                    .api_session_store
+                    .append_summary(&session_id, &summary)
+                {
                     warn!("Failed to persist shutdown summary for {session_id}: {e}");
                 }
             }

--- a/src/tools/builtin_tools.rs
+++ b/src/tools/builtin_tools.rs
@@ -47,10 +47,12 @@ impl ReadFileTool {
         Self {
             spec: ToolSpec {
                 name: "read_file".into(),
-                description: "Read a file from the filesystem with optional line-based pagination. \
+                description:
+                    "Read a file from the filesystem with optional line-based pagination. \
                     Returns lines prefixed with their 1-indexed line number in 'N|content' format. \
                     Use offset and limit for large files. \
-                    Cannot read binary files or device paths (/dev/, /proc/).".into(),
+                    Cannot read binary files or device paths (/dev/, /proc/)."
+                        .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -325,7 +327,8 @@ impl TerminalTool {
                     Returns stdout, stderr, and exit code. \
                     The default working directory is the workspace root. \
                     Use the timeout parameter for long-running commands (default 60 s, max 600 s). \
-                    Not suitable for interactive commands or persistent daemons.".into(),
+                    Not suitable for interactive commands or persistent daemons."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -427,7 +430,8 @@ impl WebSearchTool {
             spec: ToolSpec {
                 name: "web_search".into(),
                 description: "Search the web for up-to-date information using Tavily. \
-                    Returns titles, URLs, and short content excerpts for the top results.".into(),
+                    Returns titles, URLs, and short content excerpts for the top results."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -100,7 +100,10 @@ impl ToolSet {
 
     /// Names of configured MCP servers (for tool discovery / error messages).
     pub fn mcp_server_names(&self) -> Vec<String> {
-        self.mcp_clients.iter().map(|c| c.name().to_string()).collect()
+        self.mcp_clients
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect()
     }
 
     /// Reconnect one MCP server by name and refresh its tool list.
@@ -114,7 +117,9 @@ impl ToolSet {
 
         client.reconnect().await?;
         self.refresh_client_tools(client).await?;
-        Ok(format!("Reconnected MCP server '{name}' and refreshed its tools."))
+        Ok(format!(
+            "Reconnected MCP server '{name}' and refreshed its tools."
+        ))
     }
 
     /// Register an additional tool after construction.
@@ -179,7 +184,9 @@ pub async fn default_tool_set(
 
     // Register the reconnect tool only if at least one MCP server is configured.
     if !mcp_servers.is_empty() {
-        let reconnect = Box::new(builtin_tools::McpReconnectTool::new(Arc::downgrade(&tool_set)));
+        let reconnect = Box::new(builtin_tools::McpReconnectTool::new(Arc::downgrade(
+            &tool_set,
+        )));
         tool_set.register_tool(reconnect).await;
     }
 

--- a/src/tools/workspace_tools.rs
+++ b/src/tools/workspace_tools.rs
@@ -3,7 +3,7 @@ use crate::tools::Tool;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use sapphire_workspace::{dedup_chunk_results, WorkspaceState};
+use sapphire_workspace::{WorkspaceState, dedup_chunk_results};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::path::Path;
@@ -39,14 +39,17 @@ fn validate_segment(kind: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-const MEMORY_CATEGORY_GUIDE: &str =
-    "Category is mandatory and free-form, but prefer these conventions: \
+const MEMORY_CATEGORY_GUIDE: &str = "Category is mandatory and free-form, but prefer these conventions: \
      'daily' (date-stamped daily logs, slug = YYYY-MM-DD), \
      'dictionary' (short term/definition lookups for names, acronyms, jargon), \
      'knowledge' (longer-form facts, procedures, decisions, learnings — default when unsure). \
      Other categories (e.g. 'recipe', 'project') may be introduced freely.";
 
-fn memory_entry_path(state: &Mutex<WorkspaceState>, category: &str, slug: &str) -> Result<(String, std::path::PathBuf)> {
+fn memory_entry_path(
+    state: &Mutex<WorkspaceState>,
+    category: &str,
+    slug: &str,
+) -> Result<(String, std::path::PathBuf)> {
     validate_segment("category", category)?;
     validate_segment("slug", slug)?;
     let rel = format!("memory/{category}/{slug}.md");
@@ -213,7 +216,8 @@ impl MemoryUpdateTool {
                 name: "memory_update".into(),
                 description: "Overwrite an existing memory entry at \
                     memory/<category>/<slug>.md. Fails if the file does not exist \
-                    (use memory_add to create it).".into(),
+                    (use memory_add to create it)."
+                    .into(),
                 input_schema: memory_entry_schema(true),
             },
         }
@@ -234,8 +238,7 @@ impl Tool for MemoryUpdateTool {
         if !abs.exists() {
             anyhow::bail!("{rel} does not exist; use memory_add to create it");
         }
-        let raw = std::fs::read_to_string(&abs)
-            .with_context(|| format!("Failed to read {rel}"))?;
+        let raw = std::fs::read_to_string(&abs).with_context(|| format!("Failed to read {rel}"))?;
         let (mut meta, _old_body) = parse_memory_file(&raw);
         let now = Utc::now();
         meta.updated_at = Some(now);
@@ -271,7 +274,8 @@ impl MemoryAppendTool {
                     A blank line is inserted between the existing body and the \
                     new content; add your own Markdown heading if you want a \
                     section break. Frontmatter counters (updated_at) are \
-                    maintained automatically.".into(),
+                    maintained automatically."
+                    .into(),
                 input_schema: memory_entry_schema(true),
             },
         }
@@ -292,8 +296,8 @@ impl Tool for MemoryAppendTool {
         let now = Utc::now();
 
         let (meta, new_body, created) = if abs.exists() {
-            let raw = std::fs::read_to_string(&abs)
-                .with_context(|| format!("Failed to read {rel}"))?;
+            let raw =
+                std::fs::read_to_string(&abs).with_context(|| format!("Failed to read {rel}"))?;
             let (mut meta, old_body) = parse_memory_file(&raw);
             meta.updated_at = Some(now);
             if meta.created_at.is_none() {
@@ -346,7 +350,8 @@ impl MemoryReadTool {
                     and return its body. Side effect: updates the file's \
                     frontmatter (last_read_at = now, read_count += 1) so that \
                     recency and frequency can inform future weighting. \
-                    Use workspace_read instead for a non-tracking read.".into(),
+                    Use workspace_read instead for a non-tracking read."
+                    .into(),
                 input_schema: memory_entry_schema(false),
             },
         }
@@ -366,8 +371,7 @@ impl Tool for MemoryReadTool {
         if !abs.exists() {
             anyhow::bail!("{rel} does not exist");
         }
-        let raw = std::fs::read_to_string(&abs)
-            .with_context(|| format!("Failed to read {rel}"))?;
+        let raw = std::fs::read_to_string(&abs).with_context(|| format!("Failed to read {rel}"))?;
         let (mut meta, body) = parse_memory_file(&raw);
         meta.last_read_at = Some(Utc::now());
         meta.read_count = meta.read_count.saturating_add(1);
@@ -435,7 +439,8 @@ impl WorkspaceReadTool {
             spec: ToolSpec {
                 name: "workspace_read".into(),
                 description: "Read the contents of a file in the workspace \
-                    (path relative to workspace root, e.g. \"notes/2025-01.md\").".into(),
+                    (path relative to workspace root, e.g. \"notes/2025-01.md\")."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -482,7 +487,8 @@ impl WorkspaceWriteTool {
             spec: ToolSpec {
                 name: "workspace_write".into(),
                 description: "Write content to a file in the workspace \
-                    (creates or overwrites). Path is relative to workspace root.".into(),
+                    (creates or overwrites). Path is relative to workspace root."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -645,7 +651,8 @@ impl WorkspaceSyncTool {
             spec: ToolSpec {
                 name: "workspace_sync".into(),
                 description: "Sync the workspace: index all files and, if a git \
-                    remote is configured, commit and push changes.".into(),
+                    remote is configured, commit and push changes."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {}


### PR DESCRIPTION
## Summary

- Bump version to `0.3.0` across `[workspace.package]`, `sapphire-agent-api` path dependency references, and `Cargo.lock`
- Add `[0.3.0]` CHANGELOG entry covering all changes since v0.2.1
- Run `cargo fmt` across the workspace

## What's in v0.3.0

**Added**
- Daily log injection — previous day's daily log injected into the system prompt at session start
- MCP manual reconnect — `mcp_reconnect` built-in tool for reconnecting to a dropped MCP server without restarting
- Configurable day-boundary policy — `session.day_boundary` option for controlling session rollover at midnight
- Matrix multi-room — multiple Matrix rooms with independent session state
- Install scripts — `install.sh` (Unix) and `install.ps1` (Windows)

**Changed**
- Session context on restart — summary forwarded to the next session instead of raw history replay
- Workspace config consolidation — workspace settings merged from agent `config.toml`; separate workspace config no longer required
- Release workflow improvements

**Fixed**
- Matrix sync loop now auto-reconnects on network disconnect
- Bootstrap fallback summarization skipped for rooms with no agent config

## Test plan

- [ ] `cargo publish --dry-run` passes (confirmed by author before PR)
- [ ] CHANGELOG links resolve to correct release tags after tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)