### PR TITLE
chore: release v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,21 +34,27 @@ jobs:
 
   build:
     needs: prepare
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             binary: sapphire-agent
             asset_name: sapphire-agent-linux-x86_64
-          - os: macos-latest
-            binary: sapphire-agent
-            asset_name: sapphire-agent-macos-aarch64
+            continue-on-error: false
           - os: ubuntu-24.04-arm
             binary: sapphire-agent
             asset_name: sapphire-agent-linux-aarch64
+            continue-on-error: false
+          - os: macos-latest
+            binary: sapphire-agent
+            asset_name: sapphire-agent-macos-aarch64
+            continue-on-error: true
           - os: windows-latest
             binary: sapphire-agent.exe
             asset_name: sapphire-agent-windows-x86_64.exe
+            continue-on-error: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-15
+
+### Fixed
+
+- **Windows release build** — bundle SQLite into the binary via matrix-sdk's
+  `bundled-sqlite` feature so the Windows release no longer fails on the
+  missing system SQLite library.
+
+### Changed
+
+- **Release workflow** — macOS and Windows matrix entries are now
+  `continue-on-error`, so a failure on those best-effort platforms does not
+  block the Linux x86_64/aarch64 release.
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,6 +4556,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ matrix-sdk = { version = "0.16", default-features = false, features = [
     "e2e-encryption",
     "rustls-tls",
     "sqlite",
+    "bundled-sqlite",
     "markdown",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -121,7 +121,7 @@ sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.0" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.1" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.0" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.1" }
 
 # Async runtime
 tokio.workspace = true


### PR DESCRIPTION
## Summary
- Patch release fixing the v0.3.0 Windows release-build failure
- Enables matrix-sdk's `bundled-sqlite` so SQLite no longer needs to be present on the runner
- Demotes macOS / Windows release jobs to `continue-on-error` so failures on best-effort platforms do not block the Linux x86_64 / aarch64 release

## Test plan
- [x] `cargo build --release` on Linux passes with `bundled-sqlite` enabled
- [ ] Release workflow on merge produces Linux x86_64 + aarch64 binaries (required)
- [ ] Windows binary is produced via `bundled-sqlite` (best-effort)
- [ ] macOS binary still produced (best-effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)