### PR TITLE
fix(daily-log): write via WorkspaceState to include logs in sync

### DIFF
--- a/src/daily_log.rs
+++ b/src/daily_log.rs
@@ -6,7 +6,9 @@
 use crate::provider::{ChatMessage, ContentPart, Provider, Role};
 use crate::session::{SessionMeta, SessionStore, StoredMessage};
 use chrono::{Local, NaiveDate};
+use sapphire_workspace::WorkspaceState;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 
 // ---------------------------------------------------------------------------
@@ -32,7 +34,7 @@ pub fn pending_log_dates(
 pub async fn generate_daily_log(
     session_store: &SessionStore,
     provider: &dyn Provider,
-    workspace_dir: &Path,
+    ws_state: &Arc<Mutex<WorkspaceState>>,
     date: NaiveDate,
     boundary_hour: u8,
 ) -> anyhow::Result<()> {
@@ -57,15 +59,14 @@ pub async fn generate_daily_log(
         .text
         .unwrap_or_else(|| "(no summary generated)".to_string());
 
-    let log_path = daily_log_path(workspace_dir, date);
-    if let Some(parent) = log_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
+    let rel = daily_log_rel_path(date);
     let content = format!("# Daily Log: {date}\n\n{summary}\n");
-    std::fs::write(&log_path, &content)?;
+    ws_state
+        .lock()
+        .expect("WorkspaceState mutex poisoned")
+        .write_file(&rel, &content)?;
 
-    info!("Daily log written: {}", log_path.display());
+    info!("Daily log written: {}", rel.display());
     Ok(())
 }
 
@@ -74,8 +75,11 @@ pub async fn generate_daily_log(
 // ---------------------------------------------------------------------------
 
 pub fn daily_log_path(workspace_dir: &Path, date: NaiveDate) -> PathBuf {
-    workspace_dir
-        .join("memory")
+    workspace_dir.join(daily_log_rel_path(date))
+}
+
+fn daily_log_rel_path(date: NaiveDate) -> PathBuf {
+    Path::new("memory")
         .join("daily")
         .join(format!("{date}.md"))
 }
@@ -137,6 +141,7 @@ fn format_sessions(sessions: &[(SessionMeta, Vec<StoredMessage>)], date: NaiveDa
 pub async fn catchup_pending_logs(
     session_store: &SessionStore,
     provider: &dyn Provider,
+    ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
     boundary_hour: u8,
 ) {
@@ -147,7 +152,7 @@ pub async fn catchup_pending_logs(
     info!("Generating {} pending daily log(s)…", pending.len());
     for date in pending {
         if let Err(e) =
-            generate_daily_log(session_store, provider, workspace_dir, date, boundary_hour).await
+            generate_daily_log(session_store, provider, ws_state, date, boundary_hour).await
         {
             warn!("Failed to generate daily log for {date}: {e:#}");
         }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -14,13 +14,15 @@ use crate::memory_compaction::compact_memory;
 use crate::provider::Provider;
 use crate::session::SessionStore;
 use chrono::{Duration, Local, NaiveTime, Timelike};
+use sapphire_workspace::WorkspaceState;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration as StdDuration;
 use tracing::{info, warn};
 
 pub struct Heartbeat {
     pub workspace_dir: PathBuf,
+    pub ws_state: Arc<Mutex<WorkspaceState>>,
     pub day_boundary_hour: u8,
     pub daily_log_enabled: bool,
     pub memory_compaction_enabled: bool,
@@ -60,7 +62,7 @@ impl Heartbeat {
                 if let Err(e) = generate_daily_log(
                     &self.session_store,
                     self.provider.as_ref(),
-                    &self.workspace_dir,
+                    &self.ws_state,
                     yesterday,
                     self.day_boundary_hour,
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,7 @@ async fn main() -> Result<()> {
                 catchup_pending_logs(
                     &channel_session_store,
                     provider.as_ref(),
+                    &ws_state,
                     &workspace_dir,
                     config.day_boundary_hour,
                 )
@@ -278,6 +279,7 @@ async fn main() -> Result<()> {
                     });
                 let heartbeat = Heartbeat {
                     workspace_dir: workspace_dir.clone(),
+                    ws_state: Arc::clone(&ws_state),
                     day_boundary_hour: config.day_boundary_hour,
                     daily_log_enabled: config.daily_log_enabled,
                     memory_compaction_enabled: config.memory_compaction_enabled,


### PR DESCRIPTION
## Summary
- Daily logs were being written with `std::fs::write`, bypassing the sapphire-workspace indexing and git-sync pipeline. Newly generated logs were not picked up until (and often not by) the next periodic sync, so they were effectively missing from sync.
- Route daily log writes through `WorkspaceState::write_file`, matching how every other workspace file (memory entries, `workspace_write` tool) is persisted.
- Thread `Arc<Mutex<WorkspaceState>>` through `generate_daily_log` / `catchup_pending_logs` and add it to the `Heartbeat` struct; `main.rs` passes the existing `ws_state`.

## Test plan
- [ ] `cargo check` passes (verified locally — only pre-existing unused-code warnings).
- [ ] Run the agent, trigger a daily log generation (heartbeat day-boundary or catch-up path), and confirm the new `memory/daily/YYYY-MM-DD.md` is indexed and included in the next git sync commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)