### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-15
+
+### Fixed
+
+- **Daily log sync** — daily log writes now go through `WorkspaceState` so
+  generated logs are picked up by the workspace git sync instead of being
+  written directly to disk and skipped.
+- **Discord reconnect** — the Discord gateway now reconnects with exponential
+  backoff on disconnect instead of silently stopping, matching the Matrix
+  sync reconnect behavior.
+
 ## [0.3.1] - 2026-04-15
 
 ### Fixed
@@ -128,6 +139,8 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.3.2]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.2
+[0.3.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.1
 [0.3.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.0
 [0.2.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.2.1
 [0.2.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -121,7 +121,7 @@ sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.1" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.2" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.1" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.2" }
 
 # Async runtime
 tokio.workspace = true


### PR DESCRIPTION
## Summary
- Patch release fixing two reconnect/persistence bugs uncovered after v0.3.1
- Daily logs now flow through `WorkspaceState` so they are picked up by workspace git sync instead of being written directly to disk and skipped
- Discord gateway reconnects with exponential backoff on disconnect, matching the Matrix sync reconnect behavior introduced in v0.3.0

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo publish --dry-run` passes for all workspace crates
- [ ] Release workflow on merge produces Linux x86_64 + aarch64 binaries (required)
- [ ] Windows / macOS binaries produced (best-effort)
- [ ] Daily log file appears in the workspace git sync after a heartbeat run
- [ ] Discord bot reconnects after a forced gateway disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)