### PR TITLE
feat(heartbeat): periodic catchup + system-prompt invalidation for daily logs

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,7 +9,7 @@ use chrono::{Local, NaiveDate};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Maximum number of tool-call rounds per message to prevent infinite loops.
 const MAX_TOOL_ROUNDS: usize = 10;
@@ -496,6 +496,12 @@ impl Agent {
                 self.config.day_boundary_hour,
             )
             .await;
+
+        info!(
+            "Rebuilt system-prompt snapshot for {key:?} (date={today}, {} chars)",
+            system_prompt.len()
+        );
+        debug!("System-prompt snapshot for {key:?}:\n{system_prompt}");
 
         self.snapshots.lock().await.insert(
             key.clone(),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -223,6 +223,14 @@ impl Agent {
         }
     }
 
+    /// Drop all cached system-prompt snapshots so the next message rebuilds
+    /// from disk. Call this after writing any file that `build_system_prompt`
+    /// reads (e.g. a freshly generated daily log) so the change is visible to
+    /// the model without waiting for the next day-boundary cache miss.
+    pub async fn invalidate_system_prompts(&self) {
+        self.snapshots.lock().await.clear();
+    }
+
     /// Heartbeat trigger: inject a system-style prompt as if it were an
     /// incoming message, so the agent runs through the normal handle_message
     /// pipeline (history, tool loop, channel send) without faking a user

--- a/src/daily_log.rs
+++ b/src/daily_log.rs
@@ -30,19 +30,20 @@ pub fn pending_log_dates(
 }
 
 /// Generate a daily log for `date` and write it to `memory/daily/YYYY-MM-DD.md`.
-/// No-op if there are no sessions for that day.
+/// Returns `Ok(true)` if a log was written, `Ok(false)` if there were no
+/// sessions for that day (no-op).
 pub async fn generate_daily_log(
     session_store: &SessionStore,
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     date: NaiveDate,
     boundary_hour: u8,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let sessions = session_store.sessions_for_day(date, boundary_hour);
 
     if sessions.is_empty() {
         info!("No sessions found for {date}, skipping daily log");
-        return Ok(());
+        return Ok(false);
     }
 
     let transcript = format_sessions(&sessions, date);
@@ -67,7 +68,7 @@ pub async fn generate_daily_log(
         .write_file(&rel, &content)?;
 
     info!("Daily log written: {}", rel.display());
-    Ok(())
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -138,23 +139,27 @@ fn format_sessions(sessions: &[(SessionMeta, Vec<StoredMessage>)], date: NaiveDa
 
 /// Generate all pending daily logs (e.g. from days the agent was offline).
 /// Errors are logged but not propagated so startup is not blocked.
+/// Returns the number of logs successfully generated, so callers can decide
+/// whether to invalidate downstream caches (e.g. system-prompt snapshots).
 pub async fn catchup_pending_logs(
     session_store: &SessionStore,
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
     boundary_hour: u8,
-) {
+) -> usize {
     let pending = pending_log_dates(session_store, workspace_dir, boundary_hour);
     if pending.is_empty() {
-        return;
+        return 0;
     }
     info!("Generating {} pending daily log(s)…", pending.len());
+    let mut generated = 0;
     for date in pending {
-        if let Err(e) =
-            generate_daily_log(session_store, provider, ws_state, date, boundary_hour).await
-        {
-            warn!("Failed to generate daily log for {date}: {e:#}");
+        match generate_daily_log(session_store, provider, ws_state, date, boundary_hour).await {
+            Ok(true) => generated += 1,
+            Ok(false) => {}
+            Err(e) => warn!("Failed to generate daily log for {date}: {e:#}"),
         }
     }
+    generated
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -8,7 +8,7 @@
 //!    triggers on the agent according to each task's cron schedule.
 
 use crate::agent::Agent;
-use crate::daily_log::generate_daily_log;
+use crate::daily_log::{catchup_pending_logs, generate_daily_log};
 use crate::heartbeat_config::{load_heartbeat_dir, next_due};
 use crate::memory_compaction::compact_memory;
 use crate::provider::Provider;
@@ -19,6 +19,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration as StdDuration;
 use tracing::{info, warn};
+
+/// How often the catchup loop scans for missing daily logs.
+const CATCHUP_INTERVAL: StdDuration = StdDuration::from_secs(60 * 60);
 
 pub struct Heartbeat {
     pub workspace_dir: PathBuf,
@@ -33,13 +36,37 @@ pub struct Heartbeat {
 }
 
 impl Heartbeat {
-    /// Spawn the day-boundary and cron loops as independent tasks.
+    /// Spawn the day-boundary, cron, and catchup loops as independent tasks.
     pub fn spawn(self) {
         let me = Arc::new(self);
         let a = Arc::clone(&me);
         tokio::spawn(async move { a.run_day_boundary().await });
         let b = Arc::clone(&me);
         tokio::spawn(async move { b.run_cron().await });
+        if me.daily_log_enabled {
+            let c = Arc::clone(&me);
+            tokio::spawn(async move { c.run_catchup().await });
+        }
+    }
+
+    /// Periodically scan for past dates that have session messages but no
+    /// daily log file, and generate any that are missing. Recovers from
+    /// transient failures during the day-boundary fire (e.g. network blip
+    /// during the LLM call) without waiting for the next process restart.
+    async fn run_catchup(self: Arc<Self>) {
+        let mut tick = tokio::time::interval(CATCHUP_INTERVAL);
+        tick.tick().await; // skip immediate fire — startup catchup already ran in main
+        loop {
+            tick.tick().await;
+            catchup_pending_logs(
+                &self.session_store,
+                self.provider.as_ref(),
+                &self.ws_state,
+                &self.workspace_dir,
+                self.day_boundary_hour,
+            )
+            .await;
+        }
     }
 
     async fn run_day_boundary(self: Arc<Self>) {

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -58,7 +58,7 @@ impl Heartbeat {
         tick.tick().await; // skip immediate fire — startup catchup already ran in main
         loop {
             tick.tick().await;
-            catchup_pending_logs(
+            let generated = catchup_pending_logs(
                 &self.session_store,
                 self.provider.as_ref(),
                 &self.ws_state,
@@ -66,6 +66,9 @@ impl Heartbeat {
                 self.day_boundary_hour,
             )
             .await;
+            if generated > 0 {
+                self.agent.invalidate_system_prompts().await;
+            }
         }
     }
 
@@ -86,7 +89,7 @@ impl Heartbeat {
 
             if self.daily_log_enabled {
                 info!("Heartbeat: generating daily log for {yesterday}");
-                if let Err(e) = generate_daily_log(
+                match generate_daily_log(
                     &self.session_store,
                     self.provider.as_ref(),
                     &self.ws_state,
@@ -95,7 +98,11 @@ impl Heartbeat {
                 )
                 .await
                 {
-                    warn!("Heartbeat: failed to generate daily log for {yesterday}: {e:#}");
+                    Ok(true) => self.agent.invalidate_system_prompts().await,
+                    Ok(false) => {}
+                    Err(e) => warn!(
+                        "Heartbeat: failed to generate daily log for {yesterday}: {e:#}"
+                    ),
                 }
             }
 


### PR DESCRIPTION
## Summary

- Add hourly catchup loop so a missed midnight daily-log generation (e.g. transient network blip during the LLM call) recovers without waiting for the next process restart.
- Invalidate the per-conversation system-prompt cache whenever a fresh daily log is written, so the model actually sees it instead of staying on the cached snapshot until the next day boundary.

## Background

`catchup_pending_logs` only ran at startup, so any midnight failure left the log missing for the rest of the day. Worse, even if a log was generated mid-day, `Agent::get_system_prompt` caches by `(ConversationKey, local_date)` and only rebuilds when the date changes — so a freshly written log was invisible until the next midnight rolled over.

Shutdown-time summary failures (separate but related — DNS task cancellation during runtime teardown) are tracked in #48.

## Changes

- `Heartbeat::run_catchup` — third spawned task, ticks every hour, calls `catchup_pending_logs`. Only spawned when `daily_log_enabled`.
- `generate_daily_log` returns `Result<bool>` (true = wrote a file, false = no sessions for that day).
- `catchup_pending_logs` returns `usize` of logs actually generated.
- `Agent::invalidate_system_prompts` — drops all cached snapshots so the next message rebuilds.
- Heartbeat invokes the invalidator from both the catchup loop and the day-boundary loop on successful generation.

## Test plan

- [x] `cargo build`
- [x] `cargo test`
- [ ] Run locally; verify a missed daily log is generated within an hour without restart, and that subsequent messages have the new log injected into the system prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)