### PR TITLE
feat: multimodal image attachments for Discord & Matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6960,6 +6960,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,9 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 # CORS middleware
 tower-http = { version = "0.6", default-features = false, features = ["cors"] }
 
+# Base64 encoding (image attachments → Anthropic API)
+base64 = "0.22"
+
 # Discord bot (gateway + HTTP, rustls TLS)
 # Requires MESSAGE_CONTENT privileged intent enabled in Discord Developer Portal
 serenity = { version = "0.12", default-features = false, features = [

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,4 @@
-use crate::channel::{Channel, OutgoingMessage};
+use crate::channel::{Attachment, Channel, OutgoingMessage};
 use crate::config::{Config, SessionPolicy};
 use crate::context_compression::{generate_summary, maybe_compress};
 use crate::provider::{ChatMessage, ContentPart, Provider, Role, ToolCall};
@@ -252,6 +252,7 @@ impl Agent {
             room_id: room_id.to_string(),
             timestamp: now_ms,
             thread_id: None,
+            attachments: Vec::new(),
         };
         Arc::clone(self).handle_message(incoming).await
     }
@@ -330,6 +331,11 @@ impl Agent {
     /// skipped: tool payloads can be arbitrarily large (file contents, etc.)
     /// and we never reload raw history across restarts, so persisting them
     /// would only bloat the JSONL. Context survives via compaction summaries.
+    ///
+    /// Messages with `Image` parts are persisted with the raw image data
+    /// stripped (replaced with a `[image: <media_type>]` text marker) so the
+    /// JSONL stays small while daily logs / summaries can still see that an
+    /// image was sent.
     fn persist(&self, session_id: &str, msg: &ChatMessage) {
         if session_id.is_empty() {
             return;
@@ -343,7 +349,9 @@ impl Agent {
         if has_tool_parts {
             return;
         }
-        if let Err(e) = self.session_store.append(session_id, msg) {
+        let scrubbed = strip_image_data(msg);
+        let to_write = scrubbed.as_ref().unwrap_or(msg);
+        if let Err(e) = self.session_store.append(session_id, to_write) {
             warn!("Failed to persist message: {e}");
         }
     }
@@ -568,7 +576,7 @@ impl Agent {
 
         // Append user message
         {
-            let msg = ChatMessage::user(&incoming.content);
+            let msg = build_user_message(&incoming.content, &incoming.attachments);
             self.history
                 .lock()
                 .await
@@ -773,6 +781,48 @@ impl Agent {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Build a user `ChatMessage` from incoming text + binary attachments.
+/// Attachments are base64-encoded and emitted as `ContentPart::Image` parts.
+fn build_user_message(text: &str, attachments: &[Attachment]) -> ChatMessage {
+    if attachments.is_empty() {
+        return ChatMessage::user(text);
+    }
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    let images = attachments.iter().map(|a| {
+        (
+            a.media_type.clone(),
+            STANDARD.encode(&a.data),
+        )
+    });
+    ChatMessage::user_with_images(text, images)
+}
+
+/// Return a copy of `msg` with every `Image` part replaced by a small text
+/// marker, or `None` if the message has no `Image` parts (avoids cloning).
+fn strip_image_data(msg: &ChatMessage) -> Option<ChatMessage> {
+    if !msg
+        .parts
+        .iter()
+        .any(|p| matches!(p, ContentPart::Image { .. }))
+    {
+        return None;
+    }
+    let parts = msg
+        .parts
+        .iter()
+        .map(|p| match p {
+            ContentPart::Image { media_type, .. } => {
+                ContentPart::Text(format!("[image: {media_type}]"))
+            }
+            other => other.clone(),
+        })
+        .collect();
+    Some(ChatMessage {
+        role: msg.role.clone(),
+        parts,
+    })
+}
 
 /// Read the created_at date of a session file and convert to the local day.
 fn read_session_date(path: &std::path::Path, boundary_hour: u8) -> NaiveDate {

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1,4 +1,4 @@
-use crate::channel::{Channel, IncomingMessage, OutgoingMessage};
+use crate::channel::{Attachment, Channel, IncomingMessage, MAX_ATTACHMENT_BYTES, OutgoingMessage};
 use crate::config::DiscordConfig;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -47,7 +47,10 @@ impl EventHandler for DiscordHandler {
         }
 
         let content = msg.content.trim().to_string();
-        if content.is_empty() {
+        let attachments = download_image_attachments(&msg).await;
+
+        // Skip messages that have neither text nor any usable image attachment.
+        if content.is_empty() && attachments.is_empty() {
             return;
         }
 
@@ -58,6 +61,7 @@ impl EventHandler for DiscordHandler {
             room_id: msg.channel_id.to_string(),
             timestamp: msg.timestamp.unix_timestamp() as u64 * 1000,
             thread_id: None,
+            attachments,
         };
 
         if let Err(e) = self.tx.send(incoming).await {
@@ -214,6 +218,43 @@ impl Channel for DiscordChannel {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Download every `image/*` attachment on `msg`. Oversized attachments
+/// (>5 MB) and non-image attachments are skipped with a warning so the
+/// conversation continues without them.
+async fn download_image_attachments(msg: &Message) -> Vec<Attachment> {
+    let mut out = Vec::new();
+    for att in &msg.attachments {
+        let Some(ct) = att.content_type.as_deref() else {
+            continue;
+        };
+        if !ct.starts_with("image/") {
+            continue;
+        }
+        if (att.size as usize) > MAX_ATTACHMENT_BYTES {
+            warn!(
+                "Discord image '{}' is {} bytes (>5MB); skipping",
+                att.filename, att.size
+            );
+            continue;
+        }
+        match att.download().await {
+            Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => {
+                out.push(Attachment {
+                    media_type: ct.to_string(),
+                    data: bytes,
+                });
+            }
+            Ok(bytes) => warn!(
+                "Discord image '{}' decoded to {} bytes (>5MB); skipping",
+                att.filename,
+                bytes.len()
+            ),
+            Err(e) => warn!("Failed to download Discord attachment '{}': {e}", att.filename),
+        }
+    }
+    out
+}
 
 /// Split content into chunks that fit within Discord's 2000-character limit.
 fn split_for_discord(content: &str) -> Vec<String> {

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -1,4 +1,4 @@
-use crate::channel::{Channel, IncomingMessage, OutgoingMessage};
+use crate::channel::{Attachment, Channel, IncomingMessage, MAX_ATTACHMENT_BYTES, OutgoingMessage};
 use crate::config::MatrixConfig;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -6,11 +6,13 @@ use matrix_sdk::{
     Client, SessionMeta, SessionTokens,
     authentication::matrix::MatrixSession,
     config::SyncSettings,
+    media::{MediaFormat, MediaRequestParameters},
     ruma::{
         OwnedEventId, OwnedRoomId, OwnedUserId,
         events::relation::Thread,
         events::room::message::{
-            MessageType, OriginalSyncRoomMessageEvent, Relation, RoomMessageEventContent,
+            ImageMessageEventContent, MessageType, OriginalSyncRoomMessageEvent, Relation,
+            RoomMessageEventContent,
         },
     },
 };
@@ -113,6 +115,60 @@ impl MatrixChannel {
     }
 }
 
+/// Download the bytes for a Matrix `m.image` event via the SDK's authenticated
+/// media endpoint. Returns `None` (with a warning log) if the file is over the
+/// 5 MB budget or the download fails — the caller should drop the event in
+/// that case.
+async fn download_matrix_image(
+    client: &Client,
+    image: &ImageMessageEventContent,
+) -> Option<Attachment> {
+    let mime = image
+        .info
+        .as_ref()
+        .and_then(|info| info.mimetype.clone())
+        .unwrap_or_else(|| "image/octet-stream".to_string());
+
+    if !mime.starts_with("image/") {
+        return None;
+    }
+
+    if let Some(size) = image.info.as_ref().and_then(|info| info.size) {
+        let size: u64 = size.into();
+        if size as usize > MAX_ATTACHMENT_BYTES {
+            warn!(
+                "Matrix image '{}' is {} bytes (>5MB); skipping",
+                image.body, size
+            );
+            return None;
+        }
+    }
+
+    let request = MediaRequestParameters {
+        source: image.source.clone(),
+        format: MediaFormat::File,
+    };
+
+    match client.media().get_media_content(&request, true).await {
+        Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => Some(Attachment {
+            media_type: mime,
+            data: bytes,
+        }),
+        Ok(bytes) => {
+            warn!(
+                "Matrix image '{}' decoded to {} bytes (>5MB); skipping",
+                image.body,
+                bytes.len()
+            );
+            None
+        }
+        Err(e) => {
+            warn!("Failed to download Matrix image '{}': {e}", image.body);
+            None
+        }
+    }
+}
+
 #[async_trait]
 impl Channel for MatrixChannel {
     fn name(&self) -> &str {
@@ -163,8 +219,24 @@ impl Channel for MatrixChannel {
                         return;
                     }
 
-                    let MessageType::Text(ref text_content) = event.content.msgtype else {
-                        return;
+                    let (content, attachments) = match &event.content.msgtype {
+                        MessageType::Text(text_content) => {
+                            (text_content.body.clone(), Vec::new())
+                        }
+                        MessageType::Image(image_content) => {
+                            let attachment =
+                                download_matrix_image(&room.client(), image_content).await;
+                            // Use the body as a caption fallback (filename or user-supplied text).
+                            let caption = image_content
+                                .caption()
+                                .map(str::to_string)
+                                .unwrap_or_default();
+                            match attachment {
+                                Some(att) => (caption, vec![att]),
+                                None => return,
+                            }
+                        }
+                        _ => return,
                     };
 
                     let thread_id = event.content.relates_to.as_ref().and_then(|rel| {
@@ -178,10 +250,11 @@ impl Channel for MatrixChannel {
                     let msg = IncomingMessage {
                         id: event.event_id.to_string(),
                         sender: event.sender.to_string(),
-                        content: text_content.body.clone(),
+                        content,
                         room_id: room_id_str,
                         timestamp: 0,
                         thread_id,
+                        attachments,
                     };
 
                     if let Err(e) = tx.send(msg).await {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -3,6 +3,20 @@ pub mod matrix;
 
 use async_trait::async_trait;
 
+/// Maximum size of a single image attachment forwarded to the LLM.
+/// Anthropic's documented limit is 5 MB per image; oversized attachments are
+/// dropped with a warning (the conversation continues without them).
+pub const MAX_ATTACHMENT_BYTES: usize = 5 * 1024 * 1024;
+
+/// A binary attachment fetched from a channel (currently images only).
+#[derive(Debug, Clone)]
+pub struct Attachment {
+    /// MIME type, e.g. `image/png`, `image/jpeg`.
+    pub media_type: String,
+    /// Raw bytes.
+    pub data: Vec<u8>,
+}
+
 /// A message received from a channel.
 #[derive(Debug, Clone)]
 pub struct IncomingMessage {
@@ -18,6 +32,8 @@ pub struct IncomingMessage {
     pub timestamp: u64,
     /// Thread identifier for threaded replies, if applicable.
     pub thread_id: Option<String>,
+    /// Image attachments accompanying the message.
+    pub attachments: Vec<Attachment>,
 }
 
 /// A message to send through a channel.

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -46,6 +46,8 @@ fn estimate_message_tokens(msg: &ChatMessage) -> usize {
         .iter()
         .map(|p| match p {
             ContentPart::Text(t) => estimate_tokens(t),
+            // Anthropic charges per ~750x750 image tile; rough flat approximation.
+            ContentPart::Image { .. } => 1600,
             ContentPart::ToolUse { name, input, .. } => {
                 estimate_tokens(name) + estimate_tokens(&input.to_string())
             }
@@ -191,6 +193,9 @@ pub async fn generate_summary(
             match part {
                 ContentPart::Text(t) => {
                     transcript.push_str(&format!("{role_label}: {t}\n\n"));
+                }
+                ContentPart::Image { media_type, .. } => {
+                    transcript.push_str(&format!("{role_label}: [image: {media_type}]\n\n"));
                 }
                 ContentPart::ToolUse { name, .. } => {
                     transcript.push_str(&format!("{role_label}: [Called tool: {name}]\n\n"));

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -145,6 +145,9 @@ enum ApiPart {
     Text {
         text: String,
     },
+    Image {
+        source: ApiImageSource,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -153,6 +156,15 @@ enum ApiPart {
     ToolResult {
         tool_use_id: String,
         content: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ApiImageSource {
+    Base64 {
+        media_type: String,
+        data: String,
     },
 }
 
@@ -259,6 +271,15 @@ fn chat_message_to_api(msg: &ChatMessage) -> ApiMessage {
         .iter()
         .map(|p| match p {
             ContentPart::Text(t) => ApiPart::Text { text: t.clone() },
+            ContentPart::Image {
+                media_type,
+                data_base64,
+            } => ApiPart::Image {
+                source: ApiImageSource::Base64 {
+                    media_type: media_type.clone(),
+                    data: data_base64.clone(),
+                },
+            },
             ContentPart::ToolUse { id, name, input } => ApiPart::ToolUse {
                 id: id.clone(),
                 name: name.clone(),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -40,6 +40,11 @@ pub enum Role {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ContentPart {
     Text(String),
+    /// Inline image, base64-encoded. `media_type` is the MIME type (e.g. `image/png`).
+    Image {
+        media_type: String,
+        data_base64: String,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -63,6 +68,30 @@ impl ChatMessage {
         Self {
             role: Role::User,
             parts: vec![ContentPart::Text(text.into())],
+        }
+    }
+
+    /// User message with text plus inline images. Images are placed before the
+    /// text part — Anthropic recommends this ordering for best comprehension.
+    /// An empty `text` is omitted so the API never sees an empty text block.
+    pub fn user_with_images(
+        text: impl Into<String>,
+        images: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        let mut parts: Vec<ContentPart> = images
+            .into_iter()
+            .map(|(media_type, data_base64)| ContentPart::Image {
+                media_type,
+                data_base64,
+            })
+            .collect();
+        let text = text.into();
+        if !text.is_empty() {
+            parts.push(ContentPart::Text(text));
+        }
+        Self {
+            role: Role::User,
+            parts,
         }
     }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -430,6 +430,10 @@ async fn handle_get_session(
                 .iter()
                 .map(|p| match p {
                     ContentPart::Text(t) => json!({ "type": "text", "text": t }),
+                    ContentPart::Image { media_type, .. } => {
+                        // Image bytes are not exposed via the API listing; surface a marker only.
+                        json!({ "type": "image", "media_type": media_type })
+                    }
                     ContentPart::ToolUse { id, name, input } => {
                         json!({ "type": "tool_use", "id": id, "name": name, "input": input })
                     }


### PR DESCRIPTION
## Summary

- Add end-to-end support for forwarding **image attachments** from Discord and Matrix channels to the Anthropic vision API as base64-encoded inline images
- Discord: download `image/*` attachments via serenity's `Attachment::download()`; Matrix: handle `MessageType::Image` via the SDK's authenticated media endpoint (supports both plain `mxc://` and E2EE-encrypted media)
- Images exceeding 5 MB are skipped with a warning log and the conversation continues without them

### Key changes

| Layer | Files | What changed |
|-------|-------|-------------|
| **Channel** | `channel/mod.rs`, `discord.rs`, `matrix.rs` | `Attachment` type, `IncomingMessage.attachments`, download helpers |
| **Provider** | `provider/mod.rs`, `anthropic.rs` | `ContentPart::Image`, `ChatMessage::user_with_images`, `ApiPart::Image` → Anthropic base64 image block |
| **Agent** | `agent.rs` | Base64-encode attachments, persist scrubbed `[image: <mime>]` markers to keep JSONL small |
| **Support** | `context_compression.rs`, `serve.rs` | Handle new `Image` variant in token estimation and API listing |

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 9 existing tests pass
- [x] `cargo clippy` — no new warnings
- [ ] Manual: send an image in Discord → agent responds describing the image
- [ ] Manual: send an image in Matrix (both unencrypted and E2EE rooms) → agent responds describing the image
- [ ] Manual: send a >5 MB image → warning log, conversation continues with text only
- [ ] Manual: text-only messages continue to work as before (no regression)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)