### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-04-16
+
+### Added
+
+- **Daily log catchup loop** — heartbeat now runs an hourly catchup task that
+  regenerates any missing daily log without waiting for the next process
+  restart, so a transient failure at the midnight boundary self-heals within
+  the hour.
+
+### Fixed
+
+- **Shutdown summary cancellation** — `main` now awaits the agent task after
+  `serve::run` returns, so the shutdown summary's LLM call completes instead
+  of being cancelled along with the runtime (previously surfaced as a
+  misleading `dns error: task NN was cancelled`).
+- **Stale system prompt after late daily log** — freshly written daily logs
+  now invalidate the per-conversation system-prompt cache, so the model sees
+  the new log immediately instead of staying on the cached snapshot until the
+  next day boundary.
+
 ## [0.3.2] - 2026-04-15
 
 ### Fixed
@@ -139,6 +159,7 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.3.3]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.3
 [0.3.2]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.2
 [0.3.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.1
 [0.3.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -121,7 +121,7 @@ sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.2" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.3" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.2" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.3" }
 
 # Async runtime
 tokio.workspace = true


### PR DESCRIPTION
## Summary

Version bump and changelog for v0.3.3.

### Added
- **Daily log catchup loop** (#49) — hourly catchup task regenerates missed daily logs without waiting for the next process restart.

### Fixed
- **Shutdown summary cancellation** (#50, fixes #48) — `main` now awaits the agent task so the shutdown summary LLM call completes instead of being cancelled with the runtime.
- **Stale system prompt after late daily log** (#49) — freshly written daily logs now invalidate the per-conversation system-prompt cache.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo publish --dry-run\`
- [ ] Tag \`v0.3.3\` and run release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)