### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-19
+
 ### Added
 
 - **`weather` tool** — fetches a short-term weather forecast via the Open-Meteo
@@ -20,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `max_entries`. All three share the same path semantics as `file_read` /
   `file_write` (absolute, `~/...`, or workspace-relative) and update the
   retrieve index + git sync for internal paths.
+- **Weekly / monthly / yearly log auto-generation** — heartbeat now writes
+  summarised logs under `memory/{weekly,monthly,yearly}/` at the appropriate
+  day boundaries (Monday / 1st / Jan 1). Each log carries a YAML frontmatter
+  `digest:` array of importance-ordered bullets produced by the same LLM call
+  that writes the body, so the agent no longer has to call the `memory` tool
+  to recall long-horizon context.
+- **Periodic digest injection** — the system prompt gains four new blocks
+  after "Yesterday's Log": "This Week's Digests", "This Month's Digests",
+  "This Year's Digests", and "Past Years' Digests". Each block pulls the
+  top-N items of the relevant logs' digests (N per kind is configurable via
+  the new `[digest]` config section: `daily_items`, `weekly_items`,
+  `monthly_items`, `yearly_items`; defaults 3/3/5/5).
+- **Daily digest back-fill** — pre-existing daily logs that lack a `digest:`
+  frontmatter are upgraded in-place at startup and in the hourly catchup
+  loop. Unrelated frontmatter keys the memory tool writes (`last_read_at`,
+  `read_count`) are preserved.
 
 ### Changed
 
@@ -49,28 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output drops the per-result title (the new `FileSearchResult` is already
   file-level with `id`, `path`, `score`, `chunks`); results now render as
   `- {path} [score]`.
-
-### Added
-
-- **Weekly / monthly / yearly log auto-generation** — heartbeat now writes
-  summarised logs under `memory/{weekly,monthly,yearly}/` at the appropriate
-  day boundaries (Monday / 1st / Jan 1). Each log carries a YAML frontmatter
-  `digest:` array of importance-ordered bullets produced by the same LLM call
-  that writes the body, so the agent no longer has to call the `memory` tool
-  to recall long-horizon context.
-- **Periodic digest injection** — the system prompt gains four new blocks
-  after "Yesterday's Log": "This Week's Digests", "This Month's Digests",
-  "This Year's Digests", and "Past Years' Digests". Each block pulls the
-  top-N items of the relevant logs' digests (N per kind is configurable via
-  the new `[digest]` config section: `daily_items`, `weekly_items`,
-  `monthly_items`, `yearly_items`; defaults 3/3/5/5).
-- **Daily digest back-fill** — pre-existing daily logs that lack a `digest:`
-  frontmatter are upgraded in-place at startup and in the hourly catchup
-  loop. Unrelated frontmatter keys the memory tool writes (`last_read_at`,
-  `read_count`) are preserved.
-
-### Changed
-
 - **Daily log format** — newly generated dailies now carry YAML frontmatter
   with a `digest:` array. The existing body format (`# Daily Log: YYYY-MM-DD`
   + summary) is unchanged. Files can be hand-edited freely.
@@ -229,6 +225,7 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.4.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.4.0
 [0.3.3]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.3
 [0.3.2]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.2
 [0.3.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -121,7 +121,7 @@ sapphire-workspace = { version = "0.9.0", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.3.3" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.4.0" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.3.3" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.4.0" }
 
 # Async runtime
 tokio.workspace = true

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -789,12 +789,9 @@ fn build_user_message(text: &str, attachments: &[Attachment]) -> ChatMessage {
         return ChatMessage::user(text);
     }
     use base64::{Engine, engine::general_purpose::STANDARD};
-    let images = attachments.iter().map(|a| {
-        (
-            a.media_type.clone(),
-            STANDARD.encode(&a.data),
-        )
-    });
+    let images = attachments
+        .iter()
+        .map(|a| (a.media_type.clone(), STANDARD.encode(&a.data)));
     ChatMessage::user_with_images(text, images)
 }
 

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -250,7 +250,10 @@ async fn download_image_attachments(msg: &Message) -> Vec<Attachment> {
                 att.filename,
                 bytes.len()
             ),
-            Err(e) => warn!("Failed to download Discord attachment '{}': {e}", att.filename),
+            Err(e) => warn!(
+                "Failed to download Discord attachment '{}': {e}",
+                att.filename
+            ),
         }
     }
     out

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -220,9 +220,7 @@ impl Channel for MatrixChannel {
                     }
 
                     let (content, attachments) = match &event.content.msgtype {
-                        MessageType::Text(text_content) => {
-                            (text_content.body.clone(), Vec::new())
-                        }
+                        MessageType::Text(text_content) => (text_content.body.clone(), Vec::new()),
                         MessageType::Image(image_content) => {
                             let attachment =
                                 download_matrix_image(&room.client(), image_content).await;

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -112,9 +112,9 @@ impl Heartbeat {
                 {
                     Ok(true) => any_generated = true,
                     Ok(false) => {}
-                    Err(e) => warn!(
-                        "Heartbeat: failed to generate daily log for {yesterday}: {e:#}"
-                    ),
+                    Err(e) => {
+                        warn!("Heartbeat: failed to generate daily log for {yesterday}: {e:#}")
+                    }
                 }
 
                 // Weekly: today is Monday → last ISO week closed yesterday.
@@ -162,10 +162,7 @@ impl Heartbeat {
 
                 // Yearly: today is Jan 1 → last calendar year ended yesterday.
                 // Runs after monthly so December's monthly is available as input.
-                if self.digest_cfg.yearly_enabled
-                    && today.day() == 1
-                    && today.month() == 1
-                {
+                if self.digest_cfg.yearly_enabled && today.day() == 1 && today.month() == 1 {
                     let year = yesterday.year();
                     info!("Heartbeat: generating yearly log for {year:04}");
                     match generate_yearly_log(

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ use channel::discord::DiscordChannel;
 use channel::matrix::MatrixChannel;
 use clap::{Parser, Subcommand};
 use config::Config;
-use periodic_log::{catchup_missing_daily_digests, catchup_pending_daily_logs};
 use heartbeat::Heartbeat;
+use periodic_log::{catchup_missing_daily_digests, catchup_pending_daily_logs};
 use provider::anthropic::AnthropicProvider;
 use sapphire_workspace::{AppContext, Workspace as SwWorkspace, WorkspaceState};
 
@@ -263,8 +263,7 @@ async fn main() -> Result<()> {
                 .await;
 
                 // ── Back-fill digest frontmatter on existing dailies ────────
-                catchup_missing_daily_digests(provider.as_ref(), &ws_state, &workspace_dir)
-                    .await;
+                catchup_missing_daily_digests(provider.as_ref(), &ws_state, &workspace_dir).await;
 
                 // ── Agent ───────────────────────────────────────────────────
                 let agent = Arc::new(Agent::new(

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -115,9 +115,7 @@ pub fn days_of_iso_week(iso_year: i32, iso_week: u32) -> Vec<NaiveDate> {
 /// (`{year}-01` .. `{year}-(today.month-1)`). Empty in January.
 pub fn month_stems_in_year_before(today: NaiveDate) -> Vec<String> {
     let year = today.year();
-    (1..today.month())
-        .map(|m| monthly_stem(year, m))
-        .collect()
+    (1..today.month()).map(|m| monthly_stem(year, m)).collect()
 }
 
 /// Stems of every file in `memory/yearly/*.md`, sorted ascending.
@@ -133,7 +131,9 @@ pub fn existing_yearly_stems(workspace_dir: &Path) -> Vec<String> {
             if path.extension().and_then(|s| s.to_str()) != Some("md") {
                 return None;
             }
-            path.file_stem().and_then(|s| s.to_str()).map(str::to_string)
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::to_string)
         })
         .collect();
     out.sort();
@@ -220,7 +220,9 @@ pub fn pending_daily_dates(
 ) -> Vec<NaiveDate> {
     let today = crate::session::local_date_for_timestamp(Local::now(), boundary_hour);
     let mut dates = session_store.all_session_dates(boundary_hour);
-    dates.retain(|&date| date < today && !log_abs_path(workspace_dir, LogKind::Daily, &daily_stem(date)).exists());
+    dates.retain(|&date| {
+        date < today && !log_abs_path(workspace_dir, LogKind::Daily, &daily_stem(date)).exists()
+    });
     dates
 }
 
@@ -513,7 +515,9 @@ fn strip_code_fence(raw: &str) -> String {
     let open_tags: &[&str] = &["```markdown\n", "```md\n", "```\n"];
     for tag in open_tags {
         if let Some(rest) = trimmed.strip_prefix(tag)
-            && let Some(inner) = rest.strip_suffix("```").or_else(|| rest.strip_suffix("```\n"))
+            && let Some(inner) = rest
+                .strip_suffix("```")
+                .or_else(|| rest.strip_suffix("```\n"))
         {
             return inner.trim_end().to_string();
         }
@@ -881,12 +885,8 @@ mod tests {
     #[test]
     fn needs_digest_catchup_cases() {
         assert!(needs_digest_catchup("# body only\n"));
-        assert!(needs_digest_catchup(
-            "---\nother: 1\n---\n# body\n"
-        ));
-        assert!(needs_digest_catchup(
-            "---\ndigest: []\n---\n# body\n"
-        ));
+        assert!(needs_digest_catchup("---\nother: 1\n---\n# body\n"));
+        assert!(needs_digest_catchup("---\ndigest: []\n---\n# body\n"));
         assert!(!needs_digest_catchup(
             "---\ndigest:\n  - one\n---\n# body\n"
         ));

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -162,10 +162,7 @@ enum ApiPart {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ApiImageSource {
-    Base64 {
-        media_type: String,
-        data: String,
-    },
+    Base64 { media_type: String, data: String },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/builtin_tools.rs
+++ b/src/tools/builtin_tools.rs
@@ -49,14 +49,13 @@ impl FileReadTool {
             state,
             spec: ToolSpec {
                 name: "file_read".into(),
-                description:
-                    "Read a file with optional line-based pagination. \
+                description: "Read a file with optional line-based pagination. \
                     Accepts absolute paths, ~/... paths, or workspace-relative paths \
                     (resolved against the workspace root). \
                     Returns lines prefixed with their 1-indexed line number in 'N|content' format. \
                     Use offset and limit for large files. \
                     Cannot read binary files or device paths (/dev/, /proc/)."
-                        .into(),
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -176,7 +175,8 @@ impl FileWriteTool {
                     Creates the file and any missing parent directories automatically. \
                     When the target file is inside the workspace, the search index and git sync \
                     are updated automatically. \
-                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.).".into(),
+                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.)."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -309,7 +309,8 @@ impl FileAppendTool {
                     Creates any missing parent directories automatically. \
                     When the target file is inside the workspace, the search index and git sync \
                     are updated automatically. \
-                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.).".into(),
+                    Refuses writes to sensitive system paths (/etc, /boot, /bin, etc.)."
+                    .into(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -531,10 +532,7 @@ impl Tool for DirWalkTool {
     async fn execute(&self, input: &serde_json::Value) -> Result<String> {
         let path_str = input["path"].as_str().context("missing 'path'")?;
         let max_depth = input["max_depth"].as_u64().unwrap_or(5).min(20) as usize;
-        let max_entries = input["max_entries"]
-            .as_u64()
-            .unwrap_or(500)
-            .clamp(1, 5000) as usize;
+        let max_entries = input["max_entries"].as_u64().unwrap_or(500).clamp(1, 5000) as usize;
 
         let path = expand_path(path_str);
 
@@ -807,73 +805,71 @@ impl Tool for WeatherTool {
         let days = input["days"].as_u64().unwrap_or(3).clamp(1, 7);
 
         // Resolve coordinates. Explicit lat/lon wins; otherwise geocode `location`.
-        let (latitude, longitude, resolved_name) = match (
-            input["latitude"].as_f64(),
-            input["longitude"].as_f64(),
-        ) {
-            (Some(lat), Some(lon)) => {
-                if !(-90.0..=90.0).contains(&lat) {
-                    anyhow::bail!("latitude {lat} out of range (-90..90)");
+        let (latitude, longitude, resolved_name) =
+            match (input["latitude"].as_f64(), input["longitude"].as_f64()) {
+                (Some(lat), Some(lon)) => {
+                    if !(-90.0..=90.0).contains(&lat) {
+                        anyhow::bail!("latitude {lat} out of range (-90..90)");
+                    }
+                    if !(-180.0..=180.0).contains(&lon) {
+                        anyhow::bail!("longitude {lon} out of range (-180..180)");
+                    }
+                    (lat, lon, format!("{lat:.4}, {lon:.4}"))
                 }
-                if !(-180.0..=180.0).contains(&lon) {
-                    anyhow::bail!("longitude {lon} out of range (-180..180)");
+                (Some(_), None) | (None, Some(_)) => {
+                    anyhow::bail!("latitude and longitude must be provided together");
                 }
-                (lat, lon, format!("{lat:.4}, {lon:.4}"))
-            }
-            (Some(_), None) | (None, Some(_)) => {
-                anyhow::bail!("latitude and longitude must be provided together");
-            }
-            (None, None) => {
-                let location = input["location"]
-                    .as_str()
-                    .context("provide either 'location' or both 'latitude' and 'longitude'")?;
+                (None, None) => {
+                    let location = input["location"]
+                        .as_str()
+                        .context("provide either 'location' or both 'latitude' and 'longitude'")?;
 
-                let geo_resp = client
-                    .get("https://geocoding-api.open-meteo.com/v1/search")
-                    .query(&[
-                        ("name", location),
-                        ("count", "1"),
-                        ("language", "en"),
-                        ("format", "json"),
-                    ])
-                    .send()
-                    .await
-                    .context("Open-Meteo geocoding request failed")?;
+                    let geo_resp = client
+                        .get("https://geocoding-api.open-meteo.com/v1/search")
+                        .query(&[
+                            ("name", location),
+                            ("count", "1"),
+                            ("language", "en"),
+                            ("format", "json"),
+                        ])
+                        .send()
+                        .await
+                        .context("Open-Meteo geocoding request failed")?;
 
-                if !geo_resp.status().is_success() {
-                    let status = geo_resp.status();
-                    let body = geo_resp.text().await.unwrap_or_default();
-                    anyhow::bail!("Open-Meteo geocoding error {status}: {body}");
+                    if !geo_resp.status().is_success() {
+                        let status = geo_resp.status();
+                        let body = geo_resp.text().await.unwrap_or_default();
+                        anyhow::bail!("Open-Meteo geocoding error {status}: {body}");
+                    }
+
+                    let geo: serde_json::Value = geo_resp
+                        .json()
+                        .await
+                        .context("Failed to parse Open-Meteo geocoding response")?;
+
+                    let result = geo["results"]
+                        .as_array()
+                        .and_then(|arr| arr.first())
+                        .with_context(|| format!("No matches for location '{location}'"))?;
+
+                    let lat = result["latitude"]
+                        .as_f64()
+                        .context("geocoding result missing 'latitude'")?;
+                    let lon = result["longitude"]
+                        .as_f64()
+                        .context("geocoding result missing 'longitude'")?;
+                    let name = result["name"].as_str().unwrap_or(location);
+                    let admin = result["admin1"].as_str().unwrap_or("");
+                    let country = result["country"].as_str().unwrap_or("");
+                    let pretty = [name, admin, country]
+                        .iter()
+                        .filter(|s| !s.is_empty())
+                        .copied()
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    (lat, lon, pretty)
                 }
-
-                let geo: serde_json::Value = geo_resp
-                    .json()
-                    .await
-                    .context("Failed to parse Open-Meteo geocoding response")?;
-
-                let result = geo["results"]
-                    .as_array()
-                    .and_then(|arr| arr.first())
-                    .with_context(|| format!("No matches for location '{location}'"))?;
-
-                let lat = result["latitude"]
-                    .as_f64()
-                    .context("geocoding result missing 'latitude'")?;
-                let lon = result["longitude"]
-                    .as_f64()
-                    .context("geocoding result missing 'longitude'")?;
-                let name = result["name"].as_str().unwrap_or(location);
-                let admin = result["admin1"].as_str().unwrap_or("");
-                let country = result["country"].as_str().unwrap_or("");
-                let pretty = [name, admin, country]
-                    .iter()
-                    .filter(|s| !s.is_empty())
-                    .copied()
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                (lat, lon, pretty)
-            }
-        };
+            };
 
         let lat_s = latitude.to_string();
         let lon_s = longitude.to_string();
@@ -919,7 +915,10 @@ impl Tool for WeatherTool {
             let wind = current["wind_speed_10m"].as_f64();
             let code = current["weather_code"].as_i64().unwrap_or(-1);
             let time = current["time"].as_str().unwrap_or("");
-            out.push_str(&format!("\nCurrent ({time}): {}\n", wmo_code_description(code)));
+            out.push_str(&format!(
+                "\nCurrent ({time}): {}\n",
+                wmo_code_description(code)
+            ));
             if let Some(t) = temp {
                 out.push_str(&format!("  temp: {t:.1}°C"));
                 if let Some(f) = feels {

--- a/src/tools/workspace_tools.rs
+++ b/src/tools/workspace_tools.rs
@@ -499,10 +499,7 @@ impl Tool for WorkspaceSearchTool {
         } else {
             "[fts]\n"
         };
-        let lines: Vec<String> = results
-            .iter()
-            .map(|r| format!("- {}", r.path))
-            .collect();
+        let lines: Vec<String> = results.iter().map(|r| format!("- {}", r.path)).collect();
         Ok(format!("{}{}", header, lines.join("\n")))
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -281,8 +281,8 @@ fn build_digest_block(
 ) -> Option<String> {
     let mut subsections = Vec::new();
     for stem in stems {
-        let items = periodic_log::read_digest_top_n(workspace_dir, kind, stem, n)
-            .unwrap_or_default();
+        let items =
+            periodic_log::read_digest_top_n(workspace_dir, kind, stem, n).unwrap_or_default();
         if items.is_empty() {
             continue;
         }


### PR DESCRIPTION
## Summary

Release **v0.4.0** — first minor bump since 0.3.x, covering the tool-layer refactor, new filesystem/weather tools, and the weekly/monthly/yearly digest pipeline.

### Highlights

- **New tools**: `weather` (Open-Meteo, no API key), plus `file_append` / `dir_list` / `dir_walk`.
- **Tool renames (breaking)**: `terminal` → `shell` (now honours `$SHELL`), `read_file`/`write_file`/`delete_file` → `file_read`/`file_write`/`file_delete`. `workspace_read`/`workspace_write` removed — the unified `file_read`/`file_write` handle both workspace-internal and external paths via `WorkspaceState`.
- **sapphire-workspace 0.8.1 → 0.9.0**: typed `FtsQuery`/`VectorQuery` search API; `workspace_search` no longer pre-embeds queries.
- **Periodic logs**: heartbeat now generates weekly / monthly / yearly summaries under `memory/{weekly,monthly,yearly}/` with an importance-ordered `digest:` frontmatter. System prompt injects top-N items per horizon (`[digest]` config: `daily_items`/`weekly_items`/`monthly_items`/`yearly_items`, defaults 3/3/5/5). Existing dailies are back-filled on startup and in the hourly catchup loop.

Callers hard-coding the old `terminal` / `read_file` / `write_file` / `delete_file` / `workspace_read` / `workspace_write` tool names must update.

### Commits

- `style: cargo fmt` — formatting pass over the src tree.
- `chore: release v0.4.0` — workspace version 0.3.3 → 0.4.0, path dep bumps, CHANGELOG `[Unreleased]` → `[0.4.0] - 2026-04-19`.

### Release workflow

Merging this PR triggers `.github/workflows/release.yml`:
1. Tags `v0.4.0` on the merge commit.
2. Builds release binaries for linux-x86_64 / linux-aarch64 (required) and macos-aarch64 / windows-x86_64 (`continue-on-error`).
3. Creates the GitHub release with auto-generated notes.
4. Runs `cargo publish --workspace` to crates.io.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo publish --dry-run` succeeds (per maintainer)
- [ ] CI green on this PR
- [ ] After merge: release workflow tags `v0.4.0`, publishes binaries, and `cargo publish --workspace` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)