### PR TITLE
fix(channel): validate image MIME type against Anthropic's allowlist

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -228,7 +228,12 @@ async fn download_image_attachments(msg: &Message) -> Vec<Attachment> {
         let Some(ct) = att.content_type.as_deref() else {
             continue;
         };
-        if !ct.starts_with("image/") {
+        const SUPPORTED: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+        if !SUPPORTED.contains(&ct) {
+            warn!(
+                "Discord image '{}' has unsupported MIME type '{}'; skipping",
+                att.filename, ct
+            );
             continue;
         }
         if (att.size as usize) > MAX_ATTACHMENT_BYTES {

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -135,14 +135,23 @@ fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
     }
 }
 
+/// Result of attempting to download a Matrix image attachment.
+enum ImageDownload {
+    /// Successfully downloaded and format is supported.
+    Ok(Attachment),
+    /// Format could not be identified as one the Anthropic API supports.
+    /// The user should be notified so they can resend in a supported format.
+    UnsupportedFormat,
+    /// Silently skipped (too large, download failure, etc.).
+    Skipped,
+}
+
 /// Download the bytes for a Matrix `m.image` event via the SDK's authenticated
-/// media endpoint. Returns `None` (with a warning log) if the file is over the
-/// 5 MB budget, the format is unsupported, or the download fails — the caller
-/// should drop the event in that case.
+/// media endpoint.
 async fn download_matrix_image(
     client: &Client,
     image: &ImageMessageEventContent,
-) -> Option<Attachment> {
+) -> ImageDownload {
     if let Some(size) = image.info.as_ref().and_then(|info| info.size) {
         let size: u64 = size.into();
         if size as usize > MAX_ATTACHMENT_BYTES {
@@ -150,7 +159,7 @@ async fn download_matrix_image(
                 "Matrix image '{}' is {} bytes (>5MB); skipping",
                 image.body, size
             );
-            return None;
+            return ImageDownload::Skipped;
         }
     }
 
@@ -188,14 +197,14 @@ async fn download_matrix_image(
                     }
                     None => {
                         warn!(
-                            "Matrix image '{}' has unrecognised format (declared: {:?}); skipping",
+                            "Matrix image '{}' has unrecognised format (declared: {:?})",
                             image.body, declared
                         );
-                        return None;
+                        return ImageDownload::UnsupportedFormat;
                     }
                 }
             };
-            Some(Attachment {
+            ImageDownload::Ok(Attachment {
                 media_type,
                 data: bytes,
             })
@@ -206,11 +215,11 @@ async fn download_matrix_image(
                 image.body,
                 bytes.len()
             );
-            None
+            ImageDownload::Skipped
         }
         Err(e) => {
             warn!("Failed to download Matrix image '{}': {e}", image.body);
-            None
+            ImageDownload::Skipped
         }
     }
 }
@@ -265,24 +274,8 @@ impl Channel for MatrixChannel {
                         return;
                     }
 
-                    let (content, attachments) = match &event.content.msgtype {
-                        MessageType::Text(text_content) => (text_content.body.clone(), Vec::new()),
-                        MessageType::Image(image_content) => {
-                            let attachment =
-                                download_matrix_image(&room.client(), image_content).await;
-                            // Use the body as a caption fallback (filename or user-supplied text).
-                            let caption = image_content
-                                .caption()
-                                .map(str::to_string)
-                                .unwrap_or_default();
-                            match attachment {
-                                Some(att) => (caption, vec![att]),
-                                None => return,
-                            }
-                        }
-                        _ => return,
-                    };
-
+                    // Resolve thread context early — needed both for routing and
+                    // for attaching a thread relation to any error replies.
                     let thread_id = event.content.relates_to.as_ref().and_then(|rel| {
                         if let Relation::Thread(thread) = rel {
                             Some(thread.event_id.to_string())
@@ -290,6 +283,45 @@ impl Channel for MatrixChannel {
                             None
                         }
                     });
+
+                    let (content, attachments) = match &event.content.msgtype {
+                        MessageType::Text(text_content) => (text_content.body.clone(), Vec::new()),
+                        MessageType::Image(image_content) => {
+                            let result =
+                                download_matrix_image(&room.client(), image_content).await;
+                            // Use the body as a caption fallback (filename or user-supplied text).
+                            let caption = image_content
+                                .caption()
+                                .map(str::to_string)
+                                .unwrap_or_default();
+                            match result {
+                                ImageDownload::Ok(att) => (caption, vec![att]),
+                                ImageDownload::UnsupportedFormat => {
+                                    // Forward a synthetic prompt to the agent so it generates
+                                    // a natural-language reply asking the user to resend in a
+                                    // supported format (JPEG / PNG / GIF / WebP).
+                                    let msg = IncomingMessage {
+                                        id: event.event_id.to_string(),
+                                        sender: event.sender.to_string(),
+                                        content: "[system] An image was received in an unsupported format. \
+                                                  Please inform the user and ask them to resend it \
+                                                  as JPEG, PNG, GIF, or WebP."
+                                            .to_string(),
+                                        room_id: room_id_str,
+                                        timestamp: 0,
+                                        thread_id,
+                                        attachments: Vec::new(),
+                                    };
+                                    if let Err(e) = tx.send(msg).await {
+                                        warn!("Failed to forward unsupported-format event: {e}");
+                                    }
+                                    return;
+                                }
+                                ImageDownload::Skipped => return,
+                            }
+                        }
+                        _ => return,
+                    };
 
                     let msg = IncomingMessage {
                         id: event.event_id.to_string(),

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -115,24 +115,34 @@ impl MatrixChannel {
     }
 }
 
+/// Detect the MIME type of an image from its magic bytes.
+/// Returns `None` if the format is not one of the four types supported by
+/// the Anthropic API (jpeg, png, gif, webp).
+fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12
+        && bytes.starts_with(b"RIFF")
+        && &bytes[8..12] == b"WEBP"
+    {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
 /// Download the bytes for a Matrix `m.image` event via the SDK's authenticated
 /// media endpoint. Returns `None` (with a warning log) if the file is over the
-/// 5 MB budget or the download fails — the caller should drop the event in
-/// that case.
+/// 5 MB budget, the format is unsupported, or the download fails — the caller
+/// should drop the event in that case.
 async fn download_matrix_image(
     client: &Client,
     image: &ImageMessageEventContent,
 ) -> Option<Attachment> {
-    let mime = image
-        .info
-        .as_ref()
-        .and_then(|info| info.mimetype.clone())
-        .unwrap_or_else(|| "image/octet-stream".to_string());
-
-    if !mime.starts_with("image/") {
-        return None;
-    }
-
     if let Some(size) = image.info.as_ref().and_then(|info| info.size) {
         let size: u64 = size.into();
         if size as usize > MAX_ATTACHMENT_BYTES {
@@ -150,10 +160,46 @@ async fn download_matrix_image(
     };
 
     match client.media().get_media_content(&request, true).await {
-        Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => Some(Attachment {
-            media_type: mime,
-            data: bytes,
-        }),
+        Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => {
+            // Determine MIME type: trust the event metadata only if it names one
+            // of the four types the Anthropic API accepts. Otherwise fall back to
+            // sniffing the magic bytes — Matrix clients sometimes omit `mimetype`
+            // or send a generic type even for standard formats.
+            const SUPPORTED: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+            let declared = image
+                .info
+                .as_ref()
+                .and_then(|info| info.mimetype.as_deref());
+            let media_type = if declared.is_some_and(|m| SUPPORTED.contains(&m)) {
+                declared.unwrap().to_string()
+            } else {
+                match sniff_image_mime(&bytes) {
+                    Some(t) => {
+                        if declared.is_some() {
+                            warn!(
+                                "Matrix image '{}' declared MIME '{}' is unsupported; \
+                                 detected '{}' from bytes",
+                                image.body,
+                                declared.unwrap(),
+                                t
+                            );
+                        }
+                        t.to_string()
+                    }
+                    None => {
+                        warn!(
+                            "Matrix image '{}' has unrecognised format (declared: {:?}); skipping",
+                            image.body, declared
+                        );
+                        return None;
+                    }
+                }
+            };
+            Some(Attachment {
+                media_type,
+                data: bytes,
+            })
+        }
         Ok(bytes) => {
             warn!(
                 "Matrix image '{}' decoded to {} bytes (>5MB); skipping",


### PR DESCRIPTION
## Summary

- Matrix clients sometimes omit `info.mimetype` or set it to a generic type (e.g. `image/octet-stream`), which passes the old `starts_with("image/")` check but is rejected by the Anthropic API with a 400 error
- Added `sniff_image_mime()` in the Matrix handler: after downloading the bytes, the MIME type is detected from magic bytes (JPEG / PNG / GIF / WebP signatures) when the declared type is missing or unsupported
- Tightened the Discord handler to also reject MIME types not in Anthropic's allowlist instead of forwarding any `image/*`
- When a Matrix image cannot be identified as a supported format, a synthetic system prompt is forwarded to the agent so it generates a natural reply asking the user to resend in JPEG/PNG/GIF/WebP

## Test plan

- [ ] Send a JPEG via Matrix — should be processed correctly even if the client omits `mimetype`
- [ ] Send a PNG via Matrix — same
- [ ] Send an unsupported format (e.g. AVIF, HEIC) — agent should reply asking the user to resend in a supported format
- [ ] Send a JPEG via Discord — should still work
- [ ] Send an unsupported format via Discord — should be skipped with a `warn` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)