### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-20
+
+### Added
+
+- **Unsupported image format notification** — when a Matrix message contains an
+  image whose MIME type is not on Anthropic's allowlist, the agent now sends an
+  explicit reply informing the user that the format is not supported, instead of
+  silently dropping the attachment.
+
+### Fixed
+
+- **Image MIME type validation** — image attachments in Matrix messages are now
+  validated against Anthropic's supported media-type allowlist
+  (`image/jpeg`, `image/png`, `image/gif`, `image/webp`) before being forwarded
+  to the API, preventing request errors caused by unsupported formats.
+
 ## [0.4.0] - 2026-04-19
 
 ### Added
@@ -225,6 +241,7 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.4.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.4.1
 [0.4.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.4.0
 [0.3.3]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.3
 [0.3.2]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -121,7 +121,7 @@ sapphire-workspace = { version = "0.9.0", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.4.0" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.4.1" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.4.0" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.4.1" }
 
 # Async runtime
 tokio.workspace = true

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -125,10 +125,7 @@ fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
         Some("image/png")
     } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
         Some("image/gif")
-    } else if bytes.len() >= 12
-        && bytes.starts_with(b"RIFF")
-        && &bytes[8..12] == b"WEBP"
-    {
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
         Some("image/webp")
     } else {
         None
@@ -148,10 +145,7 @@ enum ImageDownload {
 
 /// Download the bytes for a Matrix `m.image` event via the SDK's authenticated
 /// media endpoint.
-async fn download_matrix_image(
-    client: &Client,
-    image: &ImageMessageEventContent,
-) -> ImageDownload {
+async fn download_matrix_image(client: &Client, image: &ImageMessageEventContent) -> ImageDownload {
     if let Some(size) = image.info.as_ref().and_then(|info| info.size) {
         let size: u64 = size.into();
         if size as usize > MAX_ATTACHMENT_BYTES {


### PR DESCRIPTION
## Summary

- Bump version `0.4.0` → `0.4.1` across workspace (`Cargo.toml`, `Cargo.lock`, `crates/sapphire-call/Cargo.toml`)
- Add `[0.4.1]` entry to `CHANGELOG.md`

## Changes included

**Fixed**
- Image attachments in Matrix messages are now validated against Anthropic's supported MIME type allowlist (`image/jpeg`, `image/png`, `image/gif`, `image/webp`) before being forwarded to the API.

**Added**
- When an unsupported image format is detected, the agent sends an explicit reply notifying the user instead of silently dropping the attachment.

## Test plan

- [ ] Merge triggers `release/` workflow → tag `v0.4.1` is created
- [ ] Binaries built and uploaded as release artifacts
- [ ] Crates published to crates.io via `cargo publish --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)