### PR TITLE
chore(deps): bump sapphire-workspace to 0.10.1 + AppContext init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,6 +3231,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6967,6 +6978,7 @@ dependencies = [
  "directories",
  "futures-util",
  "grain-id",
+ "hostname",
  "matrix-sdk",
  "reqwest",
  "sapphire-agent-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7009,9 +7009,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4bad23eedba96b695a389bd325b030a9452330c9ab54cf50db5adbeb8b636"
+checksum = "6e666070eb7fda63c1e72d044854adbc8efeada2ab070581008a6916fc62749d"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7027,13 +7027,15 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14262216508f61acf2a9c387065be8ad633068cea469d8ac390bafc77ccc7565"
+checksum = "30f97e19d9cde77fb01389798481b3d4d1210cf8b94b87e996819f9ce91512c8"
 dependencies = [
+ "chrono",
  "dirs 5.0.1",
  "git2",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -7041,11 +7043,11 @@ dependencies = [
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d65ac73122bbaa09fba44072d37a6e510e2d63ecd1c266903aecf5f70e626a2"
+checksum = "5cbce87834133a783f55622d16558bfecaa721c6c584cc109d257273d47517d7"
 dependencies = [
- "dirs 5.0.1",
+ "chrono",
  "indexmap 2.14.0",
  "md-5",
  "sapphire-retrieve",
@@ -7054,6 +7056,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "uuid",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ uuid = { version = "1", features = ["v7"] }
 
 # Workspace: file indexing, FTS, vector search, git sync
 # lancedb-store is gated behind the "lancedb-store" feature (default on)
-sapphire-workspace = { version = "0.9.0", default-features = false }
+sapphire-workspace = { version = "0.10.1", default-features = false }
 
 # Human-readable session IDs for API sessions
 grain-id = { version = "0.14", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ clap.workspace = true
 # XDG directories for config/data paths
 directories = "6.0"
 
+# System hostname lookup for the sapphire-workspace DeviceDefaults init
+hostname = "0.4"
+
 # Shell path expansion (~/)
 shellexpand = "3.1"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,19 @@ pub struct Config {
     /// takes precedence — allowing each user to override the workspace defaults.
     #[serde(default)]
     pub sync: Option<SyncConfig>,
+    /// How often the agent runs the periodic workspace sync cycle, in
+    /// minutes. Unset or `0` disables periodic sync entirely. Each tick
+    /// runs `WorkspaceState::periodic_sync`, which does a git sync **and**
+    /// an mtime-based refresh of the retrieve cache — one cadence drives
+    /// both.
+    ///
+    /// Lives at the config root (not inside `[sync]`) because the cadence
+    /// spans both `sapphire-sync` and `sapphire-retrieve`; nesting it
+    /// under `[sync]` would have implied a sync-only knob and forced a
+    /// duplicate for the retrieve side. Upstream relocated it out of
+    /// `SyncConfig` for the same reason in sapphire-workspace 0.10.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync_interval_minutes: Option<u32>,
     /// Periodic log digest configuration (weekly / monthly / yearly).
     #[serde(default)]
     pub digest: DigestConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,9 +167,17 @@ async fn main() -> Result<()> {
                 .context("Failed to resolve sapphire-workspace")?;
             // Use the [sync] section from the agent config directly.
             // WorkspaceConfig was removed in sapphire-workspace 0.8.0;
-            // open_configured now takes &SyncConfig.
+            // open_configured now takes &SyncConfig. In 0.10 the periodic
+            // cadence moved out of SyncConfig because it drives both
+            // sapphire-sync and sapphire-retrieve — keeping one knob
+            // avoids a duplicate `[retrieve]` cadence. It now lives at
+            // the agent config root as `sync_interval_minutes`, and each
+            // `periodic_sync()` call refreshes the retrieve cache too.
             let sync_config = config.sync.clone().unwrap_or_default();
-            let ws_sync_interval = sync_config.sync_interval();
+            let ws_sync_interval = config
+                .sync_interval_minutes
+                .filter(|&m| m > 0)
+                .map(|m| std::time::Duration::from_secs(m as u64 * 60));
             let ws_state = WorkspaceState::open_configured(sw_workspace, &sync_config)
                 .context("Failed to open WorkspaceState")?;
             if let Err(e) = ws_state.periodic_sync() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,42 @@ use config::Config;
 use heartbeat::Heartbeat;
 use periodic_log::{catchup_missing_daily_digests, catchup_pending_daily_logs};
 use provider::anthropic::AnthropicProvider;
-use sapphire_workspace::{AppContext, Workspace as SwWorkspace, WorkspaceState};
+use sapphire_workspace::{AppContext, DeviceDefaults, Workspace as SwWorkspace, WorkspaceState};
 
 static APP_CTX: AppContext = AppContext::new("sapphire-agent").allow_external_paths();
+
+/// Inject host-platform paths and device facts into [`APP_CTX`] before any
+/// code touches a [`SwWorkspace`]. The sapphire-workspace library deliberately
+/// does not depend on `dirs` / `hostname`, so each host app has to wire these
+/// up itself at startup. Missing this made `APP_CTX.device()` panic the first
+/// time the git sync backend tried to record device info.
+fn init_app_ctx() {
+    let base = directories::BaseDirs::new();
+    let cache_dir = base
+        .as_ref()
+        .map(|b| b.cache_dir().to_path_buf())
+        .unwrap_or_else(std::env::temp_dir)
+        .join(env!("CARGO_PKG_NAME"));
+    let data_dir = base
+        .as_ref()
+        .map(|b| b.data_dir().to_path_buf())
+        .unwrap_or_else(std::env::temp_dir)
+        .join(env!("CARGO_PKG_NAME"));
+    APP_CTX.set_cache_dir(cache_dir);
+    APP_CTX.set_data_dir(data_dir);
+
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .unwrap_or_default();
+    APP_CTX.set_device_defaults(DeviceDefaults {
+        hostname,
+        app_id: env!("CARGO_PKG_NAME").to_owned(),
+        app_version: env!("CARGO_PKG_VERSION").to_owned(),
+        platform: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+    });
+}
 use session::SessionStore;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -90,6 +123,8 @@ async fn main() -> Result<()> {
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .init();
+
+    init_app_ctx();
 
     let cli = Cli::parse();
 


### PR DESCRIPTION
## Summary
- Bump `sapphire-workspace` 0.9.0 → 0.10.1 to pick up the fix for `canonicalize_or_parent` returning paths with a trailing separator (fluo10/sapphire-workspace#48). The bug made `WorkspaceState::write_file` fail with `EISDIR (os error 21)` for any file that did not yet exist — every new daily log and `memory_add` call had been failing because of it.
- 0.10 dropped `sync_interval_minutes` from `SyncConfig` (the cadence drives both `sapphire-sync` and `sapphire-retrieve`, so a `[sync]`-local knob would have implied a duplicate `[retrieve]` cadence). Re-host the field at the agent config root and compute the `Duration` locally in `main.rs`.
- 0.10 also split device facts out into `DeviceDefaults` / `set_device_defaults`. The library deliberately doesn't depend on `dirs` / `hostname`, so wire an `init_app_ctx()` at the top of `main()` to supply cache dir, data dir, and host-detected device facts before any `SwWorkspace::resolve` call. Add `hostname = "0.4"` as a direct dep; reuse the existing `directories` crate for XDG paths.

### Breaking change
Users whose config placed `sync_interval_minutes` under `[sync]` must move it to the top level:

```toml
# before
[sync]
sync_interval_minutes = 10

# after
sync_interval_minutes = 10

[sync]
# (remaining sync backend options)
```

## Test plan
- [x] `cargo build` — succeeds (5 pre-existing warnings, no errors)
- [x] `cargo test --bin sapphire-agent` — 42 passed / 0 failed
- [x] Deploy to saph1na: confirm daily log generation succeeds for the current day and that `memory_add` no longer reports write failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)