### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-22
+
+### Changed
+
+- **`sapphire-workspace` 0.9 → 0.10.1** — the workspace crate now requires
+  each host app to supply cache/data directories and host-detected device
+  facts before any workspace is opened. `main` wires this up via a new
+  `init_app_ctx()` call at startup (using `directories` for paths and a new
+  `hostname` direct dependency), so the git sync backend can record device
+  info without panicking in `APP_CTX.device()`.
+
+### Fixed
+
+- **`file_write` / `memory_add` on non-existent files** — picked up via the
+  workspace 0.10.1 bump, which fixes `canonicalize_or_parent` returning a
+  path with a trailing separator. Previously every new daily log and every
+  new `memory_add` call failed with EISDIR until the target file already
+  existed on disk. See fluo10/sapphire-workspace#48.
+
+### Breaking
+
+- **`sync_interval_minutes` moved out of `[sync]`** — the cadence drives
+  both `sapphire-sync` and `sapphire-retrieve`, so nesting it under `[sync]`
+  was misleading. The field is now read from the agent config root. Users
+  whose `config.toml` had `sync_interval_minutes` inside `[sync]` must move
+  it to the top level.
+
 ## [0.4.1] - 2026-04-20
 
 ### Added
@@ -241,6 +268,7 @@ an HTTP/MCP server mode.
   and workspace-aware writes.
 - **Logging** — `tracing` with env-filter and ANSI output.
 
+[0.5.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.5.0
 [0.4.1]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.4.1
 [0.4.0]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.4.0
 [0.3.3]: https://github.com/fluo10/sapphire-agent/releases/tag/v0.3.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
@@ -124,7 +124,7 @@ sapphire-workspace = { version = "0.10.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde"] }
 
 # Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.4.1" }
+sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.5.0" }
 
 # HTTP server (serve command)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.4.1" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.5.0" }
 
 # Async runtime
 tokio.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace version 0.4.1 → 0.5.0
- Changelog entry covering the two changes merged since v0.4.1: `sapphire-workspace` 0.9 → 0.10.1 bump and the `init_app_ctx()` wiring at startup
- Flag the `sync_interval_minutes` config key move (out of `[sync]` → root) as a breaking change in the notes

## Test plan

- [x] `cargo check --workspace` succeeds
- [ ] CI passes on the PR
- [ ] On merge, the release workflow tags `v0.5.0`, builds binaries, cuts a GitHub release, and publishes the three workspace crates to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)