### PR TITLE
feat(provider): pluggable LLM providers with per-room/per-profile routing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -83,13 +83,23 @@ system_prompt = "You are a helpful personal assistant."
 # is used by rooms that don't pick one explicitly. Profiles that name an
 # unknown provider cause startup to fail.
 #
-# `fallback_provider` is reserved for the upcoming refusal-fallback layer
-# (e.g. when the primary refuses NSFW content); it is parsed today but not
-# yet wired into the chat path.
+# `fallback_provider` is consulted at runtime: when the primary refuses
+# (Anthropic `stop_reason = "refusal"`, OpenAI `finish_reason =
+# "content_filter"`, or a recognised apology pattern) or errors out, the
+# call is replayed against the named fallback provider.
+#
+# The conventional `background` profile is what the daily-log generator,
+# memory compaction, and periodic digests run under. Defining it lets a
+# session that mixes safe-for-Anthropic and refused content still produce
+# its end-of-day summary by handing off the refused parts to a permissive
+# local model.
 #
 # [profiles.default]
 # provider = "anthropic"
 #
 # [profiles.nsfw]
-# provider          = "local"
-# fallback_provider = "anthropic"   # not yet active; see release notes
+# provider = "local"
+#
+# [profiles.background]
+# provider          = "anthropic"
+# fallback_provider = "local"

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,9 +34,11 @@ recovery_key = "EsT... "
 #   "none"    — no day-boundary action
 # session_policy = "compact"
 
-# Per-room overrides. Keys are room_ids; values may set session_policy.
+# Per-room overrides. Keys are room_ids; values may set session_policy
+# and/or pick a named profile (see [profiles] below).
 # [rooms."!roomid:example.com"]
 # session_policy = "reset"
+# profile        = "nsfw"
 
 # Periodic log digests. The agent summarises weekly/monthly/yearly activity
 # into short importance-ordered bullet lists, stored as YAML frontmatter in
@@ -59,3 +61,35 @@ model = "claude-opus-4-6"
 max_tokens = 8192
 # System prompt sent at the beginning of every conversation.
 system_prompt = "You are a helpful personal assistant."
+
+# ── Additional providers ────────────────────────────────────────────────
+# Beyond the built-in Anthropic provider above, you can declare any number
+# of OpenAI-compatible endpoints — llama.cpp's `llama-server`, Ollama,
+# vLLM, or the OpenAI API itself. Each entry is keyed by a name you choose
+# and must specify `type = "openai_compatible"`. The reserved name
+# `anthropic` cannot be reused here.
+#
+# [providers.local]
+# type     = "openai_compatible"
+# base_url = "http://127.0.0.1:8080/v1"  # llama-server, no trailing /chat/completions
+# model    = "gemma-4-31b-it"
+# api_key  = ""                          # optional; llama.cpp does not need one
+# max_tokens = 4096
+
+# ── Profiles ────────────────────────────────────────────────────────────
+# A profile binds a use-case to a provider. Rooms select a profile via
+# `profile = "..."` in their `[rooms."<id>"]` block; the API may also pass
+# `profile` per request. The conventional `default` profile, when defined,
+# is used by rooms that don't pick one explicitly. Profiles that name an
+# unknown provider cause startup to fail.
+#
+# `fallback_provider` is reserved for the upcoming refusal-fallback layer
+# (e.g. when the primary refuses NSFW content); it is parsed today but not
+# yet wired into the chat path.
+#
+# [profiles.default]
+# provider = "anthropic"
+#
+# [profiles.nsfw]
+# provider          = "local"
+# fallback_provider = "anthropic"   # not yet active; see release notes

--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -62,20 +62,21 @@ pub async fn run(
     message: Option<String>,
     history: bool,
     json: bool,
+    profile: Option<String>,
 ) -> Result<()> {
     let base = server.trim_end_matches('/').to_string();
     let client = reqwest::Client::new();
 
     // -- --list mode ----------------------------------------------------------
     if list {
-        let (mcp_session_id, _, _) = initialize_session(&client, &base, session).await?;
+        let (mcp_session_id, _, _) = initialize_session(&client, &base, session, None).await?;
         list_sessions(&client, &base, &mcp_session_id, json).await?;
         return Ok(());
     }
 
     // -- Initialize session ---------------------------------------------------
     let (mut mcp_session_id, actual_session_id, is_new) =
-        initialize_session(&client, &base, session).await?;
+        initialize_session(&client, &base, session, profile.as_deref()).await?;
 
     // -- --history dump-only mode ---------------------------------------------
     if history {
@@ -131,7 +132,7 @@ pub async fn run(
                 continue;
             }
             "/clear" => {
-                match initialize_session(&client, &base, None).await {
+                match initialize_session(&client, &base, None, profile.as_deref()).await {
                     Ok((new_mcp_id, new_session_id, _)) => {
                         mcp_session_id = new_mcp_id;
                         println!("[new session: {new_session_id}]");
@@ -161,13 +162,18 @@ async fn initialize_session(
     client: &reqwest::Client,
     base: &str,
     session: Option<String>,
+    profile: Option<&str>,
 ) -> Result<(String, String, bool)> {
     let session_id_req = session.as_deref().unwrap_or("new");
+    let mut params = json!({ "session_id": session_id_req });
+    if let Some(p) = profile {
+        params["profile"] = json!(p);
+    }
     let body = json!({
         "jsonrpc": "2.0",
         "id": next_id(),
         "method": "initialize",
-        "params": { "session_id": session_id_req },
+        "params": params,
     });
 
     let resp = client

--- a/crates/sapphire-call/src/main.rs
+++ b/crates/sapphire-call/src/main.rs
@@ -34,6 +34,12 @@ struct Cli {
     /// and --message; ignored in REPL mode.
     #[arg(long)]
     json: bool,
+
+    /// Profile name to bind to a newly created session. Must match a
+    /// `[profiles.<name>]` entry on the server side. Ignored when
+    /// resuming an existing session via --session.
+    #[arg(long)]
+    profile: Option<String>,
 }
 
 #[tokio::main]
@@ -52,6 +58,7 @@ async fn main() -> Result<()> {
         cli.message,
         cli.history,
         cli.json,
+        cli.profile,
     )
     .await
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::channel::{Attachment, Channel, OutgoingMessage};
 use crate::config::{Config, SessionPolicy};
 use crate::context_compression::{generate_summary, maybe_compress};
+use crate::provider::registry::ProviderRegistry;
 use crate::provider::{ChatMessage, ContentPart, Provider, Role, ToolCall};
 use crate::session::{ConversationKey, SessionStore, local_date_for_timestamp};
 use crate::tools::ToolSet;
@@ -13,6 +14,15 @@ use tracing::{debug, error, info, warn};
 
 /// Maximum number of tool-call rounds per message to prevent infinite loops.
 const MAX_TOOL_ROUNDS: usize = 10;
+
+impl Agent {
+    /// Resolve the provider that should serve `room_id`, honouring the
+    /// room → profile → provider mapping defined in `Config`. Falls back to
+    /// the Anthropic provider when no profile applies.
+    fn provider_for(&self, room_id: &str) -> Arc<dyn Provider> {
+        self.providers.for_room(&self.config, room_id)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // System prompt snapshot (frozen per ConversationKey, refreshed daily)
@@ -30,7 +40,7 @@ struct SystemSnapshot {
 pub struct Agent {
     config: Config,
     channel: Arc<dyn Channel>,
-    provider: Arc<dyn Provider>,
+    providers: Arc<ProviderRegistry>,
     workspace: Arc<Workspace>,
     tools: Option<Arc<ToolSet>>,
     session_store: Arc<SessionStore>,
@@ -62,7 +72,7 @@ impl Agent {
     pub fn new(
         config: Config,
         channel: Arc<dyn Channel>,
-        provider: Arc<dyn Provider>,
+        providers: Arc<ProviderRegistry>,
         workspace: Arc<Workspace>,
         tools: Option<Arc<ToolSet>>,
         session_store: Arc<SessionStore>,
@@ -77,7 +87,7 @@ impl Agent {
         Self {
             config,
             channel,
-            provider,
+            providers,
             workspace,
             tools,
             session_store,
@@ -166,7 +176,8 @@ impl Agent {
                     _ => continue,
                 }
             };
-            match generate_summary(&*self.provider, &messages).await {
+            let provider = self.provider_for(&key.0);
+            match generate_summary(&*provider, &messages).await {
                 Ok(summary) if !summary.trim().is_empty() => {
                     if let Err(e) = self.session_store.append_summary(&session_id, &summary) {
                         warn!("Failed to persist fallback summary for {session_id}: {e}");
@@ -210,8 +221,9 @@ impl Agent {
             snapshot.len()
         );
 
-        for (_key, session_id, messages) in snapshot {
-            match generate_summary(&*self.provider, &messages).await {
+        for (key, session_id, messages) in snapshot {
+            let provider = self.provider_for(&key.0);
+            match generate_summary(&*provider, &messages).await {
                 Ok(summary) if !summary.trim().is_empty() => {
                     if let Err(e) = self.session_store.append_summary(&session_id, &summary) {
                         warn!("Failed to persist shutdown summary for {session_id}: {e}");
@@ -441,7 +453,8 @@ impl Agent {
 
         info!("Day boundary crossed for {key:?}; compacting session {session_id}");
 
-        let summary = match generate_summary(&*self.provider, &messages).await {
+        let provider = self.provider_for(&key.0);
+        let summary = match generate_summary(&*provider, &messages).await {
             Ok(s) if !s.trim().is_empty() => s,
             Ok(_) => {
                 warn!("Boundary summary for {session_id} was empty; skipping");
@@ -627,8 +640,9 @@ impl Agent {
             }
 
             // Check if context compression is needed
+            let provider = self.provider_for(&incoming.room_id);
             let messages = match maybe_compress(
-                &*self.provider,
+                &*provider,
                 system_with_context.as_deref(),
                 &messages,
                 &compression_config,
@@ -654,8 +668,7 @@ impl Agent {
                 }
             };
 
-            let response = self
-                .provider
+            let response = provider
                 .chat(
                     system_with_context.as_deref(),
                     &messages,

--- a/src/config.rs
+++ b/src/config.rs
@@ -647,6 +647,20 @@ profile = "missing"
     }
 
     #[test]
+    fn shipped_example_parses() {
+        // Sanity check: the example file we ship in the repo must parse
+        // and validate without errors so first-time users aren't greeted
+        // with a confusing TOML error.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config.example.toml");
+        let cfg = Config::load(&path).expect("config.example.toml should parse");
+        assert!(
+            cfg.validate_profiles().is_empty(),
+            "validation errors: {:?}",
+            cfg.validate_profiles()
+        );
+    }
+
+    #[test]
     fn provider_config_parses_openai_compatible() {
         let cfg = parse(
             r#"

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,15 @@ pub struct Config {
     /// Per-room overrides keyed by `room_id`.
     #[serde(default)]
     pub rooms: HashMap<String, RoomConfig>,
+    /// Additional LLM providers beyond the built-in `anthropic` one.
+    /// Keyed by user-chosen name (e.g. `"local"`, `"openai"`).
+    #[serde(default)]
+    pub providers: HashMap<String, ProviderConfig>,
+    /// Named profiles that bind a use-case (e.g. `"default"`, `"nsfw"`)
+    /// to a provider name. Rooms select a profile via `RoomConfig.profile`;
+    /// the API can also pass a profile name on a per-request basis.
+    #[serde(default)]
+    pub profiles: HashMap<String, ProfileConfig>,
     /// Whether to generate a daily log at the day boundary. Default: true.
     #[serde(default = "default_true")]
     pub daily_log_enabled: bool,
@@ -107,7 +116,45 @@ pub enum SessionPolicy {
 pub struct RoomConfig {
     /// Override the day-boundary session policy for this room.
     pub session_policy: Option<SessionPolicy>,
+    /// Profile name to use for this room. If unset, falls back to the
+    /// `"default"` profile when defined, otherwise the built-in
+    /// `anthropic` provider.
+    pub profile: Option<String>,
 }
+
+/// Definition of an additional LLM provider.
+///
+/// Tagged by `type` to allow future provider kinds. Currently only
+/// `openai_compatible` is supported.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ProviderConfig {
+    /// llama.cpp `llama-server`, OpenAI proper, Ollama, vLLM, etc.
+    #[serde(rename = "openai_compatible")]
+    OpenAiCompatible(crate::provider::openai_compatible::OpenAICompatibleConfig),
+}
+
+/// Definition of a named profile.
+///
+/// A profile picks a provider (and optionally a fallback) for a given
+/// use-case. The `"default"` profile, if defined, is used by rooms that
+/// don't specify their own profile.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProfileConfig {
+    /// Name of the provider to use. Either `"anthropic"` (built-in) or a
+    /// key from the top-level `[providers]` table.
+    pub provider: String,
+    /// Optional fallback provider used when the primary refuses a request
+    /// (e.g. NSFW content). Wired up by the routing layer.
+    #[serde(default)]
+    pub fallback_provider: Option<String>,
+}
+
+/// Built-in name of the Anthropic provider — referenced by profiles.
+pub const ANTHROPIC_PROVIDER_NAME: &str = "anthropic";
+
+/// Conventional name of the default profile.
+pub const DEFAULT_PROFILE_NAME: &str = "default";
 
 /// Configuration for the HTTP API server (serve command).
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -413,12 +460,212 @@ impl Config {
             .unwrap_or(self.session_policy)
     }
 
+    /// Resolve the profile name for a given `room_id`.
+    ///
+    /// Order: explicit room override > `"default"` profile if defined >
+    /// `None` (caller should fall back to the built-in anthropic provider).
+    pub fn profile_for(&self, room_id: &str) -> Option<&str> {
+        if let Some(name) = self
+            .rooms
+            .get(room_id)
+            .and_then(|r| r.profile.as_deref())
+        {
+            return Some(name);
+        }
+        if self.profiles.contains_key(DEFAULT_PROFILE_NAME) {
+            return Some(DEFAULT_PROFILE_NAME);
+        }
+        None
+    }
+
+    /// Resolve a profile name to its primary provider name.
+    ///
+    /// Returns `None` if the profile is not defined. Caller is expected to
+    /// fall back to the built-in anthropic provider in that case.
+    pub fn provider_for_profile(&self, profile_name: &str) -> Option<&str> {
+        self.profiles
+            .get(profile_name)
+            .map(|p| p.provider.as_str())
+    }
+
+    /// Validate that every profile points to a known provider, and that
+    /// every room's `profile` references a defined profile. Returns
+    /// human-readable error messages for each issue found.
+    pub fn validate_profiles(&self) -> Vec<String> {
+        let mut errors = Vec::new();
+        let known_provider = |name: &str| -> bool {
+            name == ANTHROPIC_PROVIDER_NAME || self.providers.contains_key(name)
+        };
+        for (pname, prof) in &self.profiles {
+            if !known_provider(&prof.provider) {
+                errors.push(format!(
+                    "profile '{pname}' references unknown provider '{}'",
+                    prof.provider
+                ));
+            }
+            if let Some(fb) = &prof.fallback_provider {
+                if !known_provider(fb) {
+                    errors.push(format!(
+                        "profile '{pname}' references unknown fallback_provider '{fb}'"
+                    ));
+                }
+            }
+        }
+        for (rid, rcfg) in &self.rooms {
+            if let Some(pname) = &rcfg.profile {
+                if !self.profiles.contains_key(pname) {
+                    errors.push(format!(
+                        "room '{rid}' references unknown profile '{pname}'"
+                    ));
+                }
+            }
+        }
+        errors
+    }
+
     /// Resolve the default config path: `~/.config/sapphire-agent/config.toml`
     pub fn default_path() -> PathBuf {
         if let Some(dirs) = directories::ProjectDirs::from("", "", "sapphire-agent") {
             dirs.config_dir().join("config.toml")
         } else {
             PathBuf::from("config.toml")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Config {
+        toml::from_str(s).expect("config should parse")
+    }
+
+    const MINIMAL: &str = r#"
+[anthropic]
+api_key = "test"
+"#;
+
+    #[test]
+    fn no_profiles_means_no_resolution() {
+        let cfg = parse(MINIMAL);
+        assert!(cfg.profile_for("!any:srv").is_none());
+        assert!(cfg.validate_profiles().is_empty());
+    }
+
+    #[test]
+    fn default_profile_is_used_when_room_unspecified() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.default]
+provider = "anthropic"
+"#,
+        );
+        assert_eq!(cfg.profile_for("!some:srv"), Some("default"));
+    }
+
+    #[test]
+    fn room_override_wins_over_default_profile() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.default]
+provider = "anthropic"
+
+[profiles.nsfw]
+provider = "local"
+
+[rooms."!nsfw:srv"]
+profile = "nsfw"
+"#,
+        );
+        assert_eq!(cfg.profile_for("!nsfw:srv"), Some("nsfw"));
+        assert_eq!(cfg.profile_for("!other:srv"), Some("default"));
+        assert_eq!(cfg.provider_for_profile("nsfw"), Some("local"));
+        assert_eq!(cfg.provider_for_profile("default"), Some("anthropic"));
+        assert!(cfg.validate_profiles().is_empty());
+    }
+
+    #[test]
+    fn validate_flags_unknown_provider_in_profile() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.default]
+provider = "ghost"
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(errors[0].contains("ghost"));
+    }
+
+    #[test]
+    fn validate_flags_unknown_fallback_provider() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.default]
+provider = "anthropic"
+fallback_provider = "ghost"
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("fallback"));
+        assert!(errors[0].contains("ghost"));
+    }
+
+    #[test]
+    fn validate_flags_unknown_profile_in_room() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[rooms."!x:srv"]
+profile = "missing"
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("missing"));
+    }
+
+    #[test]
+    fn provider_config_parses_openai_compatible() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+"#,
+        );
+        let local = cfg.providers.get("local").expect("local provider present");
+        match local {
+            ProviderConfig::OpenAiCompatible(c) => {
+                assert_eq!(c.base_url, "http://127.0.0.1:8080/v1");
+                assert_eq!(c.model, "gemma-4-31b-it");
+                assert!(c.api_key.is_none());
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,13 @@ pub const ANTHROPIC_PROVIDER_NAME: &str = "anthropic";
 /// Conventional name of the default profile.
 pub const DEFAULT_PROFILE_NAME: &str = "default";
 
+/// Conventional name of the profile used by background tasks (daily-log,
+/// memory compaction, periodic digests). When this profile is defined the
+/// background tasks honour its `provider` and `fallback_provider`; when
+/// it isn't, those tasks run on the built-in Anthropic provider with no
+/// fallback.
+pub const BACKGROUND_PROFILE_NAME: &str = "background";
+
 /// Configuration for the HTTP API server (serve command).
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ServeConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,10 +263,10 @@ async fn main() -> Result<()> {
                 ProviderRegistry::from_config(&config)
                     .context("Failed to build provider registry")?,
             );
-            // Heartbeat / serve / daily-log use a single provider directly.
-            // Until per-room routing is plumbed through those code paths
-            // (see C3/C4), they keep using the Anthropic default.
-            let provider: Arc<dyn provider::Provider> = registry.anthropic();
+            // Heartbeat / serve / daily-log run on the "background" profile
+            // when defined (with optional refusal fallback) and on plain
+            // Anthropic otherwise.
+            let provider: Arc<dyn provider::Provider> = registry.background_provider(&config);
 
             // ── API session store (sessions/api/) ───────────────────────────
             let api_session_store = Arc::new(SessionStore::with_workspace(

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use periodic_log::{
     catchup_missing_daily_digests, catchup_pending_daily_logs, catchup_pending_monthly_logs,
     catchup_pending_weekly_logs, catchup_pending_yearly_logs,
 };
-use provider::anthropic::AnthropicProvider;
+use provider::registry::ProviderRegistry;
 use sapphire_workspace::{AppContext, DeviceDefaults, Workspace as SwWorkspace, WorkspaceState};
 
 static APP_CTX: AppContext = AppContext::new("sapphire-agent").allow_external_paths();
@@ -254,9 +254,19 @@ async fn main() -> Result<()> {
             // ── Session store base directory ────────────────────────────────
             let sessions_base = config.resolved_sessions_dir(&workspace_dir);
 
-            // ── Provider ────────────────────────────────────────────────────
-            let provider: Arc<dyn provider::Provider> =
-                Arc::new(AnthropicProvider::new(&config.anthropic));
+            // ── Provider registry ────────────────────────────────────────────
+            // Builds the Anthropic provider plus any `[providers.<name>]`
+            // entries, then validates every profile/room reference. Failure
+            // here is fatal — better to refuse to start than to surprise the
+            // user mid-session with a misrouted request.
+            let registry = Arc::new(
+                ProviderRegistry::from_config(&config)
+                    .context("Failed to build provider registry")?,
+            );
+            // Heartbeat / serve / daily-log use a single provider directly.
+            // Until per-room routing is plumbed through those code paths
+            // (see C3/C4), they keep using the Anthropic default.
+            let provider: Arc<dyn provider::Provider> = registry.anthropic();
 
             // ── API session store (sessions/api/) ───────────────────────────
             let api_session_store = Arc::new(SessionStore::with_workspace(
@@ -351,7 +361,7 @@ async fn main() -> Result<()> {
                 let agent = Arc::new(Agent::new(
                     config.clone(),
                     channel,
-                    Arc::clone(&provider),
+                    Arc::clone(&registry),
                     Arc::clone(&workspace),
                     Some(Arc::clone(&tool_set)),
                     Arc::clone(&channel_session_store),

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,11 @@ enum Command {
         /// and --message; ignored in REPL mode.
         #[arg(long)]
         json: bool,
+        /// Profile name to bind to a newly created session. Must match a
+        /// `[profiles.<name>]` entry on the server side. Ignored when
+        /// resuming an existing session via --session.
+        #[arg(long)]
+        profile: Option<String>,
     },
 }
 
@@ -139,9 +144,10 @@ async fn main() -> Result<()> {
         message,
         history,
         json,
+        profile,
     }) = cli.command
     {
-        return call::run(server, session, list, message, history, json).await;
+        return call::run(server, session, list, message, history, json, profile).await;
     }
 
     let config_path = cli.config.unwrap_or_else(Config::default_path);
@@ -427,7 +433,7 @@ async fn main() -> Result<()> {
                 serve::run(
                     addr,
                     config,
-                    provider,
+                    Arc::clone(&registry),
                     workspace,
                     tool_set,
                     api_session_store,

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -218,7 +218,6 @@ enum Delta {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 struct MessageDeltaData {
     stop_reason: Option<String>,
 }
@@ -362,6 +361,7 @@ impl Provider for AnthropicProvider {
         let mut buffer = String::new();
         // BTreeMap preserves insertion order by index.
         let mut blocks: BTreeMap<usize, Block> = BTreeMap::new();
+        let mut stop_reason: Option<String> = None;
 
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.context("Error reading SSE stream")?;
@@ -417,6 +417,11 @@ impl Provider for AnthropicProvider {
                                 }
                             }
                         },
+                        Ok(SseEvent::MessageDelta { delta }) => {
+                            if let Some(reason) = delta.stop_reason {
+                                stop_reason = Some(reason);
+                            }
+                        }
                         Ok(SseEvent::Error { error }) => {
                             bail!("Anthropic stream error: {}", error.message);
                         }
@@ -459,6 +464,10 @@ impl Provider for AnthropicProvider {
         } else {
             Some(text_parts.join(""))
         };
-        Ok(ChatResponse { text, tool_calls })
+        Ok(ChatResponse {
+            text,
+            tool_calls,
+            stop_reason,
+        })
     }
 }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -1,0 +1,279 @@
+//! Refusal-fallback wrapper.
+//!
+//! Wraps a primary provider together with a fallback. The primary is tried
+//! first; if it appears to refuse the request (content-policy stop reason
+//! or a recognised apology pattern in the text) or errors out entirely,
+//! the same call is replayed against the fallback.
+//!
+//! This is the layer that lets the daily-log / memory-compaction code keep
+//! running on the Anthropic provider for everyday content but quietly hand
+//! off to a permissive local model when a session contains material
+//! Anthropic refuses to summarise.
+
+use crate::provider::{ChatMessage, ChatResponse, Provider, ToolSpec};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+pub struct FallbackProvider {
+    primary: Arc<dyn Provider>,
+    fallback: Arc<dyn Provider>,
+}
+
+impl FallbackProvider {
+    pub fn new(primary: Arc<dyn Provider>, fallback: Arc<dyn Provider>) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+/// Heuristic check for a refusal response.
+///
+/// Order of signals:
+/// 1. Provider-reported `stop_reason` of `"refusal"` (Anthropic) or
+///    `"content_filter"` (OpenAI-compatible). These are the strongest
+///    signals and match no legitimate response.
+/// 2. Short text-only response (no tool calls, capped length) whose
+///    leading sentence matches an apology pattern. The leading-pattern
+///    + length + no-tools combination keeps false positives down on
+///    legitimate "I can't find that file" style answers.
+pub fn is_refusal(resp: &ChatResponse) -> bool {
+    if matches!(
+        resp.stop_reason.as_deref(),
+        Some("refusal") | Some("content_filter")
+    ) {
+        return true;
+    }
+    if !resp.tool_calls.is_empty() {
+        return false;
+    }
+    let Some(text) = resp.text.as_deref() else {
+        return false;
+    };
+    // Long responses are almost certainly genuine answers, not apologies.
+    if text.chars().count() > 600 {
+        return false;
+    }
+    let head = text
+        .trim_start()
+        .chars()
+        .take(120)
+        .collect::<String>()
+        .to_lowercase();
+    const PATTERNS: &[&str] = &[
+        "i can't help",
+        "i cannot help",
+        "i can't assist",
+        "i cannot assist",
+        "i'm not able to",
+        "i am not able to",
+        "i'm unable to",
+        "i am unable to",
+        "i won't",
+        "i will not",
+        "申し訳",
+        "お手伝いできません",
+        "対応できません",
+    ];
+    PATTERNS.iter().any(|p| head.contains(p))
+}
+
+#[async_trait]
+impl Provider for FallbackProvider {
+    fn name(&self) -> &str {
+        self.primary.name()
+    }
+
+    async fn chat(
+        &self,
+        system: Option<&str>,
+        messages: &[ChatMessage],
+        tools: Option<&[ToolSpec]>,
+    ) -> Result<ChatResponse> {
+        match self.primary.chat(system, messages, tools).await {
+            Ok(resp) if is_refusal(&resp) => {
+                info!(
+                    "Primary provider '{}' refused; retrying via fallback '{}'",
+                    self.primary.name(),
+                    self.fallback.name()
+                );
+                self.fallback.chat(system, messages, tools).await
+            }
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                warn!(
+                    "Primary provider '{}' errored ({e:#}); retrying via fallback '{}'",
+                    self.primary.name(),
+                    self.fallback.name()
+                );
+                self.fallback.chat(system, messages, tools).await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{ChatMessage, ChatResponse, ToolCall};
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// Test double: returns a queued response on each call and records the
+    /// number of times it was invoked.
+    struct ScriptedProvider {
+        name: String,
+        responses: Mutex<Vec<Result<ChatResponse, String>>>,
+        calls: Mutex<usize>,
+    }
+
+    impl ScriptedProvider {
+        fn new(name: &str, responses: Vec<Result<ChatResponse, String>>) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                responses: Mutex::new(responses),
+                calls: Mutex::new(0),
+            })
+        }
+
+        fn calls(&self) -> usize {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for ScriptedProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn chat(
+            &self,
+            _system: Option<&str>,
+            _messages: &[ChatMessage],
+            _tools: Option<&[ToolSpec]>,
+        ) -> Result<ChatResponse> {
+            *self.calls.lock().unwrap() += 1;
+            let next = self.responses.lock().unwrap().remove(0);
+            next.map_err(|e| anyhow::anyhow!(e))
+        }
+    }
+
+    fn refusal_response() -> ChatResponse {
+        ChatResponse {
+            text: Some("I can't help with that request.".into()),
+            tool_calls: vec![],
+            stop_reason: Some("refusal".into()),
+        }
+    }
+
+    fn ok_response(text: &str) -> ChatResponse {
+        ChatResponse {
+            text: Some(text.into()),
+            tool_calls: vec![],
+            stop_reason: Some("end_turn".into()),
+        }
+    }
+
+    #[test]
+    fn refusal_stop_reason_is_detected() {
+        assert!(is_refusal(&refusal_response()));
+    }
+
+    #[test]
+    fn content_filter_stop_reason_is_detected() {
+        let resp = ChatResponse {
+            text: Some("...".into()),
+            tool_calls: vec![],
+            stop_reason: Some("content_filter".into()),
+        };
+        assert!(is_refusal(&resp));
+    }
+
+    #[test]
+    fn apology_pattern_without_stop_reason_is_detected() {
+        let resp = ChatResponse {
+            text: Some("I'm unable to assist with that one.".into()),
+            tool_calls: vec![],
+            stop_reason: Some("end_turn".into()),
+        };
+        assert!(is_refusal(&resp));
+    }
+
+    #[test]
+    fn legitimate_short_answer_is_not_a_refusal() {
+        let resp = ChatResponse {
+            text: Some("The file is at src/main.rs.".into()),
+            tool_calls: vec![],
+            stop_reason: Some("end_turn".into()),
+        };
+        assert!(!is_refusal(&resp));
+    }
+
+    #[test]
+    fn long_response_is_not_a_refusal_even_if_apology_appears() {
+        let mut text = "I'm unable to immediately answer, but here's a detailed walkthrough: "
+            .to_string();
+        text.push_str(&"x".repeat(800));
+        let resp = ChatResponse {
+            text: Some(text),
+            tool_calls: vec![],
+            stop_reason: Some("end_turn".into()),
+        };
+        assert!(!is_refusal(&resp));
+    }
+
+    #[test]
+    fn tool_call_short_circuits_text_heuristic() {
+        let resp = ChatResponse {
+            text: Some("I can't help directly, calling tool…".into()),
+            tool_calls: vec![ToolCall {
+                id: "x".into(),
+                name: "y".into(),
+                input: json!({}),
+            }],
+            stop_reason: Some("tool_use".into()),
+        };
+        assert!(!is_refusal(&resp));
+    }
+
+    #[tokio::test]
+    async fn fallback_takes_over_on_refusal() {
+        let primary = ScriptedProvider::new("primary", vec![Ok(refusal_response())]);
+        let fallback = ScriptedProvider::new("fallback", vec![Ok(ok_response("done"))]);
+        let p: Arc<dyn Provider> = primary.clone();
+        let f: Arc<dyn Provider> = fallback.clone();
+        let wrap = FallbackProvider::new(p, f);
+        let resp = wrap.chat(None, &[], None).await.unwrap();
+        assert_eq!(resp.text.as_deref(), Some("done"));
+        assert_eq!(primary.calls(), 1);
+        assert_eq!(fallback.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn fallback_takes_over_on_error() {
+        let primary = ScriptedProvider::new("primary", vec![Err("boom".to_string())]);
+        let fallback = ScriptedProvider::new("fallback", vec![Ok(ok_response("done"))]);
+        let p: Arc<dyn Provider> = primary.clone();
+        let f: Arc<dyn Provider> = fallback.clone();
+        let wrap = FallbackProvider::new(p, f);
+        let resp = wrap.chat(None, &[], None).await.unwrap();
+        assert_eq!(resp.text.as_deref(), Some("done"));
+        assert_eq!(primary.calls(), 1);
+        assert_eq!(fallback.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn primary_success_skips_fallback() {
+        let primary = ScriptedProvider::new("primary", vec![Ok(ok_response("hi"))]);
+        let fallback = ScriptedProvider::new("fallback", vec![Ok(ok_response("nope"))]);
+        let p: Arc<dyn Provider> = primary.clone();
+        let f: Arc<dyn Provider> = fallback.clone();
+        let wrap = FallbackProvider::new(p, f);
+        let resp = wrap.chat(None, &[], None).await.unwrap();
+        assert_eq!(resp.text.as_deref(), Some("hi"));
+        assert_eq!(primary.calls(), 1);
+        assert_eq!(fallback.calls(), 0);
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod fallback;
 pub mod openai_compatible;
 pub mod registry;
 
@@ -168,6 +169,12 @@ impl ChatMessage {
 pub struct ChatResponse {
     pub text: Option<String>,
     pub tool_calls: Vec<ToolCall>,
+    /// Provider-reported stop / finish reason. Captured verbatim so that
+    /// higher-level wrappers (notably the refusal-fallback layer) can
+    /// inspect it. Anthropic emits values like `"end_turn"`, `"refusal"`,
+    /// `"max_tokens"`; OpenAI-compatible servers emit `"stop"`,
+    /// `"content_filter"`, `"length"`, etc.
+    pub stop_reason: Option<String>,
 }
 
 impl ChatResponse {
@@ -175,6 +182,7 @@ impl ChatResponse {
         Self {
             text: Some(text),
             tool_calls: vec![],
+            stop_reason: None,
         }
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod openai_compatible;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod openai_compatible;
+pub mod registry;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -169,6 +169,10 @@ struct StreamChunk {
 struct StreamChoice {
     #[serde(default)]
     delta: StreamDelta,
+    /// Populated on the final chunk: `"stop"`, `"length"`,
+    /// `"content_filter"`, `"tool_calls"`, etc.
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -398,6 +402,7 @@ impl Provider for OpenAICompatibleProvider {
         let mut buffer = String::new();
         let mut text_acc = String::new();
         let mut tool_acc: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
+        let mut stop_reason: Option<String> = None;
 
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.context("Error reading SSE stream")?;
@@ -423,6 +428,9 @@ impl Provider for OpenAICompatibleProvider {
                         }
                     };
                     for choice in parsed.choices {
+                        if let Some(reason) = choice.finish_reason {
+                            stop_reason = Some(reason);
+                        }
                         if let Some(t) = choice.delta.content {
                             text_acc.push_str(&t);
                         }
@@ -474,7 +482,11 @@ impl Provider for OpenAICompatibleProvider {
             Some(text_acc)
         };
 
-        Ok(ChatResponse { text, tool_calls })
+        Ok(ChatResponse {
+            text,
+            tool_calls,
+            stop_reason,
+        })
     }
 }
 

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -1,0 +1,602 @@
+//! OpenAI-compatible chat completions provider.
+//!
+//! Targets `POST {base_url}/chat/completions` with SSE streaming. Works
+//! against llama.cpp's `llama-server`, Ollama (`/v1`), vLLM, and the OpenAI
+//! API itself. Tool calls follow the OpenAI `tools` / `tool_calls` shape.
+
+use crate::provider::{ChatMessage, ChatResponse, ContentPart, Provider, Role, ToolCall, ToolSpec};
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use tracing::debug;
+
+/// Configuration for an OpenAI-compatible endpoint.
+///
+/// Not yet wired into the top-level `Config` — that's part of the
+/// multi-provider routing work. Construct directly for now.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OpenAICompatibleConfig {
+    /// Base URL up to and including the API version segment, e.g.
+    /// `http://127.0.0.1:8080/v1` for llama.cpp or
+    /// `https://api.openai.com/v1` for OpenAI proper.
+    pub base_url: String,
+    /// Bearer token. Optional — llama.cpp's local server does not require one.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Model identifier passed in the request body. For llama.cpp this can
+    /// be any string the server accepts (often ignored when only one model
+    /// is loaded).
+    pub model: String,
+    /// Provider name surfaced via `Provider::name()`. Defaults to
+    /// `"openai_compatible"`.
+    #[serde(default)]
+    pub provider_name: Option<String>,
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
+}
+
+fn default_max_tokens() -> u32 {
+    8192
+}
+
+pub struct OpenAICompatibleProvider {
+    base_url: String,
+    api_key: Option<String>,
+    model: String,
+    name: String,
+    max_tokens: u32,
+    client: Client,
+}
+
+impl OpenAICompatibleProvider {
+    pub fn new(cfg: &OpenAICompatibleConfig) -> Self {
+        let base_url = cfg.base_url.trim_end_matches('/').to_string();
+        Self {
+            base_url,
+            api_key: cfg.api_key.clone(),
+            model: cfg.model.clone(),
+            name: cfg
+                .provider_name
+                .clone()
+                .unwrap_or_else(|| "openai_compatible".to_string()),
+            max_tokens: cfg.max_tokens,
+            client: Client::new(),
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire-format types — request
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct Request<'a> {
+    model: &'a str,
+    messages: Vec<ApiMessage>,
+    max_tokens: u32,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ApiToolSpec<'a>>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiToolSpec<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    function: ApiToolFunction<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiToolFunction<'a> {
+    name: &'a str,
+    description: &'a str,
+    parameters: &'a Value,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiMessage {
+    role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<ApiContent>,
+    /// Present on assistant messages that emit tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<ApiAssistantToolCall>>,
+    /// Present on `tool` role messages — links the result to a prior call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ApiContent {
+    /// Plain string — used for simple text-only messages and tool results.
+    Text(String),
+    /// Array of typed parts — required when images are present.
+    Parts(Vec<ApiPart>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ApiPart {
+    Text {
+        text: String,
+    },
+    ImageUrl {
+        image_url: ApiImageUrl,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct ApiImageUrl {
+    /// `data:<media_type>;base64,<data>` for inline images.
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiAssistantToolCall {
+    id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    function: ApiAssistantToolFunction,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiAssistantToolFunction {
+    name: String,
+    /// JSON-encoded string of the arguments object.
+    arguments: String,
+}
+
+// ---------------------------------------------------------------------------
+// Wire-format types — streaming response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct StreamChunk {
+    #[serde(default)]
+    choices: Vec<StreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamChoice {
+    #[serde(default)]
+    delta: StreamDelta,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct StreamDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallDelta {
+    /// Position within the assistant message's tool_calls array. Used as the
+    /// accumulator key — the same call streams in across multiple chunks at
+    /// the same `index`.
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<StreamFunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Conversion: ChatMessage -> ApiMessage(s)
+// ---------------------------------------------------------------------------
+
+/// Convert one logical `ChatMessage` into one or more wire-level `ApiMessage`s.
+///
+/// OpenAI's protocol splits tool results into their own `role: "tool"`
+/// messages — one per result — whereas the internal `ChatMessage` collapses
+/// them into a single User message with multiple `ToolResult` parts.
+fn chat_message_to_api(msg: &ChatMessage) -> Vec<ApiMessage> {
+    match msg.role {
+        Role::User => convert_user_message(msg),
+        Role::Assistant => vec![convert_assistant_message(msg)],
+    }
+}
+
+fn convert_user_message(msg: &ChatMessage) -> Vec<ApiMessage> {
+    let mut out = Vec::new();
+    let mut text_parts: Vec<ApiPart> = Vec::new();
+
+    for part in &msg.parts {
+        match part {
+            ContentPart::Text(t) => text_parts.push(ApiPart::Text { text: t.clone() }),
+            ContentPart::Image {
+                media_type,
+                data_base64,
+            } => text_parts.push(ApiPart::ImageUrl {
+                image_url: ApiImageUrl {
+                    url: format!("data:{media_type};base64,{data_base64}"),
+                },
+            }),
+            ContentPart::ToolResult {
+                tool_use_id,
+                content,
+            } => {
+                out.push(ApiMessage {
+                    role: "tool",
+                    content: Some(ApiContent::Text(content.clone())),
+                    tool_calls: None,
+                    tool_call_id: Some(tool_use_id.clone()),
+                });
+            }
+            ContentPart::ToolUse { .. } => {
+                // Should not appear on User messages — silently skip.
+            }
+        }
+    }
+
+    if !text_parts.is_empty() {
+        let content = if text_parts.len() == 1 {
+            if let ApiPart::Text { text } = &text_parts[0] {
+                ApiContent::Text(text.clone())
+            } else {
+                ApiContent::Parts(text_parts)
+            }
+        } else {
+            ApiContent::Parts(text_parts)
+        };
+        out.push(ApiMessage {
+            role: "user",
+            content: Some(content),
+            tool_calls: None,
+            tool_call_id: None,
+        });
+    }
+
+    out
+}
+
+fn convert_assistant_message(msg: &ChatMessage) -> ApiMessage {
+    let mut text: Option<String> = None;
+    let mut tool_calls: Vec<ApiAssistantToolCall> = Vec::new();
+
+    for part in &msg.parts {
+        match part {
+            ContentPart::Text(t) => {
+                text.get_or_insert_with(String::new).push_str(t);
+            }
+            ContentPart::ToolUse { id, name, input } => {
+                tool_calls.push(ApiAssistantToolCall {
+                    id: id.clone(),
+                    kind: "function",
+                    function: ApiAssistantToolFunction {
+                        name: name.clone(),
+                        arguments: serde_json::to_string(input)
+                            .unwrap_or_else(|_| "{}".to_string()),
+                    },
+                });
+            }
+            // Assistant should not carry images or tool results.
+            ContentPart::Image { .. } | ContentPart::ToolResult { .. } => {}
+        }
+    }
+
+    ApiMessage {
+        role: "assistant",
+        content: text.map(ApiContent::Text),
+        tool_calls: if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        },
+        tool_call_id: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming accumulator
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct ToolCallAccum {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+// ---------------------------------------------------------------------------
+// Provider impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl Provider for OpenAICompatibleProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn chat(
+        &self,
+        system: Option<&str>,
+        messages: &[ChatMessage],
+        tools: Option<&[ToolSpec]>,
+    ) -> Result<ChatResponse> {
+        let mut api_messages: Vec<ApiMessage> = Vec::new();
+        if let Some(sys) = system {
+            api_messages.push(ApiMessage {
+                role: "system",
+                content: Some(ApiContent::Text(sys.to_string())),
+                tool_calls: None,
+                tool_call_id: None,
+            });
+        }
+        for m in messages {
+            api_messages.extend(chat_message_to_api(m));
+        }
+
+        let api_tools: Option<Vec<ApiToolSpec<'_>>> = tools.map(|specs| {
+            specs
+                .iter()
+                .map(|s| ApiToolSpec {
+                    kind: "function",
+                    function: ApiToolFunction {
+                        name: &s.name,
+                        description: &s.description,
+                        parameters: &s.input_schema,
+                    },
+                })
+                .collect()
+        });
+
+        let body = Request {
+            model: &self.model,
+            messages: api_messages,
+            max_tokens: self.max_tokens,
+            stream: true,
+            tools: api_tools,
+        };
+
+        let url = self.endpoint();
+        debug!(
+            "Sending request to OpenAI-compatible endpoint (url={url}, model={})",
+            self.model
+        );
+
+        let mut req = self
+            .client
+            .post(&url)
+            .header("content-type", "application/json")
+            .json(&body);
+        if let Some(key) = &self.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        let response = req
+            .send()
+            .await
+            .with_context(|| format!("Failed to send request to {url}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("OpenAI-compatible API error {status}: {body}");
+        }
+
+        // Parse SSE stream.
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut text_acc = String::new();
+        let mut tool_acc: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.context("Error reading SSE stream")?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buffer.find("\n\n") {
+                let event_str = buffer[..pos].to_string();
+                buffer.drain(..pos + 2);
+
+                for line in event_str.lines() {
+                    let Some(data) = line.strip_prefix("data: ") else {
+                        continue;
+                    };
+                    let data = data.trim();
+                    if data == "[DONE]" {
+                        break;
+                    }
+                    let parsed: StreamChunk = match serde_json::from_str(data) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            debug!("Failed to parse SSE chunk: {e} | data: {data}");
+                            continue;
+                        }
+                    };
+                    for choice in parsed.choices {
+                        if let Some(t) = choice.delta.content {
+                            text_acc.push_str(&t);
+                        }
+                        if let Some(deltas) = choice.delta.tool_calls {
+                            for d in deltas {
+                                let entry = tool_acc.entry(d.index).or_default();
+                                if let Some(id) = d.id {
+                                    if !id.is_empty() {
+                                        entry.id = id;
+                                    }
+                                }
+                                if let Some(f) = d.function {
+                                    if let Some(n) = f.name {
+                                        if !n.is_empty() {
+                                            entry.name = n;
+                                        }
+                                    }
+                                    if let Some(a) = f.arguments {
+                                        entry.arguments.push_str(&a);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let tool_calls: Vec<ToolCall> = tool_acc
+            .into_values()
+            .filter(|t| !t.name.is_empty())
+            .map(|t| {
+                let input: Value = if t.arguments.is_empty() {
+                    json!({})
+                } else {
+                    serde_json::from_str(&t.arguments).unwrap_or(json!({}))
+                };
+                ToolCall {
+                    id: t.id,
+                    name: t.name,
+                    input,
+                }
+            })
+            .collect();
+
+        let text = if text_acc.is_empty() {
+            None
+        } else {
+            Some(text_acc)
+        };
+
+        Ok(ChatResponse { text, tool_calls })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::ChatMessage;
+
+    #[test]
+    fn user_text_becomes_string_content() {
+        let msg = ChatMessage::user("hello");
+        let api = chat_message_to_api(&msg);
+        assert_eq!(api.len(), 1);
+        assert_eq!(api[0].role, "user");
+        let json = serde_json::to_value(&api[0]).unwrap();
+        assert_eq!(json["content"], "hello");
+    }
+
+    #[test]
+    fn user_with_image_uses_parts_array() {
+        let msg = ChatMessage::user_with_images(
+            "describe this",
+            vec![("image/png".to_string(), "AAAA".to_string())],
+        );
+        let api = chat_message_to_api(&msg);
+        assert_eq!(api.len(), 1);
+        let json = serde_json::to_value(&api[0]).unwrap();
+        let parts = json["content"].as_array().expect("content should be array");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "image_url");
+        assert_eq!(parts[0]["image_url"]["url"], "data:image/png;base64,AAAA");
+        assert_eq!(parts[1]["type"], "text");
+        assert_eq!(parts[1]["text"], "describe this");
+    }
+
+    #[test]
+    fn tool_results_split_into_separate_tool_messages() {
+        let msg = ChatMessage::tool_results(vec![
+            ("call_a".to_string(), "result_a".to_string()),
+            ("call_b".to_string(), "result_b".to_string()),
+        ]);
+        let api = chat_message_to_api(&msg);
+        assert_eq!(api.len(), 2);
+        assert_eq!(api[0].role, "tool");
+        assert_eq!(api[0].tool_call_id.as_deref(), Some("call_a"));
+        assert_eq!(api[1].role, "tool");
+        assert_eq!(api[1].tool_call_id.as_deref(), Some("call_b"));
+    }
+
+    #[test]
+    fn assistant_with_tool_use_serializes_tool_calls() {
+        let msg = ChatMessage::assistant_with_tools(
+            Some("I'll check.".to_string()),
+            vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "get_weather".to_string(),
+                input: json!({"city": "Tokyo"}),
+            }],
+        );
+        let api = chat_message_to_api(&msg);
+        assert_eq!(api.len(), 1);
+        let json = serde_json::to_value(&api[0]).unwrap();
+        assert_eq!(json["role"], "assistant");
+        assert_eq!(json["content"], "I'll check.");
+        let calls = json["tool_calls"].as_array().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["id"], "call_1");
+        assert_eq!(calls[0]["function"]["name"], "get_weather");
+        // arguments is a JSON-encoded string per OpenAI spec.
+        let args: Value = serde_json::from_str(calls[0]["function"]["arguments"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(args, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn endpoint_strips_trailing_slash() {
+        let p = OpenAICompatibleProvider::new(&OpenAICompatibleConfig {
+            base_url: "http://localhost:8080/v1/".to_string(),
+            api_key: None,
+            model: "gemma".to_string(),
+            provider_name: None,
+            max_tokens: 4096,
+        });
+        assert_eq!(p.endpoint(), "http://localhost:8080/v1/chat/completions");
+    }
+
+    #[test]
+    fn provider_name_default_and_override() {
+        let default = OpenAICompatibleProvider::new(&OpenAICompatibleConfig {
+            base_url: "http://x/v1".to_string(),
+            api_key: None,
+            model: "m".to_string(),
+            provider_name: None,
+            max_tokens: 1,
+        });
+        assert_eq!(default.name(), "openai_compatible");
+
+        let custom = OpenAICompatibleProvider::new(&OpenAICompatibleConfig {
+            base_url: "http://x/v1".to_string(),
+            api_key: None,
+            model: "m".to_string(),
+            provider_name: Some("llama_cpp".to_string()),
+            max_tokens: 1,
+        });
+        assert_eq!(custom.name(), "llama_cpp");
+    }
+
+    #[test]
+    fn role_is_assistant_when_no_text_only_tool_use() {
+        let msg = ChatMessage::assistant_with_tools(
+            None,
+            vec![ToolCall {
+                id: "c".into(),
+                name: "n".into(),
+                input: json!({}),
+            }],
+        );
+        let api = chat_message_to_api(&msg);
+        let json = serde_json::to_value(&api[0]).unwrap();
+        assert_eq!(json["role"], "assistant");
+        assert!(json.get("content").is_none() || json["content"].is_null());
+        assert!(json["tool_calls"].is_array());
+    }
+
+}

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -1,0 +1,198 @@
+//! Provider registry — bundles all configured `Provider` implementations
+//! together with the routing logic that picks one per `room_id`.
+//!
+//! Constructed once at startup from the parsed `Config`. The Anthropic
+//! provider is always present under the name [`ANTHROPIC_PROVIDER_NAME`];
+//! additional providers come from `[providers.<name>]` config entries.
+
+use crate::config::{ANTHROPIC_PROVIDER_NAME, Config, ProviderConfig};
+use crate::provider::Provider;
+use crate::provider::anthropic::AnthropicProvider;
+use crate::provider::openai_compatible::OpenAICompatibleProvider;
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct ProviderRegistry {
+    providers: HashMap<String, Arc<dyn Provider>>,
+}
+
+impl ProviderRegistry {
+    /// Build a registry from the parsed config.
+    ///
+    /// Always installs the Anthropic provider under `"anthropic"`. Each
+    /// `[providers.<name>]` entry adds another provider keyed by its
+    /// configured name. Profile validation is performed up front and
+    /// returned as an error so misconfigurations fail at startup rather
+    /// than mid-conversation.
+    pub fn from_config(config: &Config) -> Result<Self> {
+        let errors = config.validate_profiles();
+        if !errors.is_empty() {
+            anyhow::bail!("invalid profile configuration:\n  - {}", errors.join("\n  - "));
+        }
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            ANTHROPIC_PROVIDER_NAME.to_string(),
+            Arc::new(AnthropicProvider::new(&config.anthropic)),
+        );
+
+        for (name, pcfg) in &config.providers {
+            if name == ANTHROPIC_PROVIDER_NAME {
+                anyhow::bail!(
+                    "provider name '{ANTHROPIC_PROVIDER_NAME}' is reserved for the built-in"
+                );
+            }
+            let provider: Arc<dyn Provider> = match pcfg {
+                ProviderConfig::OpenAiCompatible(c) => {
+                    let mut cfg = c.clone();
+                    if cfg.provider_name.is_none() {
+                        cfg.provider_name = Some(name.clone());
+                    }
+                    Arc::new(OpenAICompatibleProvider::new(&cfg))
+                }
+            };
+            providers.insert(name.clone(), provider);
+        }
+
+        Ok(Self { providers })
+    }
+
+    /// Look up a provider by name. Returns `None` if no such provider was
+    /// registered.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Provider>> {
+        self.providers.get(name).cloned()
+    }
+
+    /// The built-in Anthropic provider — guaranteed to be present.
+    pub fn anthropic(&self) -> Arc<dyn Provider> {
+        self.providers
+            .get(ANTHROPIC_PROVIDER_NAME)
+            .cloned()
+            .expect("anthropic provider is always registered")
+    }
+
+    /// Resolve the provider that should handle a chat in `room_id`.
+    ///
+    /// Falls back to the Anthropic provider if (a) no profile is configured
+    /// for the room, (b) the resolved profile names a provider that isn't
+    /// registered (validation should have caught this — defensive only).
+    pub fn for_room(&self, config: &Config, room_id: &str) -> Arc<dyn Provider> {
+        let provider_name = config
+            .profile_for(room_id)
+            .and_then(|p| config.provider_for_profile(p))
+            .unwrap_or(ANTHROPIC_PROVIDER_NAME);
+        self.get(provider_name).unwrap_or_else(|| self.anthropic())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Config {
+        toml::from_str(s).expect("config should parse")
+    }
+
+    #[test]
+    fn registry_always_has_anthropic() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        assert!(reg.get(ANTHROPIC_PROVIDER_NAME).is_some());
+    }
+
+    #[test]
+    fn registry_loads_openai_compatible() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        let local = reg.get("local").expect("local provider registered");
+        // The provider's name should default to its registry key.
+        assert_eq!(local.name(), "local");
+    }
+
+    #[test]
+    fn from_config_rejects_invalid_profiles() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.default]
+provider = "ghost"
+"#,
+        );
+        let err = ProviderRegistry::from_config(&cfg).err()
+            .expect("expected an error");
+        assert!(format!("{err:#}").contains("ghost"));
+    }
+
+    #[test]
+    fn from_config_rejects_reserved_name() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.anthropic]
+type = "openai_compatible"
+base_url = "http://x/v1"
+model = "y"
+"#,
+        );
+        let err = ProviderRegistry::from_config(&cfg).err()
+            .expect("expected an error");
+        assert!(format!("{err:#}").contains("reserved"));
+    }
+
+    #[test]
+    fn for_room_falls_back_to_anthropic() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        let p = reg.for_room(&cfg, "!any:srv");
+        assert_eq!(p.name(), "anthropic");
+    }
+
+    #[test]
+    fn for_room_routes_to_configured_profile() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.nsfw]
+provider = "local"
+
+[rooms."!nsfw:srv"]
+profile = "nsfw"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        assert_eq!(reg.for_room(&cfg, "!nsfw:srv").name(), "local");
+        assert_eq!(reg.for_room(&cfg, "!other:srv").name(), "anthropic");
+    }
+}

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -5,9 +5,12 @@
 //! provider is always present under the name [`ANTHROPIC_PROVIDER_NAME`];
 //! additional providers come from `[providers.<name>]` config entries.
 
-use crate::config::{ANTHROPIC_PROVIDER_NAME, Config, ProviderConfig};
+use crate::config::{
+    ANTHROPIC_PROVIDER_NAME, BACKGROUND_PROFILE_NAME, Config, ProviderConfig,
+};
 use crate::provider::Provider;
 use crate::provider::anthropic::AnthropicProvider;
+use crate::provider::fallback::FallbackProvider;
 use crate::provider::openai_compatible::OpenAICompatibleProvider;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -77,12 +80,45 @@ impl ProviderRegistry {
     /// Falls back to the Anthropic provider if (a) no profile is configured
     /// for the room, (b) the resolved profile names a provider that isn't
     /// registered (validation should have caught this — defensive only).
+    /// When the profile defines a `fallback_provider`, the result is
+    /// wrapped in a `FallbackProvider` so refusals or errors transparently
+    /// retry on the secondary.
     pub fn for_room(&self, config: &Config, room_id: &str) -> Arc<dyn Provider> {
-        let provider_name = config
-            .profile_for(room_id)
-            .and_then(|p| config.provider_for_profile(p))
-            .unwrap_or(ANTHROPIC_PROVIDER_NAME);
-        self.get(provider_name).unwrap_or_else(|| self.anthropic())
+        let Some(profile_name) = config.profile_for(room_id) else {
+            return self.anthropic();
+        };
+        self.for_profile(config, profile_name)
+    }
+
+    /// Resolve the provider for a named profile, honouring its primary +
+    /// optional fallback. Falls back to the Anthropic provider if the
+    /// profile isn't defined or names an unknown provider.
+    pub fn for_profile(&self, config: &Config, profile_name: &str) -> Arc<dyn Provider> {
+        let Some(profile) = config.profiles.get(profile_name) else {
+            return self.anthropic();
+        };
+        let primary = self
+            .get(&profile.provider)
+            .unwrap_or_else(|| self.anthropic());
+        match profile
+            .fallback_provider
+            .as_deref()
+            .and_then(|n| self.get(n))
+        {
+            Some(fallback) => Arc::new(FallbackProvider::new(primary, fallback)),
+            None => primary,
+        }
+    }
+
+    /// Provider used by background tasks (daily-log, memory compaction,
+    /// digests). Resolves the conventional `[profiles.background]`; falls
+    /// back to plain Anthropic when that profile isn't defined.
+    pub fn background_provider(&self, config: &Config) -> Arc<dyn Provider> {
+        if config.profiles.contains_key(BACKGROUND_PROFILE_NAME) {
+            self.for_profile(config, BACKGROUND_PROFILE_NAME)
+        } else {
+            self.anthropic()
+        }
     }
 }
 
@@ -170,6 +206,79 @@ api_key = "test"
         let reg = ProviderRegistry::from_config(&cfg).unwrap();
         let p = reg.for_room(&cfg, "!any:srv");
         assert_eq!(p.name(), "anthropic");
+    }
+
+    #[test]
+    fn for_room_wraps_in_fallback_when_profile_defines_one() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.default]
+provider          = "anthropic"
+fallback_provider = "local"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        // FallbackProvider::name() forwards to the primary, so the name
+        // alone doesn't prove wrapping. Two registry pointers differ in
+        // identity, though: the wrapped Arc is freshly allocated.
+        let raw_anthropic = reg.anthropic();
+        let routed = reg.for_room(&cfg, "!any:srv");
+        assert_eq!(routed.name(), "anthropic");
+        assert!(
+            !Arc::ptr_eq(&raw_anthropic, &routed),
+            "expected a wrapped FallbackProvider, got the bare anthropic Arc"
+        );
+    }
+
+    #[test]
+    fn background_provider_uses_background_profile_when_present() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.background]
+provider          = "anthropic"
+fallback_provider = "local"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        let raw_anthropic = reg.anthropic();
+        let bg = reg.background_provider(&cfg);
+        assert!(
+            !Arc::ptr_eq(&raw_anthropic, &bg),
+            "background provider should be wrapped when profile has fallback"
+        );
+    }
+
+    #[test]
+    fn background_provider_defaults_to_anthropic_when_not_configured() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        let raw_anthropic = reg.anthropic();
+        let bg = reg.background_provider(&cfg);
+        assert!(
+            Arc::ptr_eq(&raw_anthropic, &bg),
+            "without [profiles.background], background should be plain anthropic"
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -7,6 +7,7 @@
 
 use crate::config::Config;
 use crate::context_compression::{generate_summary, maybe_compress};
+use crate::provider::registry::ProviderRegistry;
 use crate::provider::{ChatMessage, ContentPart, Provider};
 use crate::session::{ConversationKey, SessionStore};
 use crate::tools::ToolSet;
@@ -34,7 +35,7 @@ const MAX_TOOL_ROUNDS: usize = 10;
 
 pub struct ServeState {
     config: Config,
-    provider: Arc<dyn Provider>,
+    registry: Arc<ProviderRegistry>,
     workspace: Arc<Workspace>,
     tools: Arc<ToolSet>,
     api_session_store: Arc<SessionStore>,
@@ -46,6 +47,28 @@ pub struct ServeState {
     /// that quitting without sending anything leaves no empty file behind.
     /// Maps internal UUID → reserved public_id (grain-id).
     pending_sessions: tokio::sync::Mutex<HashMap<String, String>>,
+    /// Per-session profile assignment from `initialize`. Sessions absent from
+    /// this map fall through to the background provider. Not persisted across
+    /// restarts — clients must re-pass `profile` on resume.
+    session_profiles: tokio::sync::Mutex<HashMap<String, String>>,
+}
+
+impl ServeState {
+    /// Provider that should serve the given session: the profile-bound
+    /// primary (with optional refusal fallback) when the client picked a
+    /// profile at initialize-time, otherwise the background provider.
+    async fn provider_for_session(&self, session_id: &str) -> Arc<dyn Provider> {
+        let profile = self
+            .session_profiles
+            .lock()
+            .await
+            .get(session_id)
+            .cloned();
+        match profile {
+            Some(name) => self.registry.for_profile(&self.config, &name),
+            None => self.registry.background_provider(&self.config),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -104,19 +127,20 @@ fn error_event(id: &Value, code: i32, message: &str) -> Event {
 pub async fn run(
     addr: String,
     config: Config,
-    provider: Arc<dyn Provider>,
+    registry: Arc<ProviderRegistry>,
     workspace: Arc<Workspace>,
     tools: Arc<ToolSet>,
     api_session_store: Arc<SessionStore>,
 ) -> anyhow::Result<()> {
     let state = Arc::new(ServeState {
         config,
-        provider,
+        registry,
         workspace,
         tools,
         api_session_store,
         sessions: tokio::sync::Mutex::new(HashMap::new()),
         pending_sessions: tokio::sync::Mutex::new(HashMap::new()),
+        session_profiles: tokio::sync::Mutex::new(HashMap::new()),
     });
 
     let app = Router::new()
@@ -158,7 +182,8 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
         snapshot.len()
     );
     for (session_id, messages) in snapshot {
-        match generate_summary(&*state.provider, &messages).await {
+        let provider = state.provider_for_session(&session_id).await;
+        match generate_summary(&*provider, &messages).await {
             Ok(summary) if !summary.trim().is_empty() => {
                 if let Err(e) = state
                     .api_session_store
@@ -222,6 +247,20 @@ async fn handle_initialize(
     params: Option<Value>,
     existing_header_session: Option<String>,
 ) -> axum::response::Response {
+    // Optional `params.profile` — must reference a defined `[profiles.*]`
+    // entry. Rejected eagerly so misspellings surface at session start
+    // rather than as a silent fallback to the background provider.
+    let requested_profile: Option<String> = params
+        .as_ref()
+        .and_then(|p| p["profile"].as_str())
+        .map(|s| s.to_string());
+    if let Some(name) = &requested_profile {
+        if !state.config.profiles.contains_key(name) {
+            let body = error_response(req_id, -32602, &format!("Unknown profile '{name}'"));
+            return body.into_response();
+        }
+    }
+
     // Resolve to an internal UUID session_id.
     // - Mcp-Session-Id header: already a UUID (internal), use directly.
     // - params.session_id: must be a 7-char grain-id (public) or "new"/absent.
@@ -292,12 +331,23 @@ async fn handle_initialize(
             .and_then(|m| m.public_id)
     };
 
+    if let Some(name) = requested_profile {
+        state
+            .session_profiles
+            .lock()
+            .await
+            .insert(session_id.clone(), name);
+    }
+
     let mut result = json!({
         "session_id": session_id,
         "is_new": is_new,
     });
     if let Some(ref pub_id) = public_id {
         result["public_id"] = json!(pub_id);
+    }
+    if let Some(name) = state.session_profiles.lock().await.get(&session_id) {
+        result["profile"] = json!(name);
     }
 
     let body = json!({
@@ -499,7 +549,11 @@ async fn run_turn(
         warn!("Failed to ensure session file: {e}");
     }
 
-    // 3. System prompt (rebuilt fresh per request)
+    // 3. Resolve provider once per turn — sessions can pin a profile at
+    //    initialize-time; absent that, the background provider is used.
+    let provider = state.provider_for_session(&session_id).await;
+
+    // 3a. System prompt (rebuilt fresh per request)
     let system = {
         let sp = state
             .workspace
@@ -540,7 +594,7 @@ async fn run_turn(
 
         // Check if context compression is needed
         match maybe_compress(
-            &*state.provider,
+            &*provider,
             system.as_deref(),
             &history,
             &compression_config,
@@ -562,8 +616,7 @@ async fn run_turn(
             }
         }
 
-        let response = state
-            .provider
+        let response = provider
             .chat(system.as_deref(), &history, Some(&tool_specs))
             .await;
 
@@ -662,9 +715,8 @@ async fn run_turn(
             let sid = session_id.clone();
             let user_msg = user_message.clone();
             tokio::spawn(async move {
-                if let Some(title) =
-                    generate_session_title(&*state2.provider, &user_msg, &text).await
-                {
+                let p = state2.provider_for_session(&sid).await;
+                if let Some(title) = generate_session_title(&*p, &user_msg, &text).await {
                     if let Err(e) = state2.api_session_store.set_title(&sid, &title) {
                         warn!("Failed to store session title: {e}");
                     }


### PR DESCRIPTION
## Summary

Adds support for routing chat traffic to different LLM backends per Matrix/Discord room and per API session, plus a refusal-fallback layer for background tasks.

- New `OpenAICompatibleProvider` (llama.cpp / OpenAI / Ollama / vLLM) alongside the existing Anthropic provider.
- Config gains `[providers.<name>]`, `[profiles.<name>]`, and `RoomConfig.profile` for declarative routing. Validation runs once at startup.
- `ProviderRegistry` resolves the active provider per turn (`for_room` for Matrix/Discord, `for_profile` for API sessions, `background_provider` for daily-log/heartbeat/compaction).
- `FallbackProvider` retries on Anthropic `stop_reason = "refusal"` / OpenAI `finish_reason = "content_filter"` / apology-pattern detection, so a session that mixes safe-for-Anthropic and refused content can still produce its end-of-day summary via a permissive local model.
- API: `initialize` accepts an optional `profile` parameter; `--profile <name>` flag on `sapphire-agent call` and `sapphire-call`.

Existing single-provider deployments are unaffected — without `[providers]` / `[profiles]`, behaviour is unchanged.

## Commits

- \`bb12466\` provider: OpenAI-compatible chat provider
- \`28fedfd\` config: providers / profiles / room.profile schema + helpers
- \`2ba6d75\` agent: per-room routing via ProviderRegistry
- \`17f5d61\` docs: config.example.toml entries
- \`fe071e5\` provider: refusal-fallback layer + ChatResponse.stop_reason
- \`6838e73\` api: per-session profile selection

## Test plan

- [x] \`cargo test --workspace\` passes (79 binary tests + 0 in api/call crates)
- [ ] llama-server (Gemma 4 31B) end-to-end smoke test against a `[profiles.nsfw]` room
- [ ] daily-log refusal fallback verified manually with a session containing refused content
- [ ] `sapphire-call --profile <name>` against a running server

## Known follow-ups

- Profile assignment for API sessions is in-memory only; resuming with `--session` does not restore the prior profile (client must re-pass `--profile`). Consider persisting in `SessionMeta` later.
- llama.cpp multimodal (image + tools in one request) is unverified; recommended to test before relying on it for the local profile.
- Anthropic `light_model` keyword routing is unchanged — still only applies within the Anthropic provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)