### PR TITLE
feat: memory namespaces with explicit include hierarchy

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -126,10 +126,20 @@ system_prompt = "You are a helpful personal assistant."
 #
 # [memory_namespace.user_nsfw]
 # include = ["user"]
+# # background_profile pins which profile drives this namespace's
+# # daily-log generation, periodic digests, and MEMORY.md compaction.
+# # Useful for routing an NSFW namespace directly to a permissive local
+# # model instead of bouncing through Anthropic refusal-fallback every
+# # day. Resolution: this field > global [profiles.background] > plain
+# # Anthropic.
+# background_profile = "nsfw"
 #
 # [profiles.user_nsfw]
 # provider         = "local"
 # memory_namespace = "user_nsfw"
+#
+# [profiles.nsfw]
+# provider = "local"
 #
 # Caveat: workspace retrieve (FTS / vector search) currently spans every
 # namespace because sapphire-workspace 0.10.x has no path_prefix filter.

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,3 +103,35 @@ system_prompt = "You are a helpful personal assistant."
 # [profiles.background]
 # provider          = "anthropic"
 # fallback_provider = "local"
+
+# ── Memory namespaces ────────────────────────────────────────────────────
+# A memory namespace owns one subtree of `memory/`: its own MEMORY.md
+# plus the daily/weekly/monthly/yearly logs and digests. Profiles pin
+# their writes to one namespace via `profile.memory_namespace`, and
+# rooms / API sessions reading the system prompt also pull in the
+# parents declared via `include`. Reads chain through the include DAG;
+# writes go only to the leaf namespace.
+#
+# The `default` namespace is implicit (no need to declare it explicitly)
+# and is what every config without `[memory_namespace.*]` resolves to.
+# `default` is also the migration target — on first startup, an existing
+# pre-namespace `memory/{daily,weekly,...}/` tree is auto-moved to
+# `memory/default/{...}` so existing workspaces keep working unchanged.
+#
+# The hierarchy below stacks: a `user_nsfw` room reads `user_nsfw` +
+# `user` + `default`, but a bare `default` room sees nothing private.
+#
+# [memory_namespace.user]
+# include = ["default"]
+#
+# [memory_namespace.user_nsfw]
+# include = ["user"]
+#
+# [profiles.user_nsfw]
+# provider         = "local"
+# memory_namespace = "user_nsfw"
+#
+# Caveat: workspace retrieve (FTS / vector search) currently spans every
+# namespace because sapphire-workspace 0.10.x has no path_prefix filter.
+# Contamination prevention is digest- and MEMORY.md-only in this
+# release; retrieve hits may still leak across namespaces.

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,11 +34,11 @@ recovery_key = "EsT... "
 #   "none"    — no day-boundary action
 # session_policy = "compact"
 
-# Per-room overrides. Keys are room_ids; values may set session_policy
-# and/or pick a named profile (see [profiles] below).
-# [rooms."!roomid:example.com"]
-# session_policy = "reset"
-# profile        = "nsfw"
+# Per-room behaviour is configured via [room_profile.<n>] further down,
+# not via per-room blocks. A room profile bundles `(profile, namespace,
+# session_policy)` and applies to a list of rooms — perfect when several
+# rooms share the same setup, and trivial to add API access controls to
+# later (see issue #73).
 
 # Periodic log digests. The agent summarises weekly/monthly/yearly activity
 # into short importance-ordered bullet lists, stored as YAML frontmatter in
@@ -76,28 +76,30 @@ system_prompt = "You are a helpful personal assistant."
 # api_key  = ""                          # optional; llama.cpp does not need one
 # max_tokens = 4096
 
-# ── Profiles ────────────────────────────────────────────────────────────
-# A profile binds a use-case to a provider. Rooms select a profile via
-# `profile = "..."` in their `[rooms."<id>"]` block; the API may also pass
-# `profile` per request. The conventional `default` profile, when defined,
-# is used by rooms that don't pick one explicitly. Profiles that name an
-# unknown provider cause startup to fail.
+# ── Profiles (LLM presets) ──────────────────────────────────────────────
+# A profile is a *pure* LLM preset: a provider plus an optional
+# refusal-fallback provider. Profiles know nothing about rooms or memory
+# namespaces; pairings happen via [room_profile.<n>] (for chat) and
+# memory_namespace.<n>.background_profile (for daily-log / digests /
+# compaction). Profiles that name an unknown provider cause startup to
+# fail.
 #
 # `fallback_provider` is consulted at runtime: when the primary refuses
 # (Anthropic `stop_reason = "refusal"`, OpenAI `finish_reason =
 # "content_filter"`, or a recognised apology pattern) or errors out, the
 # call is replayed against the named fallback provider.
 #
-# The conventional `background` profile is what the daily-log generator,
-# memory compaction, and periodic digests run under. Defining it lets a
-# session that mixes safe-for-Anthropic and refused content still produce
-# its end-of-day summary by handing off the refused parts to a permissive
-# local model.
+# The conventional `background` profile is the workspace-wide fallback
+# for background tasks (daily-log generator, memory compaction, periodic
+# digests) when a memory namespace doesn't pin its own.
 #
 # [profiles.default]
 # provider = "anthropic"
 #
-# [profiles.nsfw]
+# [profiles.opus]
+# provider = "anthropic"            # use claude-opus-4-7 in [anthropic.model]
+#
+# [profiles.local]
 # provider = "local"
 #
 # [profiles.background]
@@ -106,11 +108,10 @@ system_prompt = "You are a helpful personal assistant."
 
 # ── Memory namespaces ────────────────────────────────────────────────────
 # A memory namespace owns one subtree of `memory/`: its own MEMORY.md
-# plus the daily/weekly/monthly/yearly logs and digests. Profiles pin
-# their writes to one namespace via `profile.memory_namespace`, and
-# rooms / API sessions reading the system prompt also pull in the
-# parents declared via `include`. Reads chain through the include DAG;
-# writes go only to the leaf namespace.
+# plus the daily/weekly/monthly/yearly logs and digests. Room profiles
+# pin their writes to one namespace; rooms reading the system prompt
+# also pull in parent namespaces declared via `include`. Reads chain
+# through the include DAG; writes go only to the leaf namespace.
 #
 # The `default` namespace is implicit (no need to declare it explicitly)
 # and is what every config without `[memory_namespace.*]` resolves to.
@@ -128,18 +129,39 @@ system_prompt = "You are a helpful personal assistant."
 # include = ["user"]
 # # background_profile pins which profile drives this namespace's
 # # daily-log generation, periodic digests, and MEMORY.md compaction.
-# # Useful for routing an NSFW namespace directly to a permissive local
-# # model instead of bouncing through Anthropic refusal-fallback every
-# # day. Resolution: this field > global [profiles.background] > plain
+# # Routes an NSFW namespace directly to a permissive local model
+# # instead of bouncing through Anthropic refusal-fallback every day.
+# # Resolution: this field > global [profiles.background] > plain
 # # Anthropic.
-# background_profile = "nsfw"
+# background_profile = "local"
+
+# ── Room profiles ───────────────────────────────────────────────────────
+# A room profile bundles a chat profile + memory namespace + session
+# policy and applies to a list of rooms (Matrix room_ids, Discord
+# channel ids, etc). Each room_id may appear in at most one room
+# profile. Rooms not listed anywhere fall back to [room_profile.default]
+# if defined, otherwise the built-in defaults (Anthropic provider,
+# `default` namespace, global session_policy).
 #
-# [profiles.user_nsfw]
-# provider         = "local"
+# API sessions pin a room profile at `initialize` time via the
+# `room_profile` parameter (sapphire-call: `--room-profile <name>`).
+#
+# [room_profile.everyday]
+# profile          = "default"
+# memory_namespace = "default"     # optional; defaults to "default"
+# session_policy   = "reset"       # optional; defaults to global setting
+# rooms            = ["!chat:example.com"]
+#
+# [room_profile.development]
+# profile = "opus"                 # higher-quality model for coding work
+# rooms   = ["!dev:example.com", "!code:example.com"]
+# # memory_namespace omitted → writes to "default" alongside everyday chat
+#
+# [room_profile.private_nsfw]
+# profile          = "local"
 # memory_namespace = "user_nsfw"
-#
-# [profiles.nsfw]
-# provider = "local"
+# session_policy   = "compact"
+# rooms            = ["!nsfw:example.com"]
 #
 # Caveat: workspace retrieve (FTS / vector search) currently spans every
 # namespace because sapphire-workspace 0.10.x has no path_prefix filter.

--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn run(
     message: Option<String>,
     history: bool,
     json: bool,
-    profile: Option<String>,
+    room_profile: Option<String>,
 ) -> Result<()> {
     let base = server.trim_end_matches('/').to_string();
     let client = reqwest::Client::new();
@@ -76,7 +76,7 @@ pub async fn run(
 
     // -- Initialize session ---------------------------------------------------
     let (mut mcp_session_id, actual_session_id, is_new) =
-        initialize_session(&client, &base, session, profile.as_deref()).await?;
+        initialize_session(&client, &base, session, room_profile.as_deref()).await?;
 
     // -- --history dump-only mode ---------------------------------------------
     if history {
@@ -132,7 +132,7 @@ pub async fn run(
                 continue;
             }
             "/clear" => {
-                match initialize_session(&client, &base, None, profile.as_deref()).await {
+                match initialize_session(&client, &base, None, room_profile.as_deref()).await {
                     Ok((new_mcp_id, new_session_id, _)) => {
                         mcp_session_id = new_mcp_id;
                         println!("[new session: {new_session_id}]");
@@ -162,12 +162,12 @@ async fn initialize_session(
     client: &reqwest::Client,
     base: &str,
     session: Option<String>,
-    profile: Option<&str>,
+    room_profile: Option<&str>,
 ) -> Result<(String, String, bool)> {
     let session_id_req = session.as_deref().unwrap_or("new");
     let mut params = json!({ "session_id": session_id_req });
-    if let Some(p) = profile {
-        params["profile"] = json!(p);
+    if let Some(p) = room_profile {
+        params["room_profile"] = json!(p);
     }
     let body = json!({
         "jsonrpc": "2.0",

--- a/crates/sapphire-call/src/main.rs
+++ b/crates/sapphire-call/src/main.rs
@@ -35,11 +35,11 @@ struct Cli {
     #[arg(long)]
     json: bool,
 
-    /// Profile name to bind to a newly created session. Must match a
-    /// `[profiles.<name>]` entry on the server side. Ignored when
+    /// Room profile name to bind to a newly created session. Must match a
+    /// `[room_profile.<name>]` entry on the server side. Ignored when
     /// resuming an existing session via --session.
     #[arg(long)]
-    profile: Option<String>,
+    room_profile: Option<String>,
 }
 
 #[tokio::main]
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
         cli.message,
         cli.history,
         cli.json,
-        cli.profile,
+        cli.room_profile,
     )
     .await
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -510,11 +510,14 @@ impl Agent {
             }
         }
 
+        let namespace = self.config.namespace_for_room(&key.0);
+        let chain = self.config.resolve_namespace_chain(namespace);
         let system_prompt = self
             .workspace
             .build_system_prompt(
                 self.config.anthropic.system_prompt.as_deref(),
                 self.config.day_boundary_hour,
+                &chain,
             )
             .await;
 
@@ -719,17 +722,28 @@ impl Agent {
                         .push(msg.clone());
                     self.persist(&session_id, &msg);
 
-                    // Execute tools concurrently
+                    // Execute tools concurrently. Each task gets the
+                    // room's memory namespace via task_local so the
+                    // memory tool writes under `memory/<namespace>/...`.
+                    // tokio::spawn does not propagate task_local, so we
+                    // re-bind it inside each spawned future.
                     let tools = Arc::clone(self.tools.as_ref().unwrap());
+                    let ns = self.config.namespace_for_room(&incoming.room_id).to_string();
                     let mut handles = Vec::with_capacity(tool_calls.len());
                     for call in tool_calls {
                         let tools = Arc::clone(&tools);
-                        handles.push(tokio::spawn(async move {
-                            info!("Executing tool: {} (id={})", call.name, call.id);
-                            let result = tools.execute(&call).await;
-                            info!("Tool {} result: {}", call.name, result);
-                            (call.id, result)
-                        }));
+                        let ns = ns.clone();
+                        handles.push(tokio::spawn(
+                            crate::tools::workspace_tools::scope_memory_namespace(
+                                ns,
+                                async move {
+                                    info!("Executing tool: {} (id={})", call.name, call.id);
+                                    let result = tools.execute(&call).await;
+                                    info!("Tool {} result: {}", call.name, result);
+                                    (call.id, result)
+                                },
+                            ),
+                        ));
                     }
 
                     let mut results = Vec::with_capacity(handles.len());

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,17 @@ pub struct Config {
     /// the API can also pass a profile name on a per-request basis.
     #[serde(default)]
     pub profiles: HashMap<String, ProfileConfig>,
+    /// Memory namespaces. Each namespace owns its own subtree under
+    /// `memory/<namespace>/` (daily/weekly/monthly/yearly logs and
+    /// MEMORY.md). Profiles pin their writes to one namespace, and
+    /// rooms reading the system prompt also pull in the parent
+    /// namespaces declared via `include`.
+    ///
+    /// The `"default"` namespace is implicitly present (with `include = []`)
+    /// even when no `[memory_namespace.*]` block is configured, so that
+    /// every config has a valid root.
+    #[serde(default, rename = "memory_namespace")]
+    pub memory_namespaces: HashMap<String, MemoryNamespaceConfig>,
     /// Whether to generate a daily log at the day boundary. Default: true.
     #[serde(default = "default_true")]
     pub daily_log_enabled: bool,
@@ -148,6 +159,25 @@ pub struct ProfileConfig {
     /// (e.g. NSFW content). Wired up by the routing layer.
     #[serde(default)]
     pub fallback_provider: Option<String>,
+    /// Memory namespace this profile reads and writes. Defaults to
+    /// `"default"`. Must reference a defined `[memory_namespace.<name>]`
+    /// (or the implicit `"default"`).
+    #[serde(default)]
+    pub memory_namespace: Option<String>,
+}
+
+/// Definition of a memory namespace — a subtree under `memory/<name>/`
+/// that owns its own MEMORY.md and periodic logs. The `include` list
+/// names parent namespaces whose memory should also be visible to
+/// rooms using this namespace; reads chain through the include DAG,
+/// writes go only to the leaf namespace.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MemoryNamespaceConfig {
+    /// Names of parent namespaces whose memory should be merged in
+    /// when assembling the system prompt for this namespace. Forms a
+    /// DAG; cycles are rejected at startup.
+    #[serde(default)]
+    pub include: Vec<String>,
 }
 
 /// Built-in name of the Anthropic provider — referenced by profiles.
@@ -162,6 +192,11 @@ pub const DEFAULT_PROFILE_NAME: &str = "default";
 /// it isn't, those tasks run on the built-in Anthropic provider with no
 /// fallback.
 pub const BACKGROUND_PROFILE_NAME: &str = "background";
+
+/// Implicit name of the root memory namespace. Always present, even when
+/// no `[memory_namespace.*]` block is configured — backstop so every
+/// profile / room resolves to a valid namespace.
+pub const DEFAULT_NAMESPACE_NAME: &str = "default";
 
 /// Configuration for the HTTP API server (serve command).
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -527,7 +562,144 @@ impl Config {
                 }
             }
         }
+        // Memory namespace references on profiles.
+        for (pname, prof) in &self.profiles {
+            if let Some(ns) = &prof.memory_namespace {
+                if !self.namespace_is_defined(ns) {
+                    errors.push(format!(
+                        "profile '{pname}' references unknown memory_namespace '{ns}'"
+                    ));
+                }
+            }
+        }
+        // Memory namespace include references and cycle detection.
+        for (ns_name, ns_cfg) in &self.memory_namespaces {
+            for parent in &ns_cfg.include {
+                if !self.namespace_is_defined(parent) {
+                    errors.push(format!(
+                        "memory_namespace '{ns_name}' includes unknown namespace '{parent}'"
+                    ));
+                }
+            }
+        }
+        for ns_name in self.memory_namespaces.keys() {
+            if let Some(cycle) = self.namespace_cycle_starting_at(ns_name) {
+                errors.push(format!(
+                    "memory_namespace cycle detected: {}",
+                    cycle.join(" -> ")
+                ));
+            }
+        }
         errors
+    }
+
+    /// True if `name` is either the implicit `"default"` namespace or has a
+    /// `[memory_namespace.<name>]` block.
+    fn namespace_is_defined(&self, name: &str) -> bool {
+        name == DEFAULT_NAMESPACE_NAME || self.memory_namespaces.contains_key(name)
+    }
+
+    /// DFS from `start` looking for back-edges. Returns the cyclic path
+    /// (start -> ... -> start) on detection, otherwise `None`.
+    fn namespace_cycle_starting_at(&self, start: &str) -> Option<Vec<String>> {
+        let mut stack: Vec<String> = vec![start.to_string()];
+        let mut on_stack = std::collections::HashSet::new();
+        on_stack.insert(start.to_string());
+
+        fn dfs(
+            cfg: &Config,
+            node: &str,
+            stack: &mut Vec<String>,
+            on_stack: &mut std::collections::HashSet<String>,
+        ) -> Option<Vec<String>> {
+            let parents: Vec<String> = cfg
+                .memory_namespaces
+                .get(node)
+                .map(|c| c.include.clone())
+                .unwrap_or_default();
+            for parent in parents {
+                if on_stack.contains(&parent) {
+                    let mut cycle: Vec<String> = stack.iter().cloned().collect();
+                    cycle.push(parent);
+                    return Some(cycle);
+                }
+                stack.push(parent.clone());
+                on_stack.insert(parent.clone());
+                if let Some(c) = dfs(cfg, &parent, stack, on_stack) {
+                    return Some(c);
+                }
+                stack.pop();
+                on_stack.remove(&parent);
+            }
+            None
+        }
+
+        dfs(self, start, &mut stack, &mut on_stack)
+    }
+
+    /// Resolve `name` to its include-chain in DFS pre-order: the namespace
+    /// itself first, then each parent in include order, with parents'
+    /// parents flattened in. Duplicates are removed (first occurrence
+    /// wins). The implicit `"default"` namespace, when not configured,
+    /// resolves to a single-entry chain `["default"]`.
+    pub fn resolve_namespace_chain(&self, name: &str) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        self.namespace_chain_walk(name, &mut out, &mut seen);
+        out
+    }
+
+    fn namespace_chain_walk(
+        &self,
+        name: &str,
+        out: &mut Vec<String>,
+        seen: &mut std::collections::HashSet<String>,
+    ) {
+        if !seen.insert(name.to_string()) {
+            return;
+        }
+        out.push(name.to_string());
+        if let Some(cfg) = self.memory_namespaces.get(name) {
+            for parent in &cfg.include {
+                self.namespace_chain_walk(parent, out, seen);
+            }
+        }
+    }
+
+    /// Resolve the memory namespace for a given profile.
+    ///
+    /// Order: explicit `profile.memory_namespace` > `"default"`.
+    pub fn namespace_for_profile(&self, profile_name: &str) -> &str {
+        self.profiles
+            .get(profile_name)
+            .and_then(|p| p.memory_namespace.as_deref())
+            .unwrap_or(DEFAULT_NAMESPACE_NAME)
+    }
+
+    /// Resolve the memory namespace for a given `room_id`. Combines
+    /// `profile_for` with `namespace_for_profile`; rooms without a profile
+    /// fall through to `"default"`.
+    pub fn namespace_for_room(&self, room_id: &str) -> &str {
+        match self.profile_for(room_id) {
+            Some(p) => self.namespace_for_profile(p),
+            None => DEFAULT_NAMESPACE_NAME,
+        }
+    }
+
+    /// Every memory namespace name relevant to this config: the implicit
+    /// `"default"`, every `[memory_namespace.<name>]` key, and every
+    /// namespace named by a profile. Used by background catch-up loops to
+    /// know what subtrees to enumerate.
+    pub fn all_memory_namespaces(&self) -> Vec<String> {
+        let mut out: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        out.insert(DEFAULT_NAMESPACE_NAME.to_string());
+        out.extend(self.memory_namespaces.keys().cloned());
+        for prof in self.profiles.values() {
+            if let Some(ns) = &prof.memory_namespace {
+                out.insert(ns.clone());
+            }
+        }
+        out.into_iter().collect()
     }
 
     /// Resolve the default config path: `~/.config/sapphire-agent/config.toml`
@@ -665,6 +837,171 @@ profile = "missing"
             "validation errors: {:?}",
             cfg.validate_profiles()
         );
+    }
+
+    #[test]
+    fn namespace_default_resolves_when_unconfigured() {
+        let cfg = parse(MINIMAL);
+        assert_eq!(
+            cfg.resolve_namespace_chain(DEFAULT_NAMESPACE_NAME),
+            vec!["default".to_string()]
+        );
+        assert_eq!(cfg.namespace_for_room("!any:srv"), "default");
+        assert!(cfg.validate_profiles().is_empty());
+    }
+
+    #[test]
+    fn namespace_chain_includes_parents_in_dfs_preorder() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.user]
+include = ["default"]
+
+[memory_namespace.user_nsfw]
+include = ["user"]
+"#,
+        );
+        assert_eq!(
+            cfg.resolve_namespace_chain("user_nsfw"),
+            vec!["user_nsfw".to_string(), "user".to_string(), "default".to_string()]
+        );
+        assert_eq!(
+            cfg.resolve_namespace_chain("user"),
+            vec!["user".to_string(), "default".to_string()]
+        );
+    }
+
+    #[test]
+    fn namespace_chain_dedupes_diamond() {
+        // a includes b and c; b and c both include d. d should appear once.
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.b]
+include = ["d"]
+
+[memory_namespace.c]
+include = ["d"]
+
+[memory_namespace.d]
+
+[memory_namespace.a]
+include = ["b", "c"]
+"#,
+        );
+        let chain = cfg.resolve_namespace_chain("a");
+        assert_eq!(chain.iter().filter(|n| *n == "d").count(), 1);
+        assert_eq!(chain[0], "a");
+    }
+
+    #[test]
+    fn namespace_cycle_is_rejected() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.a]
+include = ["b"]
+
+[memory_namespace.b]
+include = ["a"]
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert!(
+            errors.iter().any(|e| e.contains("cycle")),
+            "expected cycle error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn namespace_unknown_include_is_rejected() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.user]
+include = ["ghost"]
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert!(
+            errors.iter().any(|e| e.contains("ghost")),
+            "expected unknown-namespace error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn profile_memory_namespace_resolves() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.user_nsfw]
+include = ["default"]
+
+[profiles.nsfw]
+provider         = "anthropic"
+memory_namespace = "user_nsfw"
+
+[rooms."!nsfw:srv"]
+profile = "nsfw"
+"#,
+        );
+        assert!(cfg.validate_profiles().is_empty());
+        assert_eq!(cfg.namespace_for_room("!nsfw:srv"), "user_nsfw");
+        assert_eq!(cfg.namespace_for_room("!other:srv"), "default");
+    }
+
+    #[test]
+    fn profile_unknown_memory_namespace_is_rejected() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.nsfw]
+provider         = "anthropic"
+memory_namespace = "ghost"
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert!(
+            errors.iter().any(|e| e.contains("ghost")),
+            "expected unknown-namespace error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn all_memory_namespaces_unions_sources() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.user]
+include = ["default"]
+
+[profiles.nsfw]
+provider         = "anthropic"
+memory_namespace = "user_nsfw"
+
+[memory_namespace.user_nsfw]
+include = ["user"]
+"#,
+        );
+        let all = cfg.all_memory_namespaces();
+        assert!(all.contains(&"default".to_string()));
+        assert!(all.contains(&"user".to_string()));
+        assert!(all.contains(&"user_nsfw".to_string()));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,22 +32,26 @@ pub struct Config {
     /// Used for session resets and daily log generation. Default: 0 (midnight).
     #[serde(default)]
     pub day_boundary_hour: u8,
-    /// Default session policy applied at the day boundary. Can be overridden
-    /// per room via `[rooms."<id>"]`. Default: `reset` (back-compat).
+    /// Default session policy applied at the day boundary when no room
+    /// profile sets its own policy. Default: `reset` (back-compat).
     #[serde(default)]
     pub session_policy: SessionPolicy,
-    /// Per-room overrides keyed by `room_id`.
-    #[serde(default)]
-    pub rooms: HashMap<String, RoomConfig>,
     /// Additional LLM providers beyond the built-in `anthropic` one.
     /// Keyed by user-chosen name (e.g. `"local"`, `"openai"`).
     #[serde(default)]
     pub providers: HashMap<String, ProviderConfig>,
-    /// Named profiles that bind a use-case (e.g. `"default"`, `"nsfw"`)
-    /// to a provider name. Rooms select a profile via `RoomConfig.profile`;
-    /// the API can also pass a profile name on a per-request basis.
+    /// Named profiles that bind a use-case (e.g. `"casual"`, `"opus"`,
+    /// `"local"`) to a provider name and optional refusal-fallback
+    /// provider. A profile is a *pure* LLM preset — it does **not**
+    /// know about memory namespaces or rooms; pairing happens via
+    /// `[room_profile.<n>]`.
     #[serde(default)]
     pub profiles: HashMap<String, ProfileConfig>,
+    /// Room profiles: bundle a chat profile + memory namespace +
+    /// session policy and apply to a list of rooms / API channel
+    /// targets. Each room_id appears in at most one room profile.
+    #[serde(default, rename = "room_profile")]
+    pub room_profiles: HashMap<String, RoomProfileConfig>,
     /// Memory namespaces. Each namespace owns its own subtree under
     /// `memory/<namespace>/` (daily/weekly/monthly/yearly logs and
     /// MEMORY.md). Profiles pin their writes to one namespace, and
@@ -122,15 +126,38 @@ pub enum SessionPolicy {
     None,
 }
 
-/// Per-room configuration overrides.
+/// Bundle of (chat profile, memory namespace, session policy)
+/// applied to a set of rooms.
+///
+/// Each `room_id` may appear in at most one room profile. Rooms that
+/// don't appear in any room profile fall back to `[room_profile.default]`
+/// if defined, otherwise the built-in defaults (Anthropic provider,
+/// `"default"` namespace, global `session_policy`).
+///
+/// Future-extension fields (planned for a follow-up release):
+///   - `api_enabled: bool` — gate API access per room profile
+///   - `api_keys: Vec<String>` — bearer tokens accepted by the API for
+///     this room profile
+///
+/// See https://github.com/fluo10/sapphire-agent/issues/73
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-pub struct RoomConfig {
-    /// Override the day-boundary session policy for this room.
+pub struct RoomProfileConfig {
+    /// Name of the LLM profile (in `[profiles.<n>]`) that drives chat
+    /// turns for rooms in this room profile. Required.
+    pub profile: String,
+    /// Memory namespace these rooms read and write under. Defaults to
+    /// the implicit `"default"` namespace.
+    #[serde(default)]
+    pub memory_namespace: Option<String>,
+    /// Override the day-boundary session policy for these rooms.
+    /// Falls through to `Config.session_policy` when absent.
+    #[serde(default)]
     pub session_policy: Option<SessionPolicy>,
-    /// Profile name to use for this room. If unset, falls back to the
-    /// `"default"` profile when defined, otherwise the built-in
-    /// `anthropic` provider.
-    pub profile: Option<String>,
+    /// Channel-side room ids this profile applies to. Matrix room ids,
+    /// Discord channel ids, etc. Empty `[]` means the room profile is
+    /// usable from API sessions only — no channel rooms map to it.
+    #[serde(default)]
+    pub rooms: Vec<String>,
 }
 
 /// Definition of an additional LLM provider.
@@ -145,11 +172,13 @@ pub enum ProviderConfig {
     OpenAiCompatible(crate::provider::openai_compatible::OpenAICompatibleConfig),
 }
 
-/// Definition of a named profile.
+/// Pure LLM preset — provider plus optional refusal-fallback provider.
 ///
-/// A profile picks a provider (and optionally a fallback) for a given
-/// use-case. The `"default"` profile, if defined, is used by rooms that
-/// don't specify their own profile.
+/// Profiles intentionally know **nothing** about memory namespaces or
+/// rooms. They are referenced by:
+///   - `[room_profile.<n>].profile` for chat turns
+///   - `[memory_namespace.<n>].background_profile` for daily-log /
+///     digest / compaction work
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ProfileConfig {
     /// Name of the provider to use. Either `"anthropic"` (built-in) or a
@@ -159,11 +188,6 @@ pub struct ProfileConfig {
     /// (e.g. NSFW content). Wired up by the routing layer.
     #[serde(default)]
     pub fallback_provider: Option<String>,
-    /// Memory namespace this profile reads and writes. Defaults to
-    /// `"default"`. Must reference a defined `[memory_namespace.<name>]`
-    /// (or the implicit `"default"`).
-    #[serde(default)]
-    pub memory_namespace: Option<String>,
 }
 
 /// Definition of a memory namespace — a subtree under `memory/<name>/`
@@ -506,26 +530,44 @@ impl Config {
         }
     }
 
-    /// Resolve the session policy for a given `room_id`, falling back to the
-    /// global default when no room-specific override is set.
+    /// Find the room profile a `room_id` belongs to.
+    ///
+    /// Order: explicit listing in `[room_profile.<n>].rooms` >
+    /// conventional `[room_profile.default]` (catches all unmatched
+    /// rooms) > `None`.
+    pub fn room_profile_for(&self, room_id: &str) -> Option<(&str, &RoomProfileConfig)> {
+        for (name, rp) in &self.room_profiles {
+            if rp.rooms.iter().any(|r| r == room_id) {
+                return Some((name.as_str(), rp));
+            }
+        }
+        self.room_profiles
+            .get_key_value(DEFAULT_PROFILE_NAME)
+            .map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Look up a room profile by name. Used by API sessions, which pin
+    /// a room_profile name at `initialize` time.
+    pub fn room_profile(&self, name: &str) -> Option<&RoomProfileConfig> {
+        self.room_profiles.get(name)
+    }
+
+    /// Resolve the session policy for a given `room_id`, falling back to
+    /// the global default when no room profile sets one.
     pub fn session_policy_for(&self, room_id: &str) -> SessionPolicy {
-        self.rooms
-            .get(room_id)
-            .and_then(|r| r.session_policy)
+        self.room_profile_for(room_id)
+            .and_then(|(_, rp)| rp.session_policy)
             .unwrap_or(self.session_policy)
     }
 
-    /// Resolve the profile name for a given `room_id`.
+    /// Resolve the LLM profile name for a given `room_id`.
     ///
-    /// Order: explicit room override > `"default"` profile if defined >
-    /// `None` (caller should fall back to the built-in anthropic provider).
+    /// Order: room profile that contains this room > `[profiles.default]`
+    /// if defined > `None` (caller falls back to the built-in Anthropic
+    /// provider).
     pub fn profile_for(&self, room_id: &str) -> Option<&str> {
-        if let Some(name) = self
-            .rooms
-            .get(room_id)
-            .and_then(|r| r.profile.as_deref())
-        {
-            return Some(name);
+        if let Some((_, rp)) = self.room_profile_for(room_id) {
+            return Some(rp.profile.as_str());
         }
         if self.profiles.contains_key(DEFAULT_PROFILE_NAME) {
             return Some(DEFAULT_PROFILE_NAME);
@@ -566,22 +608,29 @@ impl Config {
                 }
             }
         }
-        for (rid, rcfg) in &self.rooms {
-            if let Some(pname) = &rcfg.profile {
-                if !self.profiles.contains_key(pname) {
+        // Room profile references and uniqueness of room_ids across profiles.
+        let mut seen_rooms: HashMap<String, String> = HashMap::new();
+        for (rp_name, rp) in &self.room_profiles {
+            if !self.profiles.contains_key(&rp.profile) {
+                errors.push(format!(
+                    "room_profile '{rp_name}' references unknown profile '{}'",
+                    rp.profile
+                ));
+            }
+            if let Some(ns) = &rp.memory_namespace {
+                if !self.namespace_is_defined(ns) {
                     errors.push(format!(
-                        "room '{rid}' references unknown profile '{pname}'"
+                        "room_profile '{rp_name}' references unknown memory_namespace '{ns}'"
                     ));
                 }
             }
-        }
-        // Memory namespace references on profiles.
-        for (pname, prof) in &self.profiles {
-            if let Some(ns) = &prof.memory_namespace {
-                if !self.namespace_is_defined(ns) {
+            for room in &rp.rooms {
+                if let Some(prev) = seen_rooms.get(room) {
                     errors.push(format!(
-                        "profile '{pname}' references unknown memory_namespace '{ns}'"
+                        "room '{room}' appears in multiple room_profiles: '{prev}' and '{rp_name}'"
                     ));
+                } else {
+                    seen_rooms.insert(room.clone(), rp_name.clone());
                 }
             }
         }
@@ -705,36 +754,34 @@ impl Config {
         None
     }
 
-    /// Resolve the memory namespace for a given profile.
-    ///
-    /// Order: explicit `profile.memory_namespace` > `"default"`.
-    pub fn namespace_for_profile(&self, profile_name: &str) -> &str {
-        self.profiles
-            .get(profile_name)
-            .and_then(|p| p.memory_namespace.as_deref())
+    /// Resolve the memory namespace declared by a room profile (by
+    /// name). Falls back to `"default"` if the room profile is unknown
+    /// or doesn't set one.
+    pub fn namespace_for_room_profile(&self, name: &str) -> &str {
+        self.room_profiles
+            .get(name)
+            .and_then(|rp| rp.memory_namespace.as_deref())
             .unwrap_or(DEFAULT_NAMESPACE_NAME)
     }
 
-    /// Resolve the memory namespace for a given `room_id`. Combines
-    /// `profile_for` with `namespace_for_profile`; rooms without a profile
-    /// fall through to `"default"`.
+    /// Resolve the memory namespace for a given `room_id`. Rooms not
+    /// present in any room profile fall through to `"default"`.
     pub fn namespace_for_room(&self, room_id: &str) -> &str {
-        match self.profile_for(room_id) {
-            Some(p) => self.namespace_for_profile(p),
-            None => DEFAULT_NAMESPACE_NAME,
-        }
+        self.room_profile_for(room_id)
+            .and_then(|(_, rp)| rp.memory_namespace.as_deref())
+            .unwrap_or(DEFAULT_NAMESPACE_NAME)
     }
 
     /// Every memory namespace name relevant to this config: the implicit
     /// `"default"`, every `[memory_namespace.<name>]` key, and every
-    /// namespace named by a profile. Used by background catch-up loops to
-    /// know what subtrees to enumerate.
+    /// namespace named by a room profile. Used by background catch-up
+    /// loops to know what subtrees to enumerate.
     pub fn all_memory_namespaces(&self) -> Vec<String> {
         let mut out: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
         out.insert(DEFAULT_NAMESPACE_NAME.to_string());
         out.extend(self.memory_namespaces.keys().cloned());
-        for prof in self.profiles.values() {
-            if let Some(ns) = &prof.memory_namespace {
+        for rp in self.room_profiles.values() {
+            if let Some(ns) = &rp.memory_namespace {
                 out.insert(ns.clone());
             }
         }
@@ -786,7 +833,7 @@ provider = "anthropic"
     }
 
     #[test]
-    fn room_override_wins_over_default_profile() {
+    fn room_profile_assigns_profile_to_listed_rooms() {
         let cfg = parse(
             r#"
 [anthropic]
@@ -803,15 +850,73 @@ provider = "anthropic"
 [profiles.nsfw]
 provider = "local"
 
-[rooms."!nsfw:srv"]
+[room_profile.private_nsfw]
 profile = "nsfw"
+rooms   = ["!nsfw:srv"]
 "#,
         );
         assert_eq!(cfg.profile_for("!nsfw:srv"), Some("nsfw"));
+        // Unmatched room falls through to [profiles.default].
         assert_eq!(cfg.profile_for("!other:srv"), Some("default"));
         assert_eq!(cfg.provider_for_profile("nsfw"), Some("local"));
         assert_eq!(cfg.provider_for_profile("default"), Some("anthropic"));
         assert!(cfg.validate_profiles().is_empty());
+    }
+
+    #[test]
+    fn default_room_profile_catches_unmatched_rooms() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.casual]
+provider = "anthropic"
+
+[profiles.opus]
+provider = "anthropic"
+
+[room_profile.default]
+profile = "casual"
+rooms   = []
+
+[room_profile.dev]
+profile = "opus"
+rooms   = ["!dev:srv"]
+"#,
+        );
+        assert_eq!(cfg.profile_for("!dev:srv"), Some("opus"));
+        // An unmatched room falls through to room_profile.default.
+        assert_eq!(cfg.profile_for("!chat:srv"), Some("casual"));
+    }
+
+    #[test]
+    fn validate_rejects_room_listed_in_two_profiles() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.a]
+provider = "anthropic"
+
+[profiles.b]
+provider = "anthropic"
+
+[room_profile.first]
+profile = "a"
+rooms   = ["!shared:srv"]
+
+[room_profile.second]
+profile = "b"
+rooms   = ["!shared:srv"]
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert!(
+            errors.iter().any(|e| e.contains("multiple room_profiles")),
+            "expected duplicate-room error, got: {errors:?}"
+        );
     }
 
     #[test]
@@ -849,19 +954,22 @@ fallback_provider = "ghost"
     }
 
     #[test]
-    fn validate_flags_unknown_profile_in_room() {
+    fn validate_flags_unknown_profile_in_room_profile() {
         let cfg = parse(
             r#"
 [anthropic]
 api_key = "test"
 
-[rooms."!x:srv"]
+[room_profile.x]
 profile = "missing"
+rooms   = ["!x:srv"]
 "#,
         );
         let errors = cfg.validate_profiles();
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].contains("missing"));
+        assert!(
+            errors.iter().any(|e| e.contains("missing")),
+            "got: {errors:?}"
+        );
     }
 
     #[test]
@@ -978,7 +1086,7 @@ include = ["ghost"]
     }
 
     #[test]
-    fn profile_memory_namespace_resolves() {
+    fn room_profile_assigns_memory_namespace() {
         let cfg = parse(
             r#"
 [anthropic]
@@ -988,28 +1096,34 @@ api_key = "test"
 include = ["default"]
 
 [profiles.nsfw]
-provider         = "anthropic"
-memory_namespace = "user_nsfw"
+provider = "anthropic"
 
-[rooms."!nsfw:srv"]
-profile = "nsfw"
+[room_profile.private_nsfw]
+profile          = "nsfw"
+memory_namespace = "user_nsfw"
+rooms            = ["!nsfw:srv"]
 "#,
         );
         assert!(cfg.validate_profiles().is_empty());
         assert_eq!(cfg.namespace_for_room("!nsfw:srv"), "user_nsfw");
         assert_eq!(cfg.namespace_for_room("!other:srv"), "default");
+        assert_eq!(cfg.namespace_for_room_profile("private_nsfw"), "user_nsfw");
     }
 
     #[test]
-    fn profile_unknown_memory_namespace_is_rejected() {
+    fn room_profile_unknown_memory_namespace_is_rejected() {
         let cfg = parse(
             r#"
 [anthropic]
 api_key = "test"
 
-[profiles.nsfw]
-provider         = "anthropic"
+[profiles.x]
+provider = "anthropic"
+
+[room_profile.bad]
+profile          = "x"
 memory_namespace = "ghost"
+rooms            = ["!x:srv"]
 "#,
         );
         let errors = cfg.validate_profiles();

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,6 +178,19 @@ pub struct MemoryNamespaceConfig {
     /// DAG; cycles are rejected at startup.
     #[serde(default)]
     pub include: Vec<String>,
+    /// Profile used by background tasks (daily-log generation, periodic
+    /// digests, MEMORY.md compaction) when working under this
+    /// namespace. Lets a per-namespace policy pick a permissive local
+    /// model up front instead of relying on a refusal-fallback hop —
+    /// e.g. an NSFW namespace can route directly to its local provider
+    /// while the default namespace stays on Anthropic.
+    ///
+    /// Resolution order for a given namespace:
+    ///   1. `memory_namespace.<n>.background_profile` (this field)
+    ///   2. global `[profiles.background]` (back-compat with PR #68)
+    ///   3. plain Anthropic
+    #[serde(default)]
+    pub background_profile: Option<String>,
 }
 
 /// Built-in name of the Anthropic provider — referenced by profiles.
@@ -581,6 +594,13 @@ impl Config {
                     ));
                 }
             }
+            if let Some(prof) = &ns_cfg.background_profile {
+                if !self.profiles.contains_key(prof) {
+                    errors.push(format!(
+                        "memory_namespace '{ns_name}' references unknown background_profile '{prof}'"
+                    ));
+                }
+            }
         }
         for ns_name in self.memory_namespaces.keys() {
             if let Some(cycle) = self.namespace_cycle_starting_at(ns_name) {
@@ -664,6 +684,25 @@ impl Config {
                 self.namespace_chain_walk(parent, out, seen);
             }
         }
+    }
+
+    /// Profile name to use for background tasks (daily-log generation,
+    /// digests, memory compaction) under `namespace`. Returns `None` when
+    /// neither the namespace's own `background_profile` nor the global
+    /// `[profiles.background]` is configured — caller should then fall
+    /// back to the built-in Anthropic provider.
+    pub fn background_profile_for_namespace(&self, namespace: &str) -> Option<&str> {
+        if let Some(name) = self
+            .memory_namespaces
+            .get(namespace)
+            .and_then(|c| c.background_profile.as_deref())
+        {
+            return Some(name);
+        }
+        if self.profiles.contains_key(BACKGROUND_PROFILE_NAME) {
+            return Some(BACKGROUND_PROFILE_NAME);
+        }
+        None
     }
 
     /// Resolve the memory namespace for a given profile.
@@ -977,6 +1016,81 @@ memory_namespace = "ghost"
         assert!(
             errors.iter().any(|e| e.contains("ghost")),
             "expected unknown-namespace error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn background_profile_resolves_from_namespace_first() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.bg_global]
+provider = "anthropic"
+
+[profiles.bg_nsfw]
+provider = "anthropic"
+
+[profiles.background]
+provider = "anthropic"
+
+[memory_namespace.user_nsfw]
+include            = ["default"]
+background_profile = "bg_nsfw"
+"#,
+        );
+        assert!(cfg.validate_profiles().is_empty());
+        // Namespace-local override wins.
+        assert_eq!(
+            cfg.background_profile_for_namespace("user_nsfw"),
+            Some("bg_nsfw")
+        );
+        // No namespace override → falls back to [profiles.background].
+        assert_eq!(
+            cfg.background_profile_for_namespace("default"),
+            Some("background")
+        );
+    }
+
+    #[test]
+    fn background_profile_is_none_when_unconfigured() {
+        let cfg = parse(MINIMAL);
+        assert!(cfg.background_profile_for_namespace("default").is_none());
+    }
+
+    #[test]
+    fn background_profile_falls_back_to_global() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[profiles.background]
+provider = "anthropic"
+"#,
+        );
+        assert_eq!(
+            cfg.background_profile_for_namespace("anything"),
+            Some("background")
+        );
+    }
+
+    #[test]
+    fn unknown_background_profile_is_rejected() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[memory_namespace.user]
+background_profile = "ghost"
+"#,
+        );
+        let errors = cfg.validate_profiles();
+        assert!(
+            errors.iter().any(|e| e.contains("ghost")),
+            "expected ghost error, got: {errors:?}"
         );
     }
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -17,6 +17,7 @@ use crate::periodic_log::{
     generate_monthly_log, generate_weekly_log, generate_yearly_log,
 };
 use crate::provider::Provider;
+use crate::provider::registry::ProviderRegistry;
 use crate::session::SessionStore;
 use chrono::{Datelike, Duration, Local, NaiveTime, Timelike, Weekday};
 use sapphire_workspace::WorkspaceState;
@@ -36,7 +37,11 @@ pub struct Heartbeat {
     pub memory_compaction_enabled: bool,
     pub digest_cfg: DigestConfig,
     pub session_store: Arc<SessionStore>,
-    pub provider: Arc<dyn Provider>,
+    /// Provider registry — every background LLM call resolves through
+    /// `registry.background_provider_for_namespace(&config, &ns)` so each
+    /// namespace can pick its own primary (and optional fallback) instead
+    /// of all sharing one provider.
+    pub registry: Arc<ProviderRegistry>,
     pub agent: Arc<Agent>,
     pub default_room_id: Option<String>,
     /// Config snapshot used to enumerate memory namespaces and resolve
@@ -56,6 +61,14 @@ impl Heartbeat {
         } else {
             self.config.namespace_for_room(&meta.room_id).to_string()
         }
+    }
+
+    /// Background provider for `namespace`. Honours the namespace's
+    /// `background_profile`, falling back through the global background
+    /// profile to plain Anthropic.
+    fn provider_for_namespace(&self, namespace: &str) -> Arc<dyn Provider> {
+        self.registry
+            .background_provider_for_namespace(&self.config, namespace)
     }
 }
 
@@ -88,6 +101,7 @@ impl Heartbeat {
             );
             let mut total: usize = 0;
             for ns in self.config.all_memory_namespaces() {
+                let provider = self.provider_for_namespace(&ns);
                 let ns_for_predicate = ns.clone();
                 let me = Arc::clone(&self);
                 let predicate = move |meta: &crate::session::SessionMeta| -> bool {
@@ -95,7 +109,7 @@ impl Heartbeat {
                 };
                 total += catchup_pending_daily_logs(
                     &self.session_store,
-                    self.provider.as_ref(),
+                    provider.as_ref(),
                     &self.ws_state,
                     &self.workspace_dir,
                     &ns,
@@ -104,7 +118,7 @@ impl Heartbeat {
                 )
                 .await;
                 total += catchup_missing_daily_digests(
-                    self.provider.as_ref(),
+                    provider.as_ref(),
                     &self.ws_state,
                     &self.workspace_dir,
                     &ns,
@@ -112,7 +126,7 @@ impl Heartbeat {
                 .await;
                 if self.digest_cfg.weekly_enabled {
                     total += catchup_pending_weekly_logs(
-                        self.provider.as_ref(),
+                        provider.as_ref(),
                         &self.ws_state,
                         &self.workspace_dir,
                         &ns,
@@ -122,7 +136,7 @@ impl Heartbeat {
                 }
                 if self.digest_cfg.monthly_enabled {
                     total += catchup_pending_monthly_logs(
-                        self.provider.as_ref(),
+                        provider.as_ref(),
                         &self.ws_state,
                         &self.workspace_dir,
                         &ns,
@@ -132,7 +146,7 @@ impl Heartbeat {
                 }
                 if self.digest_cfg.yearly_enabled {
                     total += catchup_pending_yearly_logs(
-                        self.provider.as_ref(),
+                        provider.as_ref(),
                         &self.ws_state,
                         &self.workspace_dir,
                         &ns,
@@ -166,6 +180,7 @@ impl Heartbeat {
                 let today = yesterday + Duration::days(1);
                 let mut any_generated = false;
                 for ns in self.config.all_memory_namespaces() {
+                    let provider = self.provider_for_namespace(&ns);
                     info!("Heartbeat: generating daily log for {yesterday} in '{ns}'");
                     let ns_for_predicate = ns.clone();
                     let me = Arc::clone(&self);
@@ -174,7 +189,7 @@ impl Heartbeat {
                     };
                     match generate_daily_log(
                         &self.session_store,
-                        self.provider.as_ref(),
+                        provider.as_ref(),
                         &self.ws_state,
                         &self.workspace_dir,
                         &ns,
@@ -200,7 +215,7 @@ impl Heartbeat {
                             iso.week()
                         );
                         match generate_weekly_log(
-                            self.provider.as_ref(),
+                            provider.as_ref(),
                             &self.ws_state,
                             &self.workspace_dir,
                             &ns,
@@ -224,7 +239,7 @@ impl Heartbeat {
                             "Heartbeat: generating monthly log for {year:04}-{month:02} in '{ns}'"
                         );
                         match generate_monthly_log(
-                            self.provider.as_ref(),
+                            provider.as_ref(),
                             &self.ws_state,
                             &self.workspace_dir,
                             &ns,
@@ -246,7 +261,7 @@ impl Heartbeat {
                         let year = yesterday.year();
                         info!("Heartbeat: generating yearly log for {year:04} in '{ns}'");
                         match generate_yearly_log(
-                            self.provider.as_ref(),
+                            provider.as_ref(),
                             &self.ws_state,
                             &self.workspace_dir,
                             &ns,
@@ -270,8 +285,9 @@ impl Heartbeat {
 
             if self.memory_compaction_enabled {
                 for ns in self.config.all_memory_namespaces() {
+                    let provider = self.provider_for_namespace(&ns);
                     info!("Heartbeat: compacting MEMORY.md in '{ns}'");
-                    compact_memory(self.provider.as_ref(), &self.workspace_dir, &ns).await;
+                    compact_memory(provider.as_ref(), &self.workspace_dir, &ns).await;
                 }
             }
         }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -8,7 +8,7 @@
 //!    triggers on the agent according to each task's cron schedule.
 
 use crate::agent::Agent;
-use crate::config::DigestConfig;
+use crate::config::{Config, DigestConfig};
 use crate::heartbeat_config::{load_heartbeat_dir, next_due};
 use crate::memory_compaction::compact_memory;
 use crate::periodic_log::{
@@ -39,6 +39,24 @@ pub struct Heartbeat {
     pub provider: Arc<dyn Provider>,
     pub agent: Arc<Agent>,
     pub default_room_id: Option<String>,
+    /// Config snapshot used to enumerate memory namespaces and resolve
+    /// per-room namespace assignment for periodic-log catch-up.
+    pub config: Config,
+}
+
+impl Heartbeat {
+    /// Resolve which namespace a session belongs to. Matrix/Discord rooms
+    /// follow `Config::namespace_for_room`. API sessions (channel="api")
+    /// fall back to the default namespace because their per-session
+    /// profile pinning is in-memory only and not persisted in the JSONL
+    /// metadata.
+    fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
+        if meta.channel == "api" {
+            crate::config::DEFAULT_NAMESPACE_NAME.to_string()
+        } else {
+            self.config.namespace_for_room(&meta.room_id).to_string()
+        }
+    }
 }
 
 impl Heartbeat {
@@ -64,58 +82,66 @@ impl Heartbeat {
         tick.tick().await; // skip immediate fire — startup catchup already ran in main
         loop {
             tick.tick().await;
-            let logs = catchup_pending_daily_logs(
-                &self.session_store,
-                self.provider.as_ref(),
-                &self.ws_state,
-                &self.workspace_dir,
-                self.day_boundary_hour,
-            )
-            .await;
-            let digests = catchup_missing_daily_digests(
-                self.provider.as_ref(),
-                &self.ws_state,
-                &self.workspace_dir,
-            )
-            .await;
             let today_local = crate::session::local_date_for_timestamp(
                 Local::now(),
                 self.day_boundary_hour,
             );
-            let weekly = if self.digest_cfg.weekly_enabled {
-                catchup_pending_weekly_logs(
+            let mut total: usize = 0;
+            for ns in self.config.all_memory_namespaces() {
+                let ns_for_predicate = ns.clone();
+                let me = Arc::clone(&self);
+                let predicate = move |meta: &crate::session::SessionMeta| -> bool {
+                    me.namespace_for_session(meta) == ns_for_predicate
+                };
+                total += catchup_pending_daily_logs(
+                    &self.session_store,
                     self.provider.as_ref(),
                     &self.ws_state,
                     &self.workspace_dir,
-                    today_local,
+                    &ns,
+                    self.day_boundary_hour,
+                    &predicate,
                 )
-                .await
-            } else {
-                0
-            };
-            let monthly = if self.digest_cfg.monthly_enabled {
-                catchup_pending_monthly_logs(
+                .await;
+                total += catchup_missing_daily_digests(
                     self.provider.as_ref(),
                     &self.ws_state,
                     &self.workspace_dir,
-                    today_local,
+                    &ns,
                 )
-                .await
-            } else {
-                0
-            };
-            let yearly = if self.digest_cfg.yearly_enabled {
-                catchup_pending_yearly_logs(
-                    self.provider.as_ref(),
-                    &self.ws_state,
-                    &self.workspace_dir,
-                    today_local,
-                )
-                .await
-            } else {
-                0
-            };
-            if logs + digests + weekly + monthly + yearly > 0 {
+                .await;
+                if self.digest_cfg.weekly_enabled {
+                    total += catchup_pending_weekly_logs(
+                        self.provider.as_ref(),
+                        &self.ws_state,
+                        &self.workspace_dir,
+                        &ns,
+                        today_local,
+                    )
+                    .await;
+                }
+                if self.digest_cfg.monthly_enabled {
+                    total += catchup_pending_monthly_logs(
+                        self.provider.as_ref(),
+                        &self.ws_state,
+                        &self.workspace_dir,
+                        &ns,
+                        today_local,
+                    )
+                    .await;
+                }
+                if self.digest_cfg.yearly_enabled {
+                    total += catchup_pending_yearly_logs(
+                        self.provider.as_ref(),
+                        &self.ws_state,
+                        &self.workspace_dir,
+                        &ns,
+                        today_local,
+                    )
+                    .await;
+                }
+            }
+            if total > 0 {
                 self.agent.invalidate_system_prompts().await;
             }
         }
@@ -137,84 +163,103 @@ impl Heartbeat {
             );
 
             if self.daily_log_enabled {
-                info!("Heartbeat: generating daily log for {yesterday}");
-                let mut any_generated = false;
-                match generate_daily_log(
-                    &self.session_store,
-                    self.provider.as_ref(),
-                    &self.ws_state,
-                    &self.workspace_dir,
-                    yesterday,
-                    self.day_boundary_hour,
-                )
-                .await
-                {
-                    Ok(true) => any_generated = true,
-                    Ok(false) => {}
-                    Err(e) => {
-                        warn!("Heartbeat: failed to generate daily log for {yesterday}: {e:#}")
-                    }
-                }
-
-                // Weekly: today is Monday → last ISO week closed yesterday.
                 let today = yesterday + Duration::days(1);
-                if self.digest_cfg.weekly_enabled && today.weekday() == Weekday::Mon {
-                    let iso = yesterday.iso_week();
-                    info!(
-                        "Heartbeat: generating weekly log for {}-W{:02}",
-                        iso.year(),
-                        iso.week()
-                    );
-                    match generate_weekly_log(
+                let mut any_generated = false;
+                for ns in self.config.all_memory_namespaces() {
+                    info!("Heartbeat: generating daily log for {yesterday} in '{ns}'");
+                    let ns_for_predicate = ns.clone();
+                    let me = Arc::clone(&self);
+                    let predicate = move |meta: &crate::session::SessionMeta| -> bool {
+                        me.namespace_for_session(meta) == ns_for_predicate
+                    };
+                    match generate_daily_log(
+                        &self.session_store,
                         self.provider.as_ref(),
                         &self.ws_state,
                         &self.workspace_dir,
-                        iso.year(),
-                        iso.week(),
+                        &ns,
+                        yesterday,
+                        self.day_boundary_hour,
+                        &predicate,
                     )
                     .await
                     {
                         Ok(true) => any_generated = true,
                         Ok(false) => {}
-                        Err(e) => warn!("Heartbeat: failed to generate weekly log: {e:#}"),
+                        Err(e) => warn!(
+                            "Heartbeat: failed to generate daily log for {yesterday} in '{ns}': {e:#}"
+                        ),
                     }
-                }
 
-                // Monthly: today is day 1 → last calendar month ended yesterday.
-                if self.digest_cfg.monthly_enabled && today.day() == 1 {
-                    let (year, month) = (yesterday.year(), yesterday.month());
-                    info!("Heartbeat: generating monthly log for {year:04}-{month:02}");
-                    match generate_monthly_log(
-                        self.provider.as_ref(),
-                        &self.ws_state,
-                        &self.workspace_dir,
-                        year,
-                        month,
-                    )
-                    .await
-                    {
-                        Ok(true) => any_generated = true,
-                        Ok(false) => {}
-                        Err(e) => warn!("Heartbeat: failed to generate monthly log: {e:#}"),
+                    // Weekly: today is Monday → last ISO week closed yesterday.
+                    if self.digest_cfg.weekly_enabled && today.weekday() == Weekday::Mon {
+                        let iso = yesterday.iso_week();
+                        info!(
+                            "Heartbeat: generating weekly log for {}-W{:02} in '{ns}'",
+                            iso.year(),
+                            iso.week()
+                        );
+                        match generate_weekly_log(
+                            self.provider.as_ref(),
+                            &self.ws_state,
+                            &self.workspace_dir,
+                            &ns,
+                            iso.year(),
+                            iso.week(),
+                        )
+                        .await
+                        {
+                            Ok(true) => any_generated = true,
+                            Ok(false) => {}
+                            Err(e) => {
+                                warn!("Heartbeat: failed to generate weekly log in '{ns}': {e:#}")
+                            }
+                        }
                     }
-                }
 
-                // Yearly: today is Jan 1 → last calendar year ended yesterday.
-                // Runs after monthly so December's monthly is available as input.
-                if self.digest_cfg.yearly_enabled && today.day() == 1 && today.month() == 1 {
-                    let year = yesterday.year();
-                    info!("Heartbeat: generating yearly log for {year:04}");
-                    match generate_yearly_log(
-                        self.provider.as_ref(),
-                        &self.ws_state,
-                        &self.workspace_dir,
-                        year,
-                    )
-                    .await
-                    {
-                        Ok(true) => any_generated = true,
-                        Ok(false) => {}
-                        Err(e) => warn!("Heartbeat: failed to generate yearly log: {e:#}"),
+                    // Monthly: today is day 1 → last calendar month ended yesterday.
+                    if self.digest_cfg.monthly_enabled && today.day() == 1 {
+                        let (year, month) = (yesterday.year(), yesterday.month());
+                        info!(
+                            "Heartbeat: generating monthly log for {year:04}-{month:02} in '{ns}'"
+                        );
+                        match generate_monthly_log(
+                            self.provider.as_ref(),
+                            &self.ws_state,
+                            &self.workspace_dir,
+                            &ns,
+                            year,
+                            month,
+                        )
+                        .await
+                        {
+                            Ok(true) => any_generated = true,
+                            Ok(false) => {}
+                            Err(e) => {
+                                warn!("Heartbeat: failed to generate monthly log in '{ns}': {e:#}")
+                            }
+                        }
+                    }
+
+                    // Yearly: today is Jan 1 → last calendar year ended yesterday.
+                    if self.digest_cfg.yearly_enabled && today.day() == 1 && today.month() == 1 {
+                        let year = yesterday.year();
+                        info!("Heartbeat: generating yearly log for {year:04} in '{ns}'");
+                        match generate_yearly_log(
+                            self.provider.as_ref(),
+                            &self.ws_state,
+                            &self.workspace_dir,
+                            &ns,
+                            year,
+                        )
+                        .await
+                        {
+                            Ok(true) => any_generated = true,
+                            Ok(false) => {}
+                            Err(e) => {
+                                warn!("Heartbeat: failed to generate yearly log in '{ns}': {e:#}")
+                            }
+                        }
                     }
                 }
 
@@ -224,8 +269,10 @@ impl Heartbeat {
             }
 
             if self.memory_compaction_enabled {
-                info!("Heartbeat: compacting MEMORY.md");
-                compact_memory(self.provider.as_ref(), &self.workspace_dir).await;
+                for ns in self.config.all_memory_namespaces() {
+                    info!("Heartbeat: compacting MEMORY.md in '{ns}'");
+                    compact_memory(self.provider.as_ref(), &self.workspace_dir, &ns).await;
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,10 +274,6 @@ async fn main() -> Result<()> {
                 ProviderRegistry::from_config(&config)
                     .context("Failed to build provider registry")?,
             );
-            // Heartbeat / serve / daily-log run on the "background" profile
-            // when defined (with optional refusal fallback) and on plain
-            // Anthropic otherwise.
-            let provider: Arc<dyn provider::Provider> = registry.background_provider(&config);
 
             // ── API session store (sessions/api/) ───────────────────────────
             let api_session_store = Arc::new(SessionStore::with_workspace(
@@ -320,11 +316,16 @@ async fn main() -> Result<()> {
                 };
 
                 // ── Catch-up: iterate every configured memory namespace ────
+                // Each namespace's background tasks run on its own provider
+                // (resolved via `background_provider_for_namespace`), so an
+                // NSFW namespace can route to its local model up front
+                // instead of bouncing through Anthropic refusal-fallback.
                 let today_local = session::local_date_for_timestamp(
                     chrono::Local::now(),
                     config.day_boundary_hour,
                 );
                 for ns in config.all_memory_namespaces() {
+                    let provider = registry.background_provider_for_namespace(&config, &ns);
                     let cfg_for_predicate = config.clone();
                     let ns_for_predicate = ns.clone();
                     let predicate = move |meta: &session::SessionMeta| -> bool {
@@ -412,7 +413,7 @@ async fn main() -> Result<()> {
                     memory_compaction_enabled: config.memory_compaction_enabled,
                     digest_cfg: config.digest.clone(),
                     session_store: Arc::clone(&channel_session_store),
-                    provider: Arc::clone(&provider),
+                    registry: Arc::clone(&registry),
                     agent: Arc::clone(&agent),
                     default_room_id,
                     config: config.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,11 +116,11 @@ enum Command {
         /// and --message; ignored in REPL mode.
         #[arg(long)]
         json: bool,
-        /// Profile name to bind to a newly created session. Must match a
-        /// `[profiles.<name>]` entry on the server side. Ignored when
+        /// Room profile name to bind to a newly created session. Must match a
+        /// `[room_profile.<name>]` entry on the server side. Ignored when
         /// resuming an existing session via --session.
         #[arg(long)]
-        profile: Option<String>,
+        room_profile: Option<String>,
     },
 }
 
@@ -144,10 +144,10 @@ async fn main() -> Result<()> {
         message,
         history,
         json,
-        profile,
+        room_profile,
     }) = cli.command
     {
-        return call::run(server, session, list, message, history, json, profile).await;
+        return call::run(server, session, list, message, history, json, room_profile).await;
     }
 
     let config_path = cli.config.unwrap_or_else(Config::default_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,11 @@ async fn main() -> Result<()> {
         Command::Serve { bind } => {
             let workspace_dir = config.resolved_workspace_dir(&config_path);
 
+            // ── Migrate pre-namespace memory layout (one-time) ─────────────
+            if let Err(e) = migrate_pre_namespace_layout(&workspace_dir) {
+                anyhow::bail!("Memory layout migration failed: {e:#}");
+            }
+
             // ── Bootstrap file loader (AGENTS.md, SOUL.md, MEMORY.md …) ────
             let workspace = Arc::new(Workspace::new(workspace_dir.clone(), config.digest.clone()));
 
@@ -314,53 +319,67 @@ async fn main() -> Result<()> {
                     unreachable!()
                 };
 
-                // ── Catch up on any pending daily logs ──────────────────────
-                catchup_pending_daily_logs(
-                    &channel_session_store,
-                    provider.as_ref(),
-                    &ws_state,
-                    &workspace_dir,
-                    config.day_boundary_hour,
-                )
-                .await;
-
-                // ── Back-fill digest frontmatter on existing dailies ────────
-                catchup_missing_daily_digests(provider.as_ref(), &ws_state, &workspace_dir).await;
-
-                // ── Catch up on pending weekly / monthly / yearly logs ──────
-                // Day-boundary fires only run on Mon / day-1 / Jan-1, so an
-                // offline or crashed agent at those moments would otherwise
-                // leave those logs permanently missing.
+                // ── Catch-up: iterate every configured memory namespace ────
                 let today_local = session::local_date_for_timestamp(
                     chrono::Local::now(),
                     config.day_boundary_hour,
                 );
-                if config.digest.weekly_enabled {
-                    catchup_pending_weekly_logs(
+                for ns in config.all_memory_namespaces() {
+                    let cfg_for_predicate = config.clone();
+                    let ns_for_predicate = ns.clone();
+                    let predicate = move |meta: &session::SessionMeta| -> bool {
+                        if meta.channel == "api" {
+                            return ns_for_predicate == config::DEFAULT_NAMESPACE_NAME;
+                        }
+                        cfg_for_predicate.namespace_for_room(&meta.room_id) == ns_for_predicate
+                    };
+                    catchup_pending_daily_logs(
+                        &channel_session_store,
                         provider.as_ref(),
                         &ws_state,
                         &workspace_dir,
-                        today_local,
+                        &ns,
+                        config.day_boundary_hour,
+                        &predicate,
                     )
                     .await;
-                }
-                if config.digest.monthly_enabled {
-                    catchup_pending_monthly_logs(
+                    catchup_missing_daily_digests(
                         provider.as_ref(),
                         &ws_state,
                         &workspace_dir,
-                        today_local,
+                        &ns,
                     )
                     .await;
-                }
-                if config.digest.yearly_enabled {
-                    catchup_pending_yearly_logs(
-                        provider.as_ref(),
-                        &ws_state,
-                        &workspace_dir,
-                        today_local,
-                    )
-                    .await;
+                    if config.digest.weekly_enabled {
+                        catchup_pending_weekly_logs(
+                            provider.as_ref(),
+                            &ws_state,
+                            &workspace_dir,
+                            &ns,
+                            today_local,
+                        )
+                        .await;
+                    }
+                    if config.digest.monthly_enabled {
+                        catchup_pending_monthly_logs(
+                            provider.as_ref(),
+                            &ws_state,
+                            &workspace_dir,
+                            &ns,
+                            today_local,
+                        )
+                        .await;
+                    }
+                    if config.digest.yearly_enabled {
+                        catchup_pending_yearly_logs(
+                            provider.as_ref(),
+                            &ws_state,
+                            &workspace_dir,
+                            &ns,
+                            today_local,
+                        )
+                        .await;
+                    }
                 }
 
                 // ── Agent ───────────────────────────────────────────────────
@@ -396,6 +415,7 @@ async fn main() -> Result<()> {
                     provider: Arc::clone(&provider),
                     agent: Arc::clone(&agent),
                     default_room_id,
+                    config: config.clone(),
                 };
                 if config.heartbeat_enabled {
                     heartbeat.spawn();
@@ -453,4 +473,175 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// One-shot migration from the pre-namespace `memory/{daily,weekly,monthly,
+/// yearly}/` layout to the namespaced `memory/default/{...}` layout. Also
+/// moves a top-level MEMORY.md (or lowercase memory.md) into
+/// `memory/default/MEMORY.md`.
+///
+/// Idempotent: skips silently when `memory/default/` already exists with
+/// no top-level periodic dirs to move. Refuses to run when both old and
+/// new layouts coexist (ambiguous merge — the user must reconcile).
+fn migrate_pre_namespace_layout(workspace_dir: &std::path::Path) -> anyhow::Result<()> {
+    let memory_root = workspace_dir.join("memory");
+    let has_top_memory_md = ["MEMORY.md", "memory.md"]
+        .iter()
+        .any(|f| workspace_dir.join(f).is_file());
+    if !memory_root.is_dir() && !has_top_memory_md {
+        return Ok(());
+    }
+
+    let default_root = memory_root.join(config::DEFAULT_NAMESPACE_NAME);
+    let kinds = ["daily", "weekly", "monthly", "yearly"];
+    let pre_dirs: Vec<_> = kinds
+        .iter()
+        .filter(|k| memory_root.join(k).is_dir())
+        .copied()
+        .collect();
+    let pre_memory_md = ["MEMORY.md", "memory.md"]
+        .iter()
+        .map(|f| workspace_dir.join(f))
+        .find(|p| p.is_file());
+
+    if pre_dirs.is_empty() && pre_memory_md.is_none() {
+        return Ok(());
+    }
+
+    if default_root.is_dir() && !pre_dirs.is_empty() {
+        anyhow::bail!(
+            "Both pre-namespace memory dirs ({}) and memory/{} exist — refuse to migrate. \
+             Reconcile manually before starting.",
+            pre_dirs.join(", "),
+            config::DEFAULT_NAMESPACE_NAME,
+        );
+    }
+
+    std::fs::create_dir_all(&default_root)
+        .with_context(|| format!("create {}", default_root.display()))?;
+
+    for kind in &pre_dirs {
+        let src = memory_root.join(kind);
+        let dst = default_root.join(kind);
+        std::fs::rename(&src, &dst).with_context(|| {
+            format!("rename {} -> {}", src.display(), dst.display())
+        })?;
+        tracing::info!(
+            "Migrated memory subdir: {} -> {}",
+            src.display(),
+            dst.display()
+        );
+    }
+
+    if let Some(src) = pre_memory_md {
+        let dst = default_root.join("MEMORY.md");
+        std::fs::rename(&src, &dst)
+            .with_context(|| format!("rename {} -> {}", src.display(), dst.display()))?;
+        tracing::info!(
+            "Migrated MEMORY.md: {} -> {}",
+            src.display(),
+            dst.display()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_stub(path: &std::path::Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn migration_no_op_on_fresh_workspace() {
+        let td = tempfile::tempdir().unwrap();
+        migrate_pre_namespace_layout(td.path()).expect("clean migration");
+        // Nothing created.
+        assert!(!td.path().join("memory").exists());
+    }
+
+    #[test]
+    fn migration_moves_pre_namespace_layout() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        write_stub(&root.join("memory/daily/2026-04-15.md"), "daily body");
+        write_stub(&root.join("memory/weekly/2026-W16.md"), "weekly body");
+        write_stub(&root.join("memory/monthly/2026-04.md"), "monthly body");
+        write_stub(&root.join("memory/yearly/2026.md"), "yearly body");
+        write_stub(&root.join("MEMORY.md"), "core memory");
+
+        migrate_pre_namespace_layout(root).expect("migration");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/daily/2026-04-15.md")).unwrap(),
+            "daily body"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/weekly/2026-W16.md")).unwrap(),
+            "weekly body"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/monthly/2026-04.md")).unwrap(),
+            "monthly body"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/yearly/2026.md")).unwrap(),
+            "yearly body"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/MEMORY.md")).unwrap(),
+            "core memory"
+        );
+        // Old paths gone.
+        assert!(!root.join("memory/daily").exists());
+        assert!(!root.join("MEMORY.md").exists());
+    }
+
+    #[test]
+    fn migration_accepts_lowercase_memory_md() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        write_stub(&root.join("memory.md"), "lowercase memory");
+
+        migrate_pre_namespace_layout(root).expect("migration");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/MEMORY.md")).unwrap(),
+            "lowercase memory"
+        );
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        write_stub(&root.join("memory/daily/2026-04-15.md"), "daily body");
+        migrate_pre_namespace_layout(root).expect("first migration");
+        // Run again — pre-namespace dirs no longer exist; default tree
+        // already in place.
+        migrate_pre_namespace_layout(root).expect("idempotent migration");
+        assert_eq!(
+            std::fs::read_to_string(root.join("memory/default/daily/2026-04-15.md")).unwrap(),
+            "daily body"
+        );
+    }
+
+    #[test]
+    fn migration_refuses_when_layouts_coexist() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        // Both old and new layouts present — ambiguous.
+        write_stub(&root.join("memory/daily/2026-04-15.md"), "old");
+        write_stub(&root.join("memory/default/daily/2026-04-16.md"), "new");
+
+        let err = migrate_pre_namespace_layout(root).err().expect("error");
+        assert!(format!("{err:#}").contains("Reconcile manually"));
+        // Files untouched.
+        assert!(root.join("memory/daily/2026-04-15.md").exists());
+        assert!(root.join("memory/default/daily/2026-04-16.md").exists());
+    }
 }

--- a/src/memory_compaction.rs
+++ b/src/memory_compaction.rs
@@ -1,8 +1,10 @@
 //! MEMORY.md compaction.
 //!
-//! Reads `<workspace>/MEMORY.md`, asks the provider to merge duplicates and
-//! summarise stale entries, and writes the result back. The entry separator
-//! `\n\n---\n\n` (used by `MemoryTool`) is preserved by instructing the model.
+//! Reads `<workspace>/memory/<namespace>/MEMORY.md`, asks the provider to
+//! merge duplicates and summarise stale entries, and writes the result
+//! back. The entry separator `\n\n---\n\n` (used by `MemoryTool`) is
+//! preserved by instructing the model. Each namespace is compacted in
+//! isolation, so cross-namespace contamination is impossible.
 
 use crate::provider::{ChatMessage, Provider};
 use std::path::Path;
@@ -20,27 +22,25 @@ Your task: \
 \
 Output ONLY the new contents of MEMORY.md, with no extra commentary, no code fences, and no preamble.";
 
-/// Compact `<workspace_dir>/MEMORY.md` in place. No-op if the file doesn't
-/// exist or is effectively empty. Errors are logged but never returned.
-pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path) {
-    let path = workspace_dir.join("MEMORY.md");
+/// Compact `<workspace_dir>/memory/<namespace>/MEMORY.md` in place. No-op
+/// if the file doesn't exist or is effectively empty. Errors are logged
+/// but never returned.
+pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path, namespace: &str) {
+    let path = workspace_dir.join("memory").join(namespace).join("MEMORY.md");
     let original = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(_) => {
-            // Try lowercase fallback (matches workspace.rs candidate order)
-            let lower = workspace_dir.join("memory.md");
-            match std::fs::read_to_string(&lower) {
-                Ok(s) => s,
-                Err(_) => {
-                    info!("memory_compaction: no MEMORY.md found, skipping");
-                    return;
-                }
-            }
+            info!(
+                "memory_compaction: no MEMORY.md found in namespace '{namespace}', skipping"
+            );
+            return;
         }
     };
 
     if original.trim().is_empty() {
-        info!("memory_compaction: MEMORY.md is empty, skipping");
+        info!(
+            "memory_compaction: MEMORY.md in namespace '{namespace}' is empty, skipping"
+        );
         return;
     }
 
@@ -48,7 +48,9 @@ pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path) {
     let response = match provider.chat(Some(SYSTEM_PROMPT), &[user_msg], None).await {
         Ok(r) => r,
         Err(e) => {
-            warn!("memory_compaction: provider error, leaving file unchanged: {e:#}");
+            warn!(
+                "memory_compaction: provider error for '{namespace}', leaving file unchanged: {e:#}"
+            );
             return;
         }
     };
@@ -56,18 +58,21 @@ pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path) {
     let new_content = match response.text {
         Some(t) if !t.trim().is_empty() => t,
         _ => {
-            warn!("memory_compaction: empty response, leaving file unchanged");
+            warn!(
+                "memory_compaction: empty response for '{namespace}', leaving file unchanged"
+            );
             return;
         }
     };
 
     if let Err(e) = std::fs::write(&path, &new_content) {
-        warn!("memory_compaction: failed to write MEMORY.md: {e}");
+        warn!("memory_compaction: failed to write MEMORY.md in '{namespace}': {e}");
         return;
     }
 
     info!(
-        "memory_compaction: MEMORY.md updated ({} -> {} bytes)",
+        "memory_compaction: MEMORY.md in namespace '{}' updated ({} -> {} bytes)",
+        namespace,
         original.len(),
         new_content.len()
     );

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -58,16 +58,22 @@ impl LogKind {
     }
 }
 
-/// `memory/{dir}/{stem}.md` — workspace-relative path.
-pub fn log_rel_path(kind: LogKind, stem: &str) -> PathBuf {
+/// `memory/{namespace}/{dir}/{stem}.md` — workspace-relative path.
+pub fn log_rel_path(namespace: &str, kind: LogKind, stem: &str) -> PathBuf {
     Path::new("memory")
+        .join(namespace)
         .join(kind.dir())
         .join(format!("{stem}.md"))
 }
 
 /// Absolute path to the log file under `workspace_dir`.
-pub fn log_abs_path(workspace_dir: &Path, kind: LogKind, stem: &str) -> PathBuf {
-    workspace_dir.join(log_rel_path(kind, stem))
+pub fn log_abs_path(
+    workspace_dir: &Path,
+    namespace: &str,
+    kind: LogKind,
+    stem: &str,
+) -> PathBuf {
+    workspace_dir.join(log_rel_path(namespace, kind, stem))
 }
 
 // ---------------------------------------------------------------------------
@@ -118,9 +124,9 @@ pub fn month_stems_in_year_before(today: NaiveDate) -> Vec<String> {
     (1..today.month()).map(|m| monthly_stem(year, m)).collect()
 }
 
-/// Stems of every file in `memory/yearly/*.md`, sorted ascending.
-pub fn existing_yearly_stems(workspace_dir: &Path) -> Vec<String> {
-    let dir = workspace_dir.join("memory").join("yearly");
+/// Stems of every file in `memory/<namespace>/yearly/*.md`, sorted ascending.
+pub fn existing_yearly_stems(workspace_dir: &Path, namespace: &str) -> Vec<String> {
+    let dir = workspace_dir.join("memory").join(namespace).join("yearly");
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
@@ -211,17 +217,27 @@ pub fn daily_stems_in_current_iso_week_before(today: NaiveDate) -> Vec<String> {
 // Daily log generation (moved from daily_log.rs)
 // ---------------------------------------------------------------------------
 
-/// Returns dates that have session messages but no corresponding daily log
-/// file, up to and including yesterday (local time).
-pub fn pending_daily_dates(
+/// Returns dates that have at least one session message in `namespace`'s
+/// rooms but no corresponding daily log file under
+/// `memory/<namespace>/daily/`, up to and including yesterday (local time).
+///
+/// `room_predicate` decides which sessions count toward this namespace.
+/// Callers compute it from `Config::namespace_for_room`.
+pub fn pending_daily_dates<F>(
     session_store: &SessionStore,
     workspace_dir: &Path,
+    namespace: &str,
     boundary_hour: u8,
-) -> Vec<NaiveDate> {
+    room_predicate: F,
+) -> Vec<NaiveDate>
+where
+    F: Fn(&crate::session::SessionMeta) -> bool,
+{
     let today = crate::session::local_date_for_timestamp(Local::now(), boundary_hour);
-    let mut dates = session_store.all_session_dates(boundary_hour);
+    let mut dates = session_store.all_session_dates_filtered(boundary_hour, room_predicate);
     dates.retain(|&date| {
-        date < today && !log_abs_path(workspace_dir, LogKind::Daily, &daily_stem(date)).exists()
+        date < today
+            && !log_abs_path(workspace_dir, namespace, LogKind::Daily, &daily_stem(date)).exists()
     });
     dates
 }
@@ -232,20 +248,25 @@ pub fn pending_daily_dates(
 ///
 /// Writes a YAML frontmatter `digest:` array (top-10 importance-ordered
 /// bullets) alongside the Markdown summary body.
-pub async fn generate_daily_log(
+pub async fn generate_daily_log<F>(
     session_store: &SessionStore,
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     date: NaiveDate,
     boundary_hour: u8,
-) -> anyhow::Result<bool> {
-    let sessions = session_store.sessions_for_day(date, boundary_hour);
+    room_predicate: F,
+) -> anyhow::Result<bool>
+where
+    F: Fn(&crate::session::SessionMeta) -> bool,
+{
+    let sessions = session_store.sessions_for_day_filtered(date, boundary_hour, room_predicate);
     let stem = daily_stem(date);
-    let has_existing = read_body(workspace_dir, LogKind::Daily, &stem)
+    let has_existing = read_body(workspace_dir, namespace, LogKind::Daily, &stem)
         .is_some_and(|b| !b.trim().is_empty());
     if sessions.is_empty() && !has_existing {
-        info!("No sessions found for {date}, skipping daily log");
+        info!("No sessions found for {date} in namespace '{namespace}', skipping daily log");
         return Ok(false);
     }
 
@@ -258,6 +279,7 @@ pub async fn generate_daily_log(
         provider,
         ws_state,
         workspace_dir,
+        namespace,
         LogKind::Daily,
         &stem,
         "conversation transcripts",
@@ -279,6 +301,7 @@ pub async fn generate_weekly_log(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     iso_year: i32,
     iso_week: u32,
 ) -> anyhow::Result<bool> {
@@ -286,12 +309,14 @@ pub async fn generate_weekly_log(
     let days = days_of_iso_week(iso_year, iso_week);
     let mut sections = Vec::new();
     for day in &days {
-        if let Some(body) = read_body(workspace_dir, LogKind::Daily, &daily_stem(*day)) {
+        if let Some(body) = read_body(workspace_dir, namespace, LogKind::Daily, &daily_stem(*day)) {
             sections.push(body);
         }
     }
     if sections.is_empty() {
-        info!("No daily logs found for ISO week {stem}, skipping weekly log");
+        info!(
+            "No daily logs found for ISO week {stem} in namespace '{namespace}', skipping weekly log"
+        );
         return Ok(false);
     }
     let input = sections.join("\n\n---\n\n");
@@ -300,6 +325,7 @@ pub async fn generate_weekly_log(
         provider,
         ws_state,
         workspace_dir,
+        namespace,
         LogKind::Weekly,
         &stem,
         &description,
@@ -322,6 +348,7 @@ pub async fn generate_monthly_log(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     year: i32,
     month: u32,
 ) -> anyhow::Result<bool> {
@@ -329,12 +356,14 @@ pub async fn generate_monthly_log(
     let days = days_of_month(year, month);
     let mut sections = Vec::new();
     for day in &days {
-        if let Some(body) = read_body(workspace_dir, LogKind::Daily, &daily_stem(*day)) {
+        if let Some(body) = read_body(workspace_dir, namespace, LogKind::Daily, &daily_stem(*day)) {
             sections.push(body);
         }
     }
     if sections.is_empty() {
-        info!("No daily logs found for month {stem}, skipping monthly log");
+        info!(
+            "No daily logs found for month {stem} in namespace '{namespace}', skipping monthly log"
+        );
         return Ok(false);
     }
     let input = sections.join("\n\n---\n\n");
@@ -343,6 +372,7 @@ pub async fn generate_monthly_log(
         provider,
         ws_state,
         workspace_dir,
+        namespace,
         LogKind::Monthly,
         &stem,
         &description,
@@ -364,18 +394,21 @@ pub async fn generate_yearly_log(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     year: i32,
 ) -> anyhow::Result<bool> {
     let stem = yearly_stem(year);
     let mut sections = Vec::new();
     for month in 1..=12 {
         let m_stem = monthly_stem(year, month);
-        if let Some(body) = read_body(workspace_dir, LogKind::Monthly, &m_stem) {
+        if let Some(body) = read_body(workspace_dir, namespace, LogKind::Monthly, &m_stem) {
             sections.push(body);
         }
     }
     if sections.is_empty() {
-        info!("No monthly logs found for year {stem}, skipping yearly log");
+        info!(
+            "No monthly logs found for year {stem} in namespace '{namespace}', skipping yearly log"
+        );
         return Ok(false);
     }
     let input = sections.join("\n\n---\n\n");
@@ -384,6 +417,7 @@ pub async fn generate_yearly_log(
         provider,
         ws_state,
         workspace_dir,
+        namespace,
         LogKind::Yearly,
         &stem,
         &description,
@@ -400,8 +434,13 @@ pub async fn generate_yearly_log(
 /// Return the Markdown body of `memory/{kind}/{stem}.md` with any YAML
 /// frontmatter stripped. Returns `None` when the file does not exist or
 /// cannot be read.
-pub fn read_body(workspace_dir: &Path, kind: LogKind, stem: &str) -> Option<String> {
-    let raw = std::fs::read_to_string(log_abs_path(workspace_dir, kind, stem)).ok()?;
+pub fn read_body(
+    workspace_dir: &Path,
+    namespace: &str,
+    kind: LogKind,
+    stem: &str,
+) -> Option<String> {
+    let raw = std::fs::read_to_string(log_abs_path(workspace_dir, namespace, kind, stem)).ok()?;
     Some(match crate::frontmatter::split(&raw) {
         Some((_, body)) => body.trim_start_matches('\n').to_string(),
         None => raw,
@@ -413,11 +452,12 @@ pub fn read_body(workspace_dir: &Path, kind: LogKind, stem: &str) -> Option<Stri
 /// missing; returns `Some(vec![])` when `digest: []` is explicitly empty.
 pub fn read_digest_top_n(
     workspace_dir: &Path,
+    namespace: &str,
     kind: LogKind,
     stem: &str,
     n: usize,
 ) -> Option<Vec<String>> {
-    let raw = std::fs::read_to_string(log_abs_path(workspace_dir, kind, stem)).ok()?;
+    let raw = std::fs::read_to_string(log_abs_path(workspace_dir, namespace, kind, stem)).ok()?;
     let (fm, _) = crate::frontmatter::split(&raw)?;
     let mapping = crate::frontmatter::parse_mapping(fm);
     let seq = mapping.get("digest")?.as_sequence()?;
@@ -455,6 +495,7 @@ async fn write_log_with_digest(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     kind: LogKind,
     stem: &str,
     input_description: &str,
@@ -467,12 +508,13 @@ async fn write_log_with_digest(
     // Monday. Feed it into the summariser so its facts aren't erased by
     // the overwrite.
     let existing_body =
-        read_body(workspace_dir, kind, stem).filter(|b| !b.trim().is_empty());
+        read_body(workspace_dir, namespace, kind, stem).filter(|b| !b.trim().is_empty());
     let has_existing = existing_body.is_some();
 
     let combined_input = match &existing_body {
         Some(existing) => format!(
-            "## Existing draft at `memory/{}/{}.md` — preserve its plans, commitments, and unresolved items\n\n{}\n\n---\n\n## New source material ({})\n\n{}",
+            "## Existing draft at `memory/{}/{}/{}.md` — preserve its plans, commitments, and unresolved items\n\n{}\n\n---\n\n## New source material ({})\n\n{}",
+            namespace,
             kind.dir(),
             stem,
             existing.trim_end(),
@@ -522,7 +564,7 @@ Japanese). Emit raw Markdown, not a fenced code block."
     let heading = format!("# {label}: {stem}\n\n");
     let file = serialize_log_file(&digest, &format!("{heading}{}\n", body.trim_end()))?;
 
-    let rel = log_rel_path(kind, stem);
+    let rel = log_rel_path(namespace, kind, stem);
     ws_state
         .lock()
         .expect("WorkspaceState mutex poisoned")
@@ -739,8 +781,9 @@ pub async fn catchup_missing_daily_digests(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
 ) -> usize {
-    let dir = workspace_dir.join("memory").join("daily");
+    let dir = workspace_dir.join("memory").join(namespace).join("daily");
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(_) => return 0,
@@ -814,18 +857,33 @@ pub async fn catchup_missing_daily_digests(
 /// Errors are logged but not propagated so startup is not blocked.
 /// Returns the number of logs successfully generated, so callers can decide
 /// whether to invalidate downstream caches.
-pub async fn catchup_pending_daily_logs(
+pub async fn catchup_pending_daily_logs<F>(
     session_store: &SessionStore,
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     boundary_hour: u8,
-) -> usize {
-    let pending = pending_daily_dates(session_store, workspace_dir, boundary_hour);
+    room_predicate: F,
+) -> usize
+where
+    F: Fn(&crate::session::SessionMeta) -> bool + Copy,
+{
+    let pending = pending_daily_dates(
+        session_store,
+        workspace_dir,
+        namespace,
+        boundary_hour,
+        room_predicate,
+    );
     if pending.is_empty() {
         return 0;
     }
-    info!("Generating {} pending daily log(s)…", pending.len());
+    info!(
+        "Generating {} pending daily log(s) for namespace '{}'…",
+        pending.len(),
+        namespace
+    );
     let mut generated = 0;
     for date in pending {
         match generate_daily_log(
@@ -833,14 +891,16 @@ pub async fn catchup_pending_daily_logs(
             provider,
             ws_state,
             workspace_dir,
+            namespace,
             date,
             boundary_hour,
+            room_predicate,
         )
         .await
         {
             Ok(true) => generated += 1,
             Ok(false) => {}
-            Err(e) => warn!("Failed to generate daily log for {date}: {e:#}"),
+            Err(e) => warn!("Failed to generate daily log for {date} in '{namespace}': {e:#}"),
         }
     }
     generated
@@ -850,10 +910,11 @@ pub async fn catchup_pending_daily_logs(
 // Weekly / monthly / yearly catch-up
 // ---------------------------------------------------------------------------
 
-/// Distinct daily log dates on disk (i.e. stems in `memory/daily/*.md` that
-/// parse as `YYYY-MM-DD`). Used as the seed for weekly/monthly catch-up.
-fn existing_daily_dates(workspace_dir: &Path) -> Vec<NaiveDate> {
-    let dir = workspace_dir.join("memory").join("daily");
+/// Distinct daily log dates on disk for `namespace` (i.e. stems in
+/// `memory/<namespace>/daily/*.md` that parse as `YYYY-MM-DD`). Used as
+/// the seed for weekly/monthly catch-up.
+fn existing_daily_dates(workspace_dir: &Path, namespace: &str) -> Vec<NaiveDate> {
+    let dir = workspace_dir.join("memory").join(namespace).join("daily");
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
@@ -873,10 +934,11 @@ fn existing_daily_dates(workspace_dir: &Path) -> Vec<NaiveDate> {
     out
 }
 
-/// Distinct monthly log stems on disk (i.e. files in `memory/monthly/*.md`
-/// that parse as `YYYY-MM`). Used as the seed for yearly catch-up.
-fn existing_monthly_year_months(workspace_dir: &Path) -> Vec<(i32, u32)> {
-    let dir = workspace_dir.join("memory").join("monthly");
+/// Distinct monthly log stems on disk for `namespace` (i.e. files in
+/// `memory/<namespace>/monthly/*.md` that parse as `YYYY-MM`). Used as
+/// the seed for yearly catch-up.
+fn existing_monthly_year_months(workspace_dir: &Path, namespace: &str) -> Vec<(i32, u32)> {
+    let dir = workspace_dir.join("memory").join(namespace).join("monthly");
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
@@ -905,12 +967,16 @@ fn existing_monthly_year_months(workspace_dir: &Path) -> Vec<(i32, u32)> {
 /// Returns ISO (year, week) pairs that have at least one daily log on disk
 /// but no weekly log file yet, excluding `today`'s own ISO week. Sorted
 /// ascending by (year, week).
-pub fn pending_iso_weeks(workspace_dir: &Path, today: NaiveDate) -> Vec<(i32, u32)> {
+pub fn pending_iso_weeks(
+    workspace_dir: &Path,
+    namespace: &str,
+    today: NaiveDate,
+) -> Vec<(i32, u32)> {
     use std::collections::BTreeSet;
     let current_iso = today.iso_week();
     let current_key = (current_iso.year(), current_iso.week());
     let mut weeks: BTreeSet<(i32, u32)> = BTreeSet::new();
-    for date in existing_daily_dates(workspace_dir) {
+    for date in existing_daily_dates(workspace_dir, namespace) {
         let iso = date.iso_week();
         let key = (iso.year(), iso.week());
         if key >= current_key {
@@ -921,7 +987,7 @@ pub fn pending_iso_weeks(workspace_dir: &Path, today: NaiveDate) -> Vec<(i32, u3
     weeks
         .into_iter()
         .filter(|(y, w)| {
-            !log_abs_path(workspace_dir, LogKind::Weekly, &weekly_stem(*y, *w)).exists()
+            !log_abs_path(workspace_dir, namespace, LogKind::Weekly, &weekly_stem(*y, *w)).exists()
         })
         .collect()
 }
@@ -929,11 +995,15 @@ pub fn pending_iso_weeks(workspace_dir: &Path, today: NaiveDate) -> Vec<(i32, u3
 /// Returns calendar (year, month) pairs that have at least one daily log on
 /// disk but no monthly log file yet, excluding `today`'s own month. Sorted
 /// ascending.
-pub fn pending_months(workspace_dir: &Path, today: NaiveDate) -> Vec<(i32, u32)> {
+pub fn pending_months(
+    workspace_dir: &Path,
+    namespace: &str,
+    today: NaiveDate,
+) -> Vec<(i32, u32)> {
     use std::collections::BTreeSet;
     let current_key = (today.year(), today.month());
     let mut months: BTreeSet<(i32, u32)> = BTreeSet::new();
-    for date in existing_daily_dates(workspace_dir) {
+    for date in existing_daily_dates(workspace_dir, namespace) {
         let key = (date.year(), date.month());
         if key >= current_key {
             continue;
@@ -943,18 +1013,19 @@ pub fn pending_months(workspace_dir: &Path, today: NaiveDate) -> Vec<(i32, u32)>
     months
         .into_iter()
         .filter(|(y, m)| {
-            !log_abs_path(workspace_dir, LogKind::Monthly, &monthly_stem(*y, *m)).exists()
+            !log_abs_path(workspace_dir, namespace, LogKind::Monthly, &monthly_stem(*y, *m))
+                .exists()
         })
         .collect()
 }
 
 /// Returns calendar years that have at least one monthly log on disk but no
 /// yearly log file yet, excluding `today`'s own year. Sorted ascending.
-pub fn pending_years(workspace_dir: &Path, today: NaiveDate) -> Vec<i32> {
+pub fn pending_years(workspace_dir: &Path, namespace: &str, today: NaiveDate) -> Vec<i32> {
     use std::collections::BTreeSet;
     let current_year = today.year();
     let mut years: BTreeSet<i32> = BTreeSet::new();
-    for (y, _m) in existing_monthly_year_months(workspace_dir) {
+    for (y, _m) in existing_monthly_year_months(workspace_dir, namespace) {
         if y >= current_year {
             continue;
         }
@@ -962,7 +1033,9 @@ pub fn pending_years(workspace_dir: &Path, today: NaiveDate) -> Vec<i32> {
     }
     years
         .into_iter()
-        .filter(|y| !log_abs_path(workspace_dir, LogKind::Yearly, &yearly_stem(*y)).exists())
+        .filter(|y| {
+            !log_abs_path(workspace_dir, namespace, LogKind::Yearly, &yearly_stem(*y)).exists()
+        })
         .collect()
 }
 
@@ -973,21 +1046,35 @@ pub async fn catchup_pending_weekly_logs(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     today: NaiveDate,
 ) -> usize {
-    let pending = pending_iso_weeks(workspace_dir, today);
+    let pending = pending_iso_weeks(workspace_dir, namespace, today);
     if pending.is_empty() {
         return 0;
     }
-    info!("Generating {} pending weekly log(s)…", pending.len());
+    info!(
+        "Generating {} pending weekly log(s) for namespace '{}'…",
+        pending.len(),
+        namespace
+    );
     let mut generated = 0;
     for (iso_year, iso_week) in pending {
-        match generate_weekly_log(provider, ws_state, workspace_dir, iso_year, iso_week).await {
+        match generate_weekly_log(
+            provider,
+            ws_state,
+            workspace_dir,
+            namespace,
+            iso_year,
+            iso_week,
+        )
+        .await
+        {
             Ok(true) => generated += 1,
             Ok(false) => {}
             Err(e) => warn!(
-                "Failed to generate weekly log for {}-W{:02}: {e:#}",
-                iso_year, iso_week
+                "Failed to generate weekly log for {}-W{:02} in '{}': {e:#}",
+                iso_year, iso_week, namespace
             ),
         }
     }
@@ -1000,21 +1087,27 @@ pub async fn catchup_pending_monthly_logs(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     today: NaiveDate,
 ) -> usize {
-    let pending = pending_months(workspace_dir, today);
+    let pending = pending_months(workspace_dir, namespace, today);
     if pending.is_empty() {
         return 0;
     }
-    info!("Generating {} pending monthly log(s)…", pending.len());
+    info!(
+        "Generating {} pending monthly log(s) for namespace '{}'…",
+        pending.len(),
+        namespace
+    );
     let mut generated = 0;
     for (year, month) in pending {
-        match generate_monthly_log(provider, ws_state, workspace_dir, year, month).await {
+        match generate_monthly_log(provider, ws_state, workspace_dir, namespace, year, month).await
+        {
             Ok(true) => generated += 1,
             Ok(false) => {}
             Err(e) => warn!(
-                "Failed to generate monthly log for {:04}-{:02}: {e:#}",
-                year, month
+                "Failed to generate monthly log for {:04}-{:02} in '{}': {e:#}",
+                year, month, namespace
             ),
         }
     }
@@ -1027,19 +1120,27 @@ pub async fn catchup_pending_yearly_logs(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
     workspace_dir: &Path,
+    namespace: &str,
     today: NaiveDate,
 ) -> usize {
-    let pending = pending_years(workspace_dir, today);
+    let pending = pending_years(workspace_dir, namespace, today);
     if pending.is_empty() {
         return 0;
     }
-    info!("Generating {} pending yearly log(s)…", pending.len());
+    info!(
+        "Generating {} pending yearly log(s) for namespace '{}'…",
+        pending.len(),
+        namespace
+    );
     let mut generated = 0;
     for year in pending {
-        match generate_yearly_log(provider, ws_state, workspace_dir, year).await {
+        match generate_yearly_log(provider, ws_state, workspace_dir, namespace, year).await {
             Ok(true) => generated += 1,
             Ok(false) => {}
-            Err(e) => warn!("Failed to generate yearly log for {year:04}: {e:#}"),
+            Err(e) => warn!(
+                "Failed to generate yearly log for {year:04} in '{}': {e:#}",
+                namespace
+            ),
         }
     }
     generated
@@ -1081,10 +1182,13 @@ mod tests {
 
     #[test]
     fn paths() {
-        let abs = log_abs_path(Path::new("/ws"), LogKind::Weekly, "2026-W16");
-        assert_eq!(abs, PathBuf::from("/ws/memory/weekly/2026-W16.md"));
-        let rel = log_rel_path(LogKind::Monthly, "2026-04");
-        assert_eq!(rel, PathBuf::from("memory/monthly/2026-04.md"));
+        let abs = log_abs_path(Path::new("/ws"), "default", LogKind::Weekly, "2026-W16");
+        assert_eq!(abs, PathBuf::from("/ws/memory/default/weekly/2026-W16.md"));
+        let rel = log_rel_path("default", LogKind::Monthly, "2026-04");
+        assert_eq!(rel, PathBuf::from("memory/default/monthly/2026-04.md"));
+        // Non-default namespace.
+        let abs = log_abs_path(Path::new("/ws"), "user_nsfw", LogKind::Daily, "2026-05-05");
+        assert_eq!(abs, PathBuf::from("/ws/memory/user_nsfw/daily/2026-05-05.md"));
     }
 
     #[test]
@@ -1321,18 +1425,18 @@ mod tests {
             "2026-03-30", // Mon W14
         ] {
             write_stub(
-                &root.join("memory/daily").join(format!("{d}.md")),
+                &root.join("memory/default/daily").join(format!("{d}.md")),
                 "# body\n",
             );
         }
         // An existing weekly file for W14 — should be filtered out.
         write_stub(
-            &root.join("memory/weekly/2026-W14.md"),
+            &root.join("memory/default/weekly/2026-W14.md"),
             "---\ndigest: []\n---\nbody\n",
         );
 
         let today = NaiveDate::from_ymd_opt(2026, 4, 16).unwrap();
-        let pending = pending_iso_weeks(root, today);
+        let pending = pending_iso_weeks(root, "default", today);
         assert_eq!(pending, vec![(2026, 15)]);
     }
 
@@ -1346,17 +1450,17 @@ mod tests {
             "2026-04-02", "2026-04-16", // Apr (current)
         ] {
             write_stub(
-                &root.join("memory/daily").join(format!("{d}.md")),
+                &root.join("memory/default/daily").join(format!("{d}.md")),
                 "# body\n",
             );
         }
         write_stub(
-            &root.join("memory/monthly/2026-02.md"),
+            &root.join("memory/default/monthly/2026-02.md"),
             "---\ndigest: []\n---\nbody\n",
         );
 
         let today = NaiveDate::from_ymd_opt(2026, 4, 16).unwrap();
-        let pending = pending_months(root, today);
+        let pending = pending_months(root, "default", today);
         assert_eq!(pending, vec![(2026, 3)]);
     }
 
@@ -1366,18 +1470,18 @@ mod tests {
         let root = td.path();
         for stem in ["2024-06", "2024-12", "2025-01", "2026-03"] {
             write_stub(
-                &root.join("memory/monthly").join(format!("{stem}.md")),
+                &root.join("memory/default/monthly").join(format!("{stem}.md")),
                 "# body\n",
             );
         }
         // Existing yearly for 2024 — should be excluded.
         write_stub(
-            &root.join("memory/yearly/2024.md"),
+            &root.join("memory/default/yearly/2024.md"),
             "---\ndigest: []\n---\nbody\n",
         );
 
         let today = NaiveDate::from_ymd_opt(2026, 4, 16).unwrap();
-        let pending = pending_years(root, today);
+        let pending = pending_years(root, "default", today);
         // 2024 exists → skipped. 2025 missing → pending. 2026 = current → skipped.
         assert_eq!(pending, vec![2025]);
     }
@@ -1386,9 +1490,9 @@ mod tests {
     fn pending_enumerations_handle_missing_directories() {
         let td = make_tempdir();
         let today = NaiveDate::from_ymd_opt(2026, 4, 16).unwrap();
-        assert!(pending_iso_weeks(td.path(), today).is_empty());
-        assert!(pending_months(td.path(), today).is_empty());
-        assert!(pending_years(td.path(), today).is_empty());
+        assert!(pending_iso_weeks(td.path(), "default", today).is_empty());
+        assert!(pending_months(td.path(), "default", today).is_empty());
+        assert!(pending_years(td.path(), "default", today).is_empty());
     }
 
     #[test]

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -376,8 +376,9 @@ model = "gemma-4-31b-it"
 [profiles.nsfw]
 provider = "local"
 
-[rooms."!nsfw:srv"]
+[room_profile.private_nsfw]
 profile = "nsfw"
+rooms   = ["!nsfw:srv"]
 "#,
         );
         let reg = ProviderRegistry::from_config(&cfg).unwrap();

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -120,6 +120,27 @@ impl ProviderRegistry {
             self.anthropic()
         }
     }
+
+    /// Provider used by background tasks operating under a specific memory
+    /// namespace. Resolution order:
+    ///
+    ///   1. `memory_namespace.<n>.background_profile` if set
+    ///   2. global `[profiles.background]` if defined
+    ///   3. plain Anthropic
+    ///
+    /// Lets an NSFW namespace route directly to its permissive local
+    /// provider without paying a refusal-fallback hop on every daily-log
+    /// generation.
+    pub fn background_provider_for_namespace(
+        &self,
+        config: &Config,
+        namespace: &str,
+    ) -> Arc<dyn Provider> {
+        match config.background_profile_for_namespace(namespace) {
+            Some(profile_name) => self.for_profile(config, profile_name),
+            None => self.anthropic(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -261,6 +282,65 @@ fallback_provider = "local"
         assert!(
             !Arc::ptr_eq(&raw_anthropic, &bg),
             "background provider should be wrapped when profile has fallback"
+        );
+    }
+
+    #[test]
+    fn background_provider_for_namespace_uses_namespace_override() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.local_only]
+provider = "local"
+
+[memory_namespace.user_nsfw]
+include            = ["default"]
+background_profile = "local_only"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        let p = reg.background_provider_for_namespace(&cfg, "user_nsfw");
+        assert_eq!(p.name(), "local");
+        // Namespaces without their own override fall back to anthropic
+        // when no global [profiles.background] is defined.
+        let p_default = reg.background_provider_for_namespace(&cfg, "default");
+        assert_eq!(p_default.name(), "anthropic");
+    }
+
+    #[test]
+    fn background_provider_for_namespace_falls_back_to_global() {
+        let cfg = parse(
+            r#"
+[anthropic]
+api_key = "test"
+
+[providers.local]
+type = "openai_compatible"
+base_url = "http://127.0.0.1:8080/v1"
+model = "gemma-4-31b-it"
+
+[profiles.background]
+provider          = "anthropic"
+fallback_provider = "local"
+"#,
+        );
+        let reg = ProviderRegistry::from_config(&cfg).unwrap();
+        // No namespace override → use the global [profiles.background].
+        // The provider's name forwards to the primary (anthropic), but a
+        // FallbackProvider was wrapped around it — verify by Arc identity
+        // against the bare anthropic provider.
+        let raw_anthropic = reg.anthropic();
+        let p = reg.background_provider_for_namespace(&cfg, "default");
+        assert!(
+            !Arc::ptr_eq(&raw_anthropic, &p),
+            "expected wrapped FallbackProvider, got the bare anthropic Arc"
         );
     }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -47,25 +47,27 @@ pub struct ServeState {
     /// that quitting without sending anything leaves no empty file behind.
     /// Maps internal UUID → reserved public_id (grain-id).
     pending_sessions: tokio::sync::Mutex<HashMap<String, String>>,
-    /// Per-session profile assignment from `initialize`. Sessions absent from
-    /// this map fall through to the background provider. Not persisted across
-    /// restarts — clients must re-pass `profile` on resume.
-    session_profiles: tokio::sync::Mutex<HashMap<String, String>>,
+    /// Per-session room_profile pin from `initialize`. Sessions absent
+    /// from this map fall through to the background provider. Not
+    /// persisted across restarts — clients must re-pass `room_profile`
+    /// on resume.
+    session_room_profiles: tokio::sync::Mutex<HashMap<String, String>>,
 }
 
 impl ServeState {
-    /// Provider that should serve the given session: the profile-bound
-    /// primary (with optional refusal fallback) when the client picked a
-    /// profile at initialize-time, otherwise the background provider.
+    /// Provider that should serve the given session. Resolves the
+    /// session's pinned room_profile to its `profile`, then to a
+    /// concrete provider (with optional refusal fallback). Falls back
+    /// to the background provider when no room_profile is pinned.
     async fn provider_for_session(&self, session_id: &str) -> Arc<dyn Provider> {
-        let profile = self
-            .session_profiles
+        let rp_name = self
+            .session_room_profiles
             .lock()
             .await
             .get(session_id)
             .cloned();
-        match profile {
-            Some(name) => self.registry.for_profile(&self.config, &name),
+        match rp_name.and_then(|n| self.config.room_profile(&n).map(|rp| rp.profile.clone())) {
+            Some(profile_name) => self.registry.for_profile(&self.config, &profile_name),
             None => self.registry.background_provider(&self.config),
         }
     }
@@ -140,7 +142,7 @@ pub async fn run(
         api_session_store,
         sessions: tokio::sync::Mutex::new(HashMap::new()),
         pending_sessions: tokio::sync::Mutex::new(HashMap::new()),
-        session_profiles: tokio::sync::Mutex::new(HashMap::new()),
+        session_room_profiles: tokio::sync::Mutex::new(HashMap::new()),
     });
 
     let app = Router::new()
@@ -247,16 +249,18 @@ async fn handle_initialize(
     params: Option<Value>,
     existing_header_session: Option<String>,
 ) -> axum::response::Response {
-    // Optional `params.profile` — must reference a defined `[profiles.*]`
-    // entry. Rejected eagerly so misspellings surface at session start
-    // rather than as a silent fallback to the background provider.
-    let requested_profile: Option<String> = params
+    // Optional `params.room_profile` — must reference a defined
+    // `[room_profile.<n>]` entry. Rejected eagerly so misspellings
+    // surface at session start rather than as a silent fallback to
+    // the background provider.
+    let requested_room_profile: Option<String> = params
         .as_ref()
-        .and_then(|p| p["profile"].as_str())
+        .and_then(|p| p["room_profile"].as_str())
         .map(|s| s.to_string());
-    if let Some(name) = &requested_profile {
-        if !state.config.profiles.contains_key(name) {
-            let body = error_response(req_id, -32602, &format!("Unknown profile '{name}'"));
+    if let Some(name) = &requested_room_profile {
+        if state.config.room_profile(name).is_none() {
+            let body =
+                error_response(req_id, -32602, &format!("Unknown room_profile '{name}'"));
             return body.into_response();
         }
     }
@@ -331,9 +335,9 @@ async fn handle_initialize(
             .and_then(|m| m.public_id)
     };
 
-    if let Some(name) = requested_profile {
+    if let Some(name) = requested_room_profile {
         state
-            .session_profiles
+            .session_room_profiles
             .lock()
             .await
             .insert(session_id.clone(), name);
@@ -346,8 +350,8 @@ async fn handle_initialize(
     if let Some(ref pub_id) = public_id {
         result["public_id"] = json!(pub_id);
     }
-    if let Some(name) = state.session_profiles.lock().await.get(&session_id) {
-        result["profile"] = json!(name);
+    if let Some(name) = state.session_room_profiles.lock().await.get(&session_id) {
+        result["room_profile"] = json!(name);
     }
 
     let body = json!({
@@ -554,10 +558,10 @@ async fn run_turn(
     let provider = state.provider_for_session(&session_id).await;
 
     // 3a. System prompt (rebuilt fresh per request). Namespace chain
-    //     follows the session's pinned profile when set, otherwise the
-    //     implicit default namespace.
-    let namespace = match state.session_profiles.lock().await.get(&session_id) {
-        Some(profile) => state.config.namespace_for_profile(profile).to_string(),
+    //     follows the session's pinned room_profile when set; otherwise
+    //     the implicit default namespace.
+    let namespace = match state.session_room_profiles.lock().await.get(&session_id) {
+        Some(rp_name) => state.config.namespace_for_room_profile(rp_name).to_string(),
         None => crate::config::DEFAULT_NAMESPACE_NAME.to_string(),
     };
     let namespace_chain = state.config.resolve_namespace_chain(&namespace);

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -553,13 +553,21 @@ async fn run_turn(
     //    initialize-time; absent that, the background provider is used.
     let provider = state.provider_for_session(&session_id).await;
 
-    // 3a. System prompt (rebuilt fresh per request)
+    // 3a. System prompt (rebuilt fresh per request). Namespace chain
+    //     follows the session's pinned profile when set, otherwise the
+    //     implicit default namespace.
+    let namespace = match state.session_profiles.lock().await.get(&session_id) {
+        Some(profile) => state.config.namespace_for_profile(profile).to_string(),
+        None => crate::config::DEFAULT_NAMESPACE_NAME.to_string(),
+    };
+    let namespace_chain = state.config.resolve_namespace_chain(&namespace);
     let system = {
         let sp = state
             .workspace
             .build_system_prompt(
                 state.config.anthropic.system_prompt.as_deref(),
                 state.config.day_boundary_hour,
+                &namespace_chain,
             )
             .await;
         if sp.is_empty() { None } else { Some(sp) }
@@ -659,18 +667,22 @@ async fn run_turn(
                     .await;
                 }
 
-                // Execute all tools concurrently
+                // Execute all tools concurrently — each call wrapped in
+                // the session's memory namespace (task_local) so the
+                // memory tool writes under `memory/<namespace>/...`.
                 let tools = Arc::clone(&state.tools);
+                let ns = namespace.clone();
                 let results: Vec<(String, String)> =
                     futures_util::future::join_all(tool_calls.iter().map(|c| {
                         let tools = Arc::clone(&tools);
                         let c = c.clone();
-                        async move {
+                        let ns = ns.clone();
+                        crate::tools::workspace_tools::scope_memory_namespace(ns, async move {
                             info!("Executing tool: {} (id={})", c.name, c.id);
                             let result = tools.execute(&c).await;
                             info!("Tool {} done", c.name);
                             (c.id, result)
-                        }
+                        })
                     }))
                     .await;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -486,6 +486,66 @@ impl SessionStore {
         results
     }
 
+    /// Like `sessions_for_day`, but only returns sessions for which
+    /// `predicate(&meta)` is true. Used by daily-log generation when it
+    /// runs per memory namespace: the caller supplies a predicate that
+    /// keeps only rooms mapped to the namespace being generated.
+    pub fn sessions_for_day_filtered<F>(
+        &self,
+        date: NaiveDate,
+        boundary_hour: u8,
+        predicate: F,
+    ) -> Vec<(SessionMeta, Vec<StoredMessage>)>
+    where
+        F: Fn(&SessionMeta) -> bool,
+    {
+        self.sessions_for_day(date, boundary_hour)
+            .into_iter()
+            .filter(|(meta, _)| predicate(meta))
+            .collect()
+    }
+
+    /// Like `all_session_dates`, but only counts sessions whose `meta`
+    /// satisfies `predicate`. Used so per-namespace daily-log catch-up
+    /// only enumerates dates that have at least one in-namespace session.
+    pub fn all_session_dates_filtered<F>(
+        &self,
+        boundary_hour: u8,
+        predicate: F,
+    ) -> Vec<NaiveDate>
+    where
+        F: Fn(&SessionMeta) -> bool,
+    {
+        let dir = match fs::read_dir(&self.sessions_dir) {
+            Ok(d) => d,
+            Err(_) => return vec![],
+        };
+
+        let mut dates = std::collections::HashSet::new();
+
+        for entry in dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            if let Some((meta, messages, _, _)) = load_session_file(&path) {
+                if !predicate(&meta) {
+                    continue;
+                }
+                for msg in messages {
+                    let local_ts = msg.timestamp.with_timezone(&Local);
+                    let date = local_date_for_timestamp(local_ts, boundary_hour);
+                    dates.insert(date);
+                }
+            }
+        }
+
+        let mut sorted: Vec<NaiveDate> = dates.into_iter().collect();
+        sorted.sort();
+        sorted
+    }
+
     /// Return all local dates for which at least one session message exists.
     /// Used by daily_log to find dates that need a log generated.
     pub fn all_session_dates(&self, boundary_hour: u8) -> Vec<NaiveDate> {

--- a/src/tools/workspace_tools.rs
+++ b/src/tools/workspace_tools.rs
@@ -18,6 +18,41 @@ fn lock(state: &Mutex<WorkspaceState>) -> std::sync::MutexGuard<'_, WorkspaceSta
 }
 
 // ---------------------------------------------------------------------------
+// Active memory namespace
+// ---------------------------------------------------------------------------
+//
+// The memory tool needs to know which namespace to write under
+// (`memory/<namespace>/<category>/<slug>.md`). The choice is per chat
+// turn — Matrix/Discord rooms and pinned API sessions each map to their
+// own namespace via Config — but the Tool trait's `execute(input)` API
+// has no per-call context. Bridging that with a `tokio::task_local` lets
+// the agent and serve loops scope each tool execution without changing
+// the trait, and keeps the default ("default") behaviour for any future
+// caller that forgets to scope.
+
+tokio::task_local! {
+    static MEMORY_NAMESPACE_TL: String;
+}
+
+/// Run `fut` with `MEMORY_NAMESPACE_TL` set to `namespace`. Used by the
+/// agent / API serve loops to scope per-turn tool executions to the
+/// caller's namespace.
+pub fn scope_memory_namespace<F: std::future::Future>(
+    namespace: String,
+    fut: F,
+) -> impl std::future::Future<Output = F::Output> {
+    MEMORY_NAMESPACE_TL.scope(namespace, fut)
+}
+
+/// The namespace this turn's tool calls should read/write under. Falls
+/// back to `"default"` when called outside a `scope_memory_namespace`.
+fn current_memory_namespace() -> String {
+    MEMORY_NAMESPACE_TL
+        .try_with(|s| s.clone())
+        .unwrap_or_else(|_| crate::config::DEFAULT_NAMESPACE_NAME.to_string())
+}
+
+// ---------------------------------------------------------------------------
 // memory
 // ---------------------------------------------------------------------------
 
@@ -52,7 +87,8 @@ fn memory_entry_path(
 ) -> Result<(String, std::path::PathBuf)> {
     validate_segment("category", category)?;
     validate_segment("slug", slug)?;
-    let rel = format!("memory/{category}/{slug}.md");
+    let namespace = current_memory_namespace();
+    let rel = format!("memory/{namespace}/{category}/{slug}.md");
     let abs = lock(state).workspace.root.join(&rel);
     Ok((rel, abs))
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -23,7 +23,9 @@ struct WorkspaceFileDef {
 }
 
 /// Ordered list of workspace files, following openclaw's convention.
-/// Files that don't exist are silently skipped.
+/// Files that don't exist are silently skipped. MEMORY.md is **not**
+/// included here — it lives under `memory/<namespace>/MEMORY.md` and is
+/// assembled per turn from the room's namespace chain.
 /// See: https://github.com/openclaw/openclaw (src/agents/workspace.ts)
 static WORKSPACE_FILES: &[WorkspaceFileDef] = &[
     // openclaw uses "AGENTS.md" (plural); we also accept "AGENT.md" for
@@ -51,11 +53,6 @@ static WORKSPACE_FILES: &[WorkspaceFileDef] = &[
     WorkspaceFileDef {
         candidates: &["BOOTSTRAP.md"],
         heading: "# Bootstrap",
-    },
-    // openclaw tries "MEMORY.md" first, falls back to lowercase "memory.md".
-    WorkspaceFileDef {
-        candidates: &["MEMORY.md", "memory.md"],
-        heading: "# Memory",
     },
 ];
 
@@ -97,8 +94,20 @@ impl Workspace {
     /// Build the full system prompt:
     /// 1. Base system_prompt from config (if any)
     /// 2. Each workspace file that exists, in openclaw order
-    /// 3. Previous day's daily log (if it exists)
-    pub async fn build_system_prompt(&self, base: Option<&str>, boundary_hour: u8) -> String {
+    /// 3. Chained MEMORY.md from the room's namespace and its includes
+    /// 4. Previous day's daily log (if it exists)
+    ///
+    /// `namespace_chain` is the DFS-pre-order list of namespaces this
+    /// room reads from — typically computed via
+    /// `Config::resolve_namespace_chain(Config::namespace_for_room(room_id))`.
+    /// The first entry is the room's own namespace; later entries are
+    /// included parents.
+    pub async fn build_system_prompt(
+        &self,
+        base: Option<&str>,
+        boundary_hour: u8,
+        namespace_chain: &[String],
+    ) -> String {
         let mut parts: Vec<String> = Vec::new();
 
         if let Some(b) = base.filter(|s| !s.is_empty()) {
@@ -121,37 +130,75 @@ impl Workspace {
             }
         }
 
+        // Per-namespace MEMORY.md, chained.
+        if let Some(block) = self.build_memory_block(namespace_chain).await {
+            parts.push(block);
+        }
+
         // Inject periodic logs (yesterday's full body + digest blocks for
         // this week / month / year / past years).
         let today = crate::session::local_date_for_timestamp(now_local, boundary_hour);
-        self.inject_periodic_logs(&mut parts, today);
+        self.inject_periodic_logs(&mut parts, today, namespace_chain);
 
         parts.join("\n\n---\n\n")
     }
 
-    /// Append log injection blocks to `parts`: yesterday's full body, then
-    /// top-N digest blocks for this week / month / year / past years.
-    fn inject_periodic_logs(&self, parts: &mut Vec<String>, today: chrono::NaiveDate) {
-        // Yesterday's full body (kept verbatim from pre-#42 behaviour).
-        if let Some(yesterday) = today.pred_opt()
+    /// Read MEMORY.md from each namespace in the chain (closest first) and
+    /// concatenate as `## <namespace>` subsections under one combined
+    /// `# Memory` heading. Namespaces with no MEMORY.md are skipped.
+    /// Returns `None` if the entire chain has no MEMORY.md to inject.
+    async fn build_memory_block(&self, namespace_chain: &[String]) -> Option<String> {
+        let mut subsections = Vec::new();
+        for ns in namespace_chain {
+            let rel = format!("memory/{ns}/MEMORY.md");
+            if let Some(content) = self.read_file(&rel).await
+                && !content.trim().is_empty()
+            {
+                subsections.push(format!("## {ns}\n\n{content}"));
+            }
+        }
+        if subsections.is_empty() {
+            None
+        } else {
+            Some(format!("# Memory\n\n{}", subsections.join("\n\n")))
+        }
+    }
+
+    /// Append log injection blocks to `parts`: yesterday's full body
+    /// (room's own namespace only) plus top-N digest blocks aggregated
+    /// across the namespace chain.
+    fn inject_periodic_logs(
+        &self,
+        parts: &mut Vec<String>,
+        today: chrono::NaiveDate,
+        namespace_chain: &[String],
+    ) {
+        // Yesterday's full body — read only from the room's direct
+        // namespace (the first chain entry). Reading from the chain would
+        // balloon the body verbatim; parents' yesterday context is
+        // conveyed through digest items below.
+        if let Some(direct_ns) = namespace_chain.first()
+            && let Some(yesterday) = today.pred_opt()
             && let Some(body) = periodic_log::read_body(
                 &self.dir,
+                direct_ns,
                 LogKind::Daily,
                 &periodic_log::daily_stem(yesterday),
             )
             && !body.trim().is_empty()
         {
             let truncated = truncate_chars(&body, MAX_FILE_CHARS);
-            debug!("Injecting yesterday's daily log: {yesterday}");
+            debug!("Injecting yesterday's daily log from '{direct_ns}': {yesterday}");
             parts.push(format!("# Yesterday's Log\n\n{truncated}"));
         }
 
         // "This Week's Digests" — daily files in `[iso_week_start, yesterday)`.
         if self.digest_cfg.daily_items > 0 {
             let stems = periodic_log::daily_stems_in_current_iso_week_before(today);
-            if let Some(b) = build_digest_block(
+            if let Some(b) = build_chained_digest_block(
                 "# This Week's Digests",
                 &self.dir,
+                namespace_chain,
                 LogKind::Daily,
                 &stems,
                 self.digest_cfg.daily_items,
@@ -164,9 +211,10 @@ impl Workspace {
         // calendar month, excluding the current ISO week.
         if self.digest_cfg.weekly_items > 0 {
             let stems = periodic_log::week_stems_in_month_before(today);
-            if let Some(b) = build_digest_block(
+            if let Some(b) = build_chained_digest_block(
                 "# This Month's Digests",
                 &self.dir,
+                namespace_chain,
                 LogKind::Weekly,
                 &stems,
                 self.digest_cfg.weekly_items,
@@ -178,9 +226,10 @@ impl Workspace {
         // "This Year's Digests" — monthly files Jan..(current month - 1).
         if self.digest_cfg.monthly_items > 0 {
             let stems = periodic_log::month_stems_in_year_before(today);
-            if let Some(b) = build_digest_block(
+            if let Some(b) = build_chained_digest_block(
                 "# This Year's Digests",
                 &self.dir,
+                namespace_chain,
                 LogKind::Monthly,
                 &stems,
                 self.digest_cfg.monthly_items,
@@ -189,17 +238,32 @@ impl Workspace {
             }
         }
 
-        // "Past Years' Digests" — every yearly file on disk.
+        // "Past Years' Digests" — every yearly file on disk for any
+        // namespace in the chain. We compute a per-namespace stem list
+        // since each namespace can have its own yearly files.
         if self.digest_cfg.yearly_items > 0 {
-            let stems = periodic_log::existing_yearly_stems(&self.dir);
-            if let Some(b) = build_digest_block(
-                "# Past Years' Digests",
-                &self.dir,
-                LogKind::Yearly,
-                &stems,
-                self.digest_cfg.yearly_items,
-            ) {
-                parts.push(b);
+            let mut subsections: Vec<String> = Vec::new();
+            for ns in namespace_chain {
+                let stems = periodic_log::existing_yearly_stems(&self.dir, ns);
+                for stem in &stems {
+                    if let Some(items) = periodic_log::read_digest_top_n(
+                        &self.dir,
+                        ns,
+                        LogKind::Yearly,
+                        stem,
+                        self.digest_cfg.yearly_items,
+                    ) {
+                        if items.is_empty() {
+                            continue;
+                        }
+                        let bullets: Vec<String> =
+                            items.into_iter().map(|i| format!("- {i}")).collect();
+                        subsections.push(format!("## {ns}/{stem}\n\n{}", bullets.join("\n")));
+                    }
+                }
+            }
+            if !subsections.is_empty() {
+                parts.push(format!("# Past Years' Digests\n\n{}", subsections.join("\n\n")));
             }
         }
     }
@@ -268,26 +332,30 @@ impl Workspace {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Assemble a heading + per-stem bulleted subsections of top-N digest items.
-/// Each subsection is introduced by `## {stem}` followed by the top-N items
-/// as Markdown bullets. Stems with no digest or an empty digest are skipped.
-/// Returns `None` if every stem was skipped.
-fn build_digest_block(
+/// Assemble a heading + per-`(namespace, stem)` bulleted subsections of
+/// top-N digest items, walking each stem against every namespace in the
+/// chain. Each subsection is introduced by `## {namespace}/{stem}`.
+/// `(namespace, stem)` pairs whose file is missing or has an empty digest
+/// are skipped. Returns `None` if no pair produced a subsection.
+fn build_chained_digest_block(
     heading: &str,
     workspace_dir: &Path,
+    namespace_chain: &[String],
     kind: LogKind,
     stems: &[String],
     n: usize,
 ) -> Option<String> {
     let mut subsections = Vec::new();
-    for stem in stems {
-        let items =
-            periodic_log::read_digest_top_n(workspace_dir, kind, stem, n).unwrap_or_default();
-        if items.is_empty() {
-            continue;
+    for ns in namespace_chain {
+        for stem in stems {
+            let items = periodic_log::read_digest_top_n(workspace_dir, ns, kind, stem, n)
+                .unwrap_or_default();
+            if items.is_empty() {
+                continue;
+            }
+            let bullets: Vec<String> = items.into_iter().map(|i| format!("- {i}")).collect();
+            subsections.push(format!("## {ns}/{stem}\n\n{}", bullets.join("\n")));
         }
-        let bullets: Vec<String> = items.into_iter().map(|i| format!("- {i}")).collect();
-        subsections.push(format!("## {stem}\n\n{}", bullets.join("\n")));
     }
     if subsections.is_empty() {
         None


### PR DESCRIPTION
## Summary

Slices the shared `memory/` tree into per-namespace subtrees so NSFW (or any other class of sensitive content) can no longer contaminate the SFW system prompt via daily-log digests or MEMORY.md compaction. Solves the contamination risk introduced by the refusal-fallback layer in #68.

The hierarchy is explicit (`include = [...]`) so future multi-tenant scenarios — a shared default room visible to everyone, a personal room that adds the user's private memory, a personal NSFW room that further adds explicit memory — stack cleanly without ad-hoc per-feature flags.

## Layout

```
memory/
├── default/
│   ├── MEMORY.md
│   ├── daily/2026-05-05.md
│   ├── weekly/2026-W19.md
│   ├── monthly/2026-05.md
│   └── yearly/2026.md
├── user/
│   ├── MEMORY.md
│   └── daily/...
└── user_nsfw/
    ├── MEMORY.md
    └── daily/...
```

## Configuration

```toml
[memory_namespace.user]
include = ["default"]

[memory_namespace.user_nsfw]
include = ["user"]

[profiles.user_nsfw]
provider         = "local"
memory_namespace = "user_nsfw"
```

The implicit `default` namespace exists even with no `[memory_namespace.*]` block, so existing configs keep working unchanged.

## Behaviour

* **Writes**: each profile pins to one namespace; daily / weekly / monthly / yearly logs and MEMORY.md edits land under `memory/<that namespace>/...`. The memory tool inherits the active namespace via a tokio `task_local` set per turn.
* **Reads**: rooms read the include chain. A `user_nsfw` room's system prompt shows `## user_nsfw/`, `## user/`, and `## default/` digest subsections plus chained MEMORY.md sections. A bare `default` room sees only `## default/...`.
* **Yesterday's full body**: only from the room's direct namespace (parents convey context through digests; chain expansion would balloon the body).
* **Refusal fallback isolation**: because daily logs are now per-namespace, refusals in an NSFW room get fallback-served and written to that namespace, not into `default`. No new fallback plumbing was needed.
* **Migration**: on first startup, an existing `memory/{daily,weekly,monthly,yearly}/` plus top-level MEMORY.md (or lowercase `memory.md`) auto-renames under `memory/default/`. Idempotent; refuses when old and new layouts coexist.

## Test plan

- [x] `cargo test --workspace` — 92 binary tests pass (added 11 namespace tests in config.rs, 5 migration tests in main.rs, updated periodic_log path tests)
- [ ] Live smoke against `~/.saph1na_workspace`: back up, run once, verify `memory/default/...` matches the old layout byte-for-byte
- [ ] NSFW isolation: configure `[memory_namespace.user_nsfw]` + a profile/room pinned to it; verify the day-boundary daily log lands in `memory/user_nsfw/daily/<today>.md` and `memory/default/daily/<today>.md` is untouched
- [ ] System prompt for SFW vs NSFW rooms shows the expected `## namespace/...` subsection sets
- [ ] Memory tool from an NSFW room writes to `memory/user_nsfw/...`

## Known limitations

- Workspace retrieve (FTS / vector) is **not** namespace-filtered. sapphire-workspace 0.10.x has no `path_prefix` API; contamination prevention here is digest- and MEMORY.md-only. Retrieve hits may still cross namespaces. Future work: add `path_prefix` upstream and bump.
- API session profile pinning is in-memory; sessions resumed via `--session` after a restart fall back to the default namespace until the client re-passes `--profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)