### PR TITLE
feat(channel): run Matrix and Discord concurrently

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,4 @@
-use crate::channel::{Attachment, Channel, OutgoingMessage};
+use crate::channel::{Attachment, Channels, OutgoingMessage};
 use crate::config::{Config, SessionPolicy};
 use crate::context_compression::{generate_summary, maybe_compress};
 use crate::provider::registry::ProviderRegistry;
@@ -39,7 +39,7 @@ struct SystemSnapshot {
 
 pub struct Agent {
     config: Config,
-    channel: Arc<dyn Channel>,
+    channels: Arc<Channels>,
     providers: Arc<ProviderRegistry>,
     workspace: Arc<Workspace>,
     tools: Option<Arc<ToolSet>>,
@@ -71,7 +71,7 @@ pub struct Agent {
 impl Agent {
     pub fn new(
         config: Config,
-        channel: Arc<dyn Channel>,
+        channels: Arc<Channels>,
         providers: Arc<ProviderRegistry>,
         workspace: Arc<Workspace>,
         tools: Option<Arc<ToolSet>>,
@@ -86,7 +86,7 @@ impl Agent {
         );
         Self {
             config,
-            channel,
+            channels,
             providers,
             workspace,
             tools,
@@ -123,24 +123,35 @@ impl Agent {
             return;
         }
 
-        // Build the set of room/channel IDs this instance is configured to
-        // handle.  An empty set means "no restriction" (e.g. Discord with
-        // channel_ids = []) and falls back to processing everything.
+        // Build the set of room/channel IDs this instance is configured
+        // to handle. If any configured channel uses the "listen
+        // everywhere" wildcard (Discord with channel_ids = []), treat
+        // the whole agent as unrestricted — narrowing to only the other
+        // channel's explicit set would silently drop everything that
+        // channel was supposed to handle.
+        let mut wildcard = false;
         let allowed: std::collections::HashSet<String> = {
             let mut set = std::collections::HashSet::new();
             if let Some(m) = &self.config.matrix {
-                set.extend(m.room_ids.iter().cloned());
+                if m.room_ids.is_empty() {
+                    wildcard = true;
+                } else {
+                    set.extend(m.room_ids.iter().cloned());
+                }
             }
             if let Some(d) = &self.config.discord {
-                set.extend(d.channel_ids.iter().cloned());
+                if d.channel_ids.is_empty() {
+                    wildcard = true;
+                } else {
+                    set.extend(d.channel_ids.iter().cloned());
+                }
             }
             set
         };
 
         let (to_process, skipped): (Vec<(ConversationKey, Vec<ChatMessage>)>, usize) =
-            if allowed.is_empty() {
-                // No restriction configured (e.g. Discord with channel_ids=[])
-                // — process all sessions.
+            if wildcard || allowed.is_empty() {
+                // No restriction configured — process all sessions.
                 (pending, 0)
             } else {
                 let (yes, no): (Vec<_>, Vec<_>) = pending
@@ -272,9 +283,9 @@ impl Agent {
     pub async fn run(self: Arc<Self>) -> anyhow::Result<()> {
         let (tx, mut rx) = mpsc::channel(64);
 
-        let channel = Arc::clone(&self.channel);
+        let channels = Arc::clone(&self.channels);
         let listen_handle = tokio::spawn(async move {
-            if let Err(e) = channel.listen(tx).await {
+            if let Err(e) = channels.listen_all(tx).await {
                 error!("Channel listen error: {e:#}");
             }
         });
@@ -324,7 +335,17 @@ impl Agent {
         if let Some(id) = sessions.get(key) {
             return id.clone();
         }
-        let channel_name = self.channel.name().to_string();
+        let channel_name = self
+            .channels
+            .channel_name_for_room(&key.0)
+            .await
+            .unwrap_or_else(|| {
+                self.channels
+                    .names()
+                    .first()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            });
         match self.session_store.create_session(key, &channel_name) {
             Ok(id) => {
                 sessions.insert(key.clone(), id.clone());
@@ -602,7 +623,7 @@ impl Agent {
             self.persist(&session_id, &msg);
         }
 
-        let _ = self.channel.start_typing(&incoming.room_id).await;
+        let _ = self.channels.start_typing(&incoming.room_id).await;
 
         // Refresh MCP tools if any server signalled a change.
         if let Some(tools) = &self.tools {
@@ -682,9 +703,9 @@ impl Agent {
             match response {
                 Err(e) => {
                     error!("Provider error: {e:#}");
-                    let _ = self.channel.stop_typing(&incoming.room_id).await;
+                    let _ = self.channels.stop_typing(&incoming.room_id).await;
                     let _ = self
-                        .channel
+                        .channels
                         .send(&OutgoingMessage::new(
                             format!("⚠️ Error: {e}"),
                             incoming.room_id.clone(),
@@ -766,7 +787,7 @@ impl Agent {
             }
         };
 
-        let _ = self.channel.stop_typing(&incoming.room_id).await;
+        let _ = self.channels.stop_typing(&incoming.room_id).await;
 
         if let Some(text) = final_text {
             if !text.is_empty() {
@@ -775,7 +796,7 @@ impl Agent {
                     room_id: incoming.room_id.clone(),
                     thread_id: incoming.thread_id.clone(),
                 };
-                self.channel
+                self.channels
                     .send(&out)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to send response: {e:#}"))?;

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -1,7 +1,12 @@
 pub mod discord;
 pub mod matrix;
 
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{RwLock, mpsc};
+use tracing::{error, warn};
 
 /// Maximum size of a single image attachment forwarded to the LLM.
 /// Anthropic's documented limit is 5 MB per image; oversized attachments are
@@ -74,3 +79,151 @@ pub trait Channel: Send + Sync {
         Ok(())
     }
 }
+
+/// Dispatcher that fronts every configured `Channel` (Matrix + Discord)
+/// for the agent. Maintains a `room_id → channel name` routing map so
+/// outgoing replies and typing indicators land on the channel the
+/// originating message came from.
+///
+/// The routing map is seeded from `Config` (Matrix.room_ids and
+/// Discord.channel_ids) so proactive sends to known rooms work without
+/// having received a message first; it's also updated on every
+/// incoming message so DMs / unlisted rooms become routable as soon as
+/// the user pings the agent there.
+pub struct Channels {
+    list: Vec<(String, Arc<dyn Channel>)>,
+    routing: RwLock<HashMap<String, String>>,
+}
+
+impl Channels {
+    pub fn new(list: Vec<(String, Arc<dyn Channel>)>, seed: HashMap<String, String>) -> Self {
+        Self {
+            list,
+            routing: RwLock::new(seed),
+        }
+    }
+
+    /// Names of every configured channel, in the order they were
+    /// registered. Useful for diagnostics and bootstrap room filtering.
+    pub fn names(&self) -> Vec<&str> {
+        self.list.iter().map(|(n, _)| n.as_str()).collect()
+    }
+
+    /// True when no channels are registered (e.g. standby mode or
+    /// API-only deployment).
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    /// Channel name (as recorded in session metadata) responsible for a
+    /// given `room_id`, if known.
+    pub async fn channel_name_for_room(&self, room_id: &str) -> Option<String> {
+        self.routing.read().await.get(room_id).cloned()
+    }
+
+    fn channel_by_name(&self, name: &str) -> Option<&Arc<dyn Channel>> {
+        self.list.iter().find(|(n, _)| n == name).map(|(_, c)| c)
+    }
+
+    async fn channel_for_room_or_first(&self, room_id: &str) -> Option<Arc<dyn Channel>> {
+        if let Some(name) = self.channel_name_for_room(room_id).await
+            && let Some(ch) = self.channel_by_name(&name)
+        {
+            return Some(Arc::clone(ch));
+        }
+        // Last-ditch fallback: if only one channel is configured, use it.
+        if self.list.len() == 1 {
+            return Some(Arc::clone(&self.list[0].1));
+        }
+        None
+    }
+
+    pub async fn send(&self, msg: &OutgoingMessage) -> Result<()> {
+        let ch = self
+            .channel_for_room_or_first(&msg.room_id)
+            .await
+            .ok_or_else(|| anyhow!("no channel registered for room {}", msg.room_id))?;
+        ch.send(msg).await
+    }
+
+    pub async fn start_typing(&self, room_id: &str) -> Result<()> {
+        if let Some(ch) = self.channel_for_room_or_first(room_id).await {
+            ch.start_typing(room_id).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn stop_typing(&self, room_id: &str) -> Result<()> {
+        if let Some(ch) = self.channel_for_room_or_first(room_id).await {
+            ch.stop_typing(room_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Spawn a `listen` task per registered channel, all forwarding into
+    /// the same outgoing `tx`. Each forwarded message updates the
+    /// routing map so the originating channel is locked in for any
+    /// subsequent outgoing reply.
+    pub async fn listen_all(
+        self: Arc<Self>,
+        tx: mpsc::Sender<IncomingMessage>,
+    ) -> Result<()> {
+        if self.list.is_empty() {
+            return Err(anyhow!("listen_all called with no channels registered"));
+        }
+        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+        for (name, ch) in self.list.iter().cloned().collect::<Vec<_>>() {
+            let outer_tx = tx.clone();
+            let me = Arc::clone(&self);
+            let (inner_tx, mut inner_rx) = mpsc::channel::<IncomingMessage>(64);
+            let listen_name = name.clone();
+            handles.push(tokio::spawn(async move {
+                if let Err(e) = ch.listen(inner_tx).await {
+                    error!("Channel '{listen_name}' listen error: {e:#}");
+                }
+            }));
+            let forward_name = name.clone();
+            handles.push(tokio::spawn(async move {
+                while let Some(msg) = inner_rx.recv().await {
+                    me.routing
+                        .write()
+                        .await
+                        .insert(msg.room_id.clone(), forward_name.clone());
+                    if outer_tx.send(msg).await.is_err() {
+                        warn!("Channel '{forward_name}' forwarder: receiver closed");
+                        break;
+                    }
+                }
+            }));
+        }
+        // Wait until any of the listen tasks ends — that's our signal
+        // to abort the rest. (Forward tasks exit on tx close after
+        // listens drop their senders.)
+        for h in handles {
+            let _ = h.await;
+        }
+        Ok(())
+    }
+}
+
+/// Build the routing seed map from a `Config` so proactive sends
+/// (heartbeat cron tasks, etc.) succeed without needing a prior
+/// inbound message.
+///
+/// Lives here rather than `Channels::new` to avoid circular dependency
+/// concerns and so test code can build a `Channels` without a `Config`.
+pub fn seed_routing_from_config(config: &crate::config::Config) -> HashMap<String, String> {
+    let mut seed = HashMap::new();
+    if let Some(m) = &config.matrix {
+        for r in &m.room_ids {
+            seed.insert(r.clone(), "matrix".to_string());
+        }
+    }
+    if let Some(d) = &config.discord {
+        for c in &d.channel_ids {
+            seed.insert(c.clone(), "discord".to_string());
+        }
+    }
+    seed
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,10 +6,13 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
-    /// Matrix channel configuration. Required if `discord` is not set.
+    /// Matrix channel configuration. Both `matrix` and `discord` may be
+    /// configured at once — when set, both run concurrently in the
+    /// same `serve` process. At least one of them is required (unless
+    /// `standby_mode = true`).
     #[serde(default)]
     pub matrix: Option<MatrixConfig>,
-    /// Discord channel configuration. Required if `matrix` is not set.
+    /// Discord channel configuration. May coexist with `matrix`.
     #[serde(default)]
     pub discord: Option<DiscordConfig>,
     pub anthropic: AnthropicConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,14 @@ async fn main() -> Result<()> {
             if let Err(e) = migrate_pre_namespace_layout(&workspace_dir) {
                 anyhow::bail!("Memory layout migration failed: {e:#}");
             }
+            // ── Consolidate sessions/{matrix,discord} into sessions/channel ──
+            // Both chat channels can run concurrently now and share one
+            // session store keyed by ULID; the originating channel is
+            // still recorded inside each session's metadata.
+            let sessions_base_for_migration = config.resolved_sessions_dir(&workspace_dir);
+            if let Err(e) = migrate_per_channel_sessions(&sessions_base_for_migration) {
+                anyhow::bail!("Session layout migration failed: {e:#}");
+            }
 
             // ── Bootstrap file loader (AGENTS.md, SOUL.md, MEMORY.md …) ────
             let workspace = Arc::new(Workspace::new(workspace_dir.clone(), config.digest.clone()));
@@ -293,27 +301,39 @@ async fn main() -> Result<()> {
             // returns, cancelling any in-flight LLM call (#48).
             let mut agent_handle: Option<tokio::task::JoinHandle<()>> = None;
 
-            // ── Channel + Agent (Matrix or Discord, if configured) ──────────
+            // ── Channel + Agent (Matrix and/or Discord, if configured) ──────
             if !config.standby_mode && (config.matrix.is_some() || config.discord.is_some()) {
-                let channel_name = if config.discord.is_some() {
-                    "discord"
-                } else {
-                    "matrix"
-                };
+                // Sessions from every chat channel land in one shared
+                // directory now that both Matrix and Discord can run
+                // concurrently. The originating channel name is still
+                // recorded in each session's metadata. See
+                // `migrate_per_channel_sessions` for the one-time move.
                 let channel_session_store = Arc::new(SessionStore::with_workspace(
-                    sessions_base.join(channel_name),
+                    sessions_base.join("channel"),
                     Arc::clone(&ws_state),
                 ));
 
-                let channel: Arc<dyn channel::Channel> = if let Some(d) = &config.discord {
-                    Arc::new(
-                        DiscordChannel::new(d).context("Failed to initialise Discord channel")?,
-                    )
-                } else if let Some(m) = &config.matrix {
-                    Arc::new(MatrixChannel::new(m))
-                } else {
-                    unreachable!()
-                };
+                let mut channel_list: Vec<(String, Arc<dyn channel::Channel>)> = Vec::new();
+                if let Some(m) = &config.matrix {
+                    channel_list.push(("matrix".to_string(), Arc::new(MatrixChannel::new(m))));
+                }
+                if let Some(d) = &config.discord {
+                    channel_list.push((
+                        "discord".to_string(),
+                        Arc::new(
+                            DiscordChannel::new(d)
+                                .context("Failed to initialise Discord channel")?,
+                        ),
+                    ));
+                }
+                let channels = Arc::new(channel::Channels::new(
+                    channel_list,
+                    channel::seed_routing_from_config(&config),
+                ));
+                tracing::info!(
+                    "Channels active: {}",
+                    channels.names().join(", ")
+                );
 
                 // ── Catch-up: iterate every configured memory namespace ────
                 // Each namespace's background tasks run on its own provider
@@ -386,7 +406,7 @@ async fn main() -> Result<()> {
                 // ── Agent ───────────────────────────────────────────────────
                 let agent = Arc::new(Agent::new(
                     config.clone(),
-                    channel,
+                    Arc::clone(&channels),
                     Arc::clone(&registry),
                     Arc::clone(&workspace),
                     Some(Arc::clone(&tool_set)),
@@ -473,6 +493,76 @@ async fn main() -> Result<()> {
         Command::Call { .. } => unreachable!(),
     }
 
+    Ok(())
+}
+
+/// One-shot migration from the per-channel session layout
+/// (`sessions/matrix/` + `sessions/discord/`) to the consolidated
+/// `sessions/channel/` directory. The originating channel is still
+/// recorded in each session's `meta.channel` field, so the move is
+/// pure reshuffling.
+///
+/// Idempotent: skips silently when neither legacy directory exists.
+/// Refuses to run when a name collision would clobber an existing
+/// `sessions/channel/<id>.jsonl` (extremely unlikely with ULIDs but
+/// handled for safety).
+fn migrate_per_channel_sessions(sessions_base: &std::path::Path) -> anyhow::Result<()> {
+    let target = sessions_base.join("channel");
+    let mut sources: Vec<std::path::PathBuf> = Vec::new();
+    for legacy in ["matrix", "discord"] {
+        let dir = sessions_base.join(legacy);
+        if dir.is_dir() {
+            sources.push(dir);
+        }
+    }
+    if sources.is_empty() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&target)
+        .with_context(|| format!("create {}", target.display()))?;
+
+    for src in sources {
+        let entries = match std::fs::read_dir(&src) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("Skipping {}: {e}", src.display());
+                continue;
+            }
+        };
+        let mut moved = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(file_name) = path.file_name() else {
+                continue;
+            };
+            let dst = target.join(file_name);
+            if dst.exists() {
+                anyhow::bail!(
+                    "Refusing to migrate {}: destination {} already exists. \
+                     Reconcile manually before starting.",
+                    path.display(),
+                    dst.display(),
+                );
+            }
+            std::fs::rename(&path, &dst).with_context(|| {
+                format!("rename {} -> {}", path.display(), dst.display())
+            })?;
+            moved += 1;
+        }
+        // Remove the now-empty legacy directory; non-fatal if it has
+        // unexpected leftover entries (e.g. user-dropped files).
+        let _ = std::fs::remove_dir(&src);
+        tracing::info!(
+            "Migrated {} session file(s) from {} to {}",
+            moved,
+            src.display(),
+            target.display()
+        );
+    }
     Ok(())
 }
 
@@ -644,5 +734,62 @@ mod tests {
         // Files untouched.
         assert!(root.join("memory/daily/2026-04-15.md").exists());
         assert!(root.join("memory/default/daily/2026-04-16.md").exists());
+    }
+
+    #[test]
+    fn session_migration_no_op_on_fresh_workspace() {
+        let td = tempfile::tempdir().unwrap();
+        migrate_per_channel_sessions(td.path()).expect("clean migration");
+        assert!(!td.path().join("channel").exists());
+    }
+
+    #[test]
+    fn session_migration_consolidates_matrix_and_discord() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        write_stub(&base.join("matrix/01H1.jsonl"), "matrix");
+        write_stub(&base.join("matrix/01H2.jsonl"), "matrix2");
+        write_stub(&base.join("discord/01H3.jsonl"), "discord");
+
+        migrate_per_channel_sessions(base).expect("migration");
+
+        for stem in ["01H1", "01H2", "01H3"] {
+            let path = base.join("channel").join(format!("{stem}.jsonl"));
+            assert!(path.exists(), "missing: {}", path.display());
+        }
+        assert!(!base.join("matrix").exists(), "matrix dir should be removed");
+        assert!(!base.join("discord").exists(), "discord dir should be removed");
+    }
+
+    #[test]
+    fn session_migration_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        write_stub(&base.join("matrix/01H1.jsonl"), "matrix");
+        migrate_per_channel_sessions(base).expect("first");
+        migrate_per_channel_sessions(base).expect("second is a no-op");
+        assert!(base.join("channel/01H1.jsonl").exists());
+    }
+
+    #[test]
+    fn session_migration_refuses_on_collision() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        write_stub(&base.join("matrix/01H1.jsonl"), "matrix");
+        write_stub(&base.join("channel/01H1.jsonl"), "pre-existing");
+        let err = migrate_per_channel_sessions(base).err().expect("error");
+        assert!(
+            format!("{err:#}").contains("already exists"),
+            "got: {err:#}"
+        );
+        // Original files untouched.
+        assert_eq!(
+            std::fs::read_to_string(base.join("matrix/01H1.jsonl")).unwrap(),
+            "matrix"
+        );
+        assert_eq!(
+            std::fs::read_to_string(base.join("channel/01H1.jsonl")).unwrap(),
+            "pre-existing"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #75. When both \`[matrix]\` and \`[discord]\` are configured, they now run side-by-side in one \`sapphire-agent serve\` process; previously Discord won the if/else select in \`main.rs\` and Matrix was silently dropped.

* New \`channel::Channels\` dispatcher fronts every configured chat backend. Outgoing replies and typing indicators route by \`room_id\` via a routing map seeded from config and updated on every incoming message, so DMs and unlisted rooms become routable as soon as the user pings the bot there.
* \`Agent.channel: Arc<dyn Channel>\` → \`Agent.channels: Arc<Channels>\`. All call sites updated.
* Session storage consolidated to \`sessions/channel/\` (was \`sessions/{matrix,discord}/\`). Originating channel still recorded in each session's \`meta.channel\` field. One-time \`migrate_per_channel_sessions\` startup pass moves legacy files; idempotent, refuses on filename collision.
* \`Agent::bootstrap\` room filter now treats an empty \`room_ids\`/\`channel_ids\` (\"listen everywhere\") on either side as a wildcard for the whole agent, so a wildcard Discord paired with explicit Matrix rooms doesn't silently drop unlisted Discord channels.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test --workspace\` — 104 pass (4 new session-migration tests)
- [ ] Live test: configure both \`[matrix]\` and \`[discord]\` in one config, confirm a Matrix message and a Discord message are both received and replied to in the same process
- [ ] Live test: send a proactive heartbeat message; confirm it lands on the configured \`default_room_id\` (Matrix-priority)
- [ ] Live test: existing workspace with \`sessions/matrix/\` + \`sessions/discord/\` migrates cleanly to \`sessions/channel/\` on startup; resumed session continuity preserved

## Known limitations / out of scope

- Heartbeat \`default_room_id\` stays single-valued (Matrix-priority, falls back to Discord). Per-cron-task channel targeting is a future enhancement.
- Multiple Matrix homeservers / multiple Discord bot tokens still not supported.
- Cross-channel message bridging is not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)