### PR TITLE
Split control API onto /rpc, reserve /mcp for the future MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **Control API endpoint renamed `/mcp` → `/rpc`** — the existing
+  JSON-RPC control surface (`initialize`, `chat`, `get_session`,
+  `list_sessions`, `voice/*`) is sapphire-agent's own control API, not
+  an MCP server, so it moves to a neutral path. The session header is
+  likewise renamed `Mcp-Session-Id` → `Session-Id`. `sapphire-call` is
+  updated in lockstep. `/mcp` is now unbound and reserved for a real
+  MCP server (#79, #80); `/a2a` is reserved for a future Agent-to-Agent
+  endpoint.
+
 ## [0.5.0] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A personal AI assistant agent that lives in a [`sapphire-workspace`](https://cra
 - **Background**: heartbeat cron tasks, periodic memory compaction, periodic workspace sync, daily logs.
 - **Commands**:
   - `call` — interactive REPL (reedline)
-  - `serve` — MCP Streamable HTTP API
+  - `serve` — JSON-RPC over HTTP control API (`/rpc`)
   - `run` — start the channel listeners
   - `verify` — validate config and report loaded workspace files
 

--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -1,8 +1,9 @@
 //! Client library for `sapphire-agent`.
 //!
-//! Provides an HTTP client for the sapphire-agent JSON-RPC 2.0 API and an
-//! interactive REPL that can be embedded in any binary (`sapphire-agent call`
-//! or the standalone `sapphire-call`).
+//! Provides an HTTP client for the sapphire-agent control API
+//! (`/rpc`, JSON-RPC 2.0) and an interactive REPL that can be embedded
+//! in any binary (`sapphire-agent call` or the standalone
+//! `sapphire-call`).
 
 pub mod voice;
 
@@ -18,10 +19,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 pub use voice::{VoiceEvent, WakeWordConfig, WakeWordModel, voice_config, voice_pipeline_run};
 
-/// Initialize an MCP session against `base`. Returns the internal
-/// `Mcp-Session-Id`, the human-readable display id, and whether the
-/// session is brand-new. Exposed so out-of-tree clients (e.g. the voice
-/// satellite) can reuse the same session-setup flow as the REPL.
+/// Initialize an RPC session against `base`. Returns the internal
+/// session id (UUID, sent back on subsequent requests via the
+/// `Session-Id` header), the human-readable display id, and whether
+/// the session is brand-new. Exposed so out-of-tree clients (e.g. the
+/// voice satellite) can reuse the same session-setup flow as the REPL.
 pub async fn initialize(
     client: &reqwest::Client,
     base: &str,
@@ -86,18 +88,18 @@ pub async fn run(
 
     // -- --list mode ----------------------------------------------------------
     if list {
-        let (mcp_session_id, _, _) = initialize_session(&client, &base, session, None).await?;
-        list_sessions(&client, &base, &mcp_session_id, json).await?;
+        let (session_id, _, _) = initialize_session(&client, &base, session, None).await?;
+        list_sessions(&client, &base, &session_id, json).await?;
         return Ok(());
     }
 
     // -- Initialize session ---------------------------------------------------
-    let (mut mcp_session_id, actual_session_id, is_new) =
+    let (mut session_id, display_id, is_new) =
         initialize_session(&client, &base, session, room_profile.as_deref()).await?;
 
     // -- --history dump-only mode ---------------------------------------------
     if history {
-        dump_history(&client, &base, &mcp_session_id, json, true).await?;
+        dump_history(&client, &base, &session_id, json, true).await?;
         return Ok(());
     }
 
@@ -107,7 +109,7 @@ pub async fn run(
         if trimmed.is_empty() {
             anyhow::bail!("--message requires non-empty text");
         }
-        send_chat(&client, &base, &mcp_session_id, trimmed, json).await?;
+        send_chat(&client, &base, &session_id, trimmed, json).await?;
         if !json {
             println!();
         }
@@ -117,10 +119,10 @@ pub async fn run(
     // -- REPL -----------------------------------------------------------------
     // --json is a no-op in REPL mode (text output is always human-readable).
     let _ = json;
-    println!("sapphire-agent call  (session: {actual_session_id})");
+    println!("sapphire-agent call  (session: {display_id})");
     if !is_new {
         println!("[resumed existing session]\n");
-        if let Err(e) = dump_history(&client, &base, &mcp_session_id, false, false).await {
+        if let Err(e) = dump_history(&client, &base, &session_id, false, false).await {
             eprintln!("[warning: failed to load history: {e:#}]");
         }
     }
@@ -150,9 +152,9 @@ pub async fn run(
             }
             "/clear" => {
                 match initialize_session(&client, &base, None, room_profile.as_deref()).await {
-                    Ok((new_mcp_id, new_session_id, _)) => {
-                        mcp_session_id = new_mcp_id;
-                        println!("[new session: {new_session_id}]");
+                    Ok((new_sid, new_display_id, _)) => {
+                        session_id = new_sid;
+                        println!("[new session: {new_display_id}]");
                     }
                     Err(e) => eprintln!("[error starting new session: {e:#}]"),
                 }
@@ -162,7 +164,7 @@ pub async fn run(
             _ => {}
         }
 
-        if let Err(e) = send_chat(&client, &base, &mcp_session_id, trimmed, false).await {
+        if let Err(e) = send_chat(&client, &base, &session_id, trimmed, false).await {
             eprintln!("[error: {e:#}]");
         }
         println!();
@@ -194,16 +196,16 @@ async fn initialize_session(
     });
 
     let resp = client
-        .post(format!("{base}/mcp"))
+        .post(format!("{base}/rpc"))
         .json(&body)
         .send()
         .await
         .context("Failed to connect to server. Is `sapphire-agent serve` running?")?
         .error_for_status()?;
 
-    let mcp_session_id = resp
+    let session_id = resp
         .headers()
-        .get("mcp-session-id")
+        .get("session-id")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
         .unwrap_or_else(|| session_id_req.to_string());
@@ -218,11 +220,11 @@ async fn initialize_session(
     let display_id = result["public_id"]
         .as_str()
         .or_else(|| result["session_id"].as_str())
-        .unwrap_or(&mcp_session_id)
+        .unwrap_or(&session_id)
         .to_string();
     let is_new = result["is_new"].as_bool().unwrap_or(true);
 
-    Ok((mcp_session_id, display_id, is_new))
+    Ok((session_id, display_id, is_new))
 }
 
 // ---------------------------------------------------------------------------
@@ -232,7 +234,7 @@ async fn initialize_session(
 async fn dump_history(
     client: &reqwest::Client,
     base: &str,
-    mcp_session_id: &str,
+    session_id: &str,
     json_mode: bool,
     standalone: bool,
 ) -> Result<()> {
@@ -244,8 +246,8 @@ async fn dump_history(
     });
 
     let val: Value = client
-        .post(format!("{base}/mcp"))
-        .header("mcp-session-id", mcp_session_id)
+        .post(format!("{base}/rpc"))
+        .header("session-id", session_id)
         .json(&body)
         .send()
         .await?
@@ -316,7 +318,7 @@ async fn dump_history(
 async fn list_sessions(
     client: &reqwest::Client,
     base: &str,
-    mcp_session_id: &str,
+    session_id: &str,
     json_mode: bool,
 ) -> Result<()> {
     let body = json!({
@@ -327,8 +329,8 @@ async fn list_sessions(
     });
 
     let val: Value = client
-        .post(format!("{base}/mcp"))
-        .header("mcp-session-id", mcp_session_id)
+        .post(format!("{base}/rpc"))
+        .header("session-id", session_id)
         .json(&body)
         .send()
         .await?
@@ -370,7 +372,7 @@ async fn list_sessions(
 async fn send_chat(
     client: &reqwest::Client,
     base: &str,
-    mcp_session_id: &str,
+    session_id: &str,
     content: &str,
     json_mode: bool,
 ) -> Result<()> {
@@ -383,8 +385,8 @@ async fn send_chat(
     });
 
     let resp = client
-        .post(format!("{base}/mcp"))
-        .header("mcp-session-id", mcp_session_id)
+        .post(format!("{base}/rpc"))
+        .header("session-id", session_id)
         .header("accept", "text/event-stream")
         .json(&body)
         .send()

--- a/crates/sapphire-agent-api/src/voice.rs
+++ b/crates/sapphire-agent-api/src/voice.rs
@@ -1,4 +1,5 @@
-//! Client-side helpers for the `voice/pipeline_run` MCP method.
+//! Client-side helpers for the `voice/pipeline_run` JSON-RPC method
+//! exposed on the sapphire-agent control endpoint (`/rpc`).
 //!
 //! Wraps the request/response shape used by the server in `serve.rs`:
 //! audio in (base64 s16le mono 16 kHz) → SSE progress events
@@ -54,8 +55,8 @@ pub struct WakeWordModel {
 /// Fetch the server's global wake-word configuration. Returns an
 /// empty `WakeWordConfig` when `[voice].wake_word_model` is unset.
 ///
-/// No session or MCP token needed — wake-word config is the same for
-/// every satellite regardless of room_profile, so this is a stateless
+/// No session token needed — wake-word config is the same for every
+/// satellite regardless of room_profile, so this is a stateless
 /// GET-like call.
 pub async fn voice_config(
     client: &reqwest::Client,
@@ -69,7 +70,7 @@ pub async fn voice_config(
         "params": {},
     });
     let val: Value = client
-        .post(format!("{base}/mcp"))
+        .post(format!("{base}/rpc"))
         .json(&body)
         .send()
         .await?
@@ -193,7 +194,7 @@ pub async fn voice_pipeline_run(
     });
 
     let resp = client
-        .post(format!("{base}/mcp"))
+        .post(format!("{base}/rpc"))
         .header("accept", "text/event-stream")
         .json(&body)
         .send()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1306,35 +1306,6 @@ rooms   = ["!x:srv"]
         );
     }
 
-    /// Smoke check that every TOML under `test-configs/` parses and
-    /// validates. These files are documentation templates the user
-    /// copies into place for manual end-to-end runs; if they break
-    /// we want to know before they're copy-pasted, not after.
-    #[test]
-    fn test_configs_parse_and_validate() {
-        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test-configs");
-        let entries: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
-            .unwrap_or_else(|e| panic!("read_dir({}) failed: {e}", dir.display()))
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .filter(|p| p.extension().is_some_and(|x| x == "toml"))
-            .collect();
-        assert!(
-            !entries.is_empty(),
-            "test-configs/ must contain at least one .toml"
-        );
-        for path in entries {
-            let cfg = Config::load(&path)
-                .unwrap_or_else(|e| panic!("{} failed to parse: {e:#}", path.display()));
-            let errs = cfg.validate_profiles();
-            assert!(
-                errs.is_empty(),
-                "{} validation errors: {:?}",
-                path.display(),
-                errs
-            );
-        }
-    }
-
     #[test]
     fn namespace_default_resolves_when_unconfigured() {
         let cfg = parse(MINIMAL);

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,9 +1,11 @@
-//! HTTP API server implementing MCP Streamable HTTP transport + JSON-RPC 2.0.
+//! HTTP API server for sapphire-agent control API (JSON-RPC 2.0 over HTTP).
 //!
-//! Endpoint: POST /mcp  (chat, initialize, list_sessions)
-//!           GET  /mcp  (Phase 2: server→client SSE push, currently 405)
+//! Endpoint: POST /rpc  (chat, initialize, list_sessions, get_session, voice/*)
+//!           GET  /rpc  (Phase 2: server→client SSE push, currently 405)
 //!
-//! Session management follows the MCP standard: `Mcp-Session-Id` request header.
+//! Session management uses a `Session-Id` request/response header. The
+//! `/mcp` endpoint is reserved for the future MCP server (issue #80,
+//! #79) and is intentionally not served here.
 
 use crate::config::Config;
 use crate::context_compression::{generate_summary, maybe_compress};
@@ -161,8 +163,13 @@ pub async fn run(
     state: Arc<ServeState>,
 ) -> anyhow::Result<()> {
 
+    // Routes are intentionally separated so future protocol endpoints
+    // (`/mcp` for the MCP server in #79/#80, an eventual `/a2a` for the
+    // Agent-to-Agent protocol) can be mounted alongside `/rpc` without
+    // colliding with the control API methods (`chat`, `initialize`,
+    // `voice/*`, …) that live here.
     let app = Router::new()
-        .route("/mcp", post(mcp_post).get(mcp_get))
+        .route("/rpc", post(rpc_post).get(rpc_get))
         .layer(tower_http::cors::CorsLayer::permissive())
         .with_state(Arc::clone(&state));
 
@@ -217,16 +224,16 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
 }
 
 // ---------------------------------------------------------------------------
-// POST /mcp  — dispatch JSON-RPC methods
+// POST /rpc  — dispatch JSON-RPC methods
 // ---------------------------------------------------------------------------
 
-async fn mcp_post(
+async fn rpc_post(
     State(state): State<Arc<ServeState>>,
     headers: HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> impl IntoResponse {
     let session_id = headers
-        .get("mcp-session-id")
+        .get("session-id")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
@@ -249,13 +256,13 @@ async fn mcp_post(
 }
 
 // ---------------------------------------------------------------------------
-// GET /mcp  — Phase 2 placeholder (server→client push)
+// GET /rpc  — Phase 2 placeholder (server→client push)
 // ---------------------------------------------------------------------------
 
-async fn mcp_get() -> impl IntoResponse {
+async fn rpc_get() -> impl IntoResponse {
     (
         StatusCode::METHOD_NOT_ALLOWED,
-        "GET /mcp is reserved for Phase 2 server-initiated tool requests",
+        "GET /rpc is reserved for Phase 2 server-initiated tool requests",
     )
 }
 
@@ -286,7 +293,7 @@ async fn handle_initialize(
     }
 
     // Resolve to an internal UUID session_id.
-    // - Mcp-Session-Id header: already a UUID (internal), use directly.
+    // - Session-Id header: already a UUID (internal), use directly.
     // - params.session_id: must be a 7-char grain-id (public) or "new"/absent.
     let resolved: Option<String> = if let Some(uuid) = existing_header_session {
         // Header carries the internal UUID we issued — trust it directly.
@@ -384,15 +391,15 @@ async fn handle_initialize(
         .status(StatusCode::OK)
         .header("content-type", "application/json")
         .header(
-            "mcp-session-id",
+            "session-id",
             HeaderValue::from_str(&session_id).unwrap_or_else(|_| HeaderValue::from_static("")),
         )
         .body(axum::body::Body::from(body.to_string()))
         .unwrap();
 
-    // Also set Mcp-Session-Id in the response headers (accessible via response)
+    // Also set Session-Id in the response headers (accessible via response)
     response.headers_mut().insert(
-        "mcp-session-id",
+        "session-id",
         HeaderValue::from_str(&session_id).unwrap_or_else(|_| HeaderValue::from_static("")),
     );
 
@@ -413,7 +420,7 @@ async fn handle_chat(
         Some(id) => id,
         None => {
             // No session: return JSON error
-            let body = error_response(req_id, -32602, "Missing Mcp-Session-Id header");
+            let body = error_response(req_id, -32602, "Missing Session-Id header");
             return body.into_response();
         }
     };
@@ -482,7 +489,7 @@ async fn handle_get_session(
     let session_id = match session_id {
         Some(id) => id,
         None => {
-            let body = error_response(req_id, -32602, "Missing Mcp-Session-Id header");
+            let body = error_response(req_id, -32602, "Missing Session-Id header");
             return body.into_response();
         }
     };

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Exposes STT / TTS provider abstractions and a registry that builds
 //! concrete instances from `[stt_provider.*]` / `[tts_provider.*]` config
-//! blocks. The MCP `voice/pipeline_run` method (in [`crate::serve`])
-//! wires these into a per-request flow:
+//! blocks. The `voice/pipeline_run` JSON-RPC method on `/rpc` (in
+//! [`crate::serve`]) wires these into a per-request flow:
 //!
 //! ```text
 //! base64 PCM ─► SttProvider::transcribe ─► transcript text

--- a/src/voice/providers/mock.rs
+++ b/src/voice/providers/mock.rs
@@ -1,8 +1,8 @@
 //! Deterministic mock STT/TTS providers.
 //!
-//! Useful for end-to-end pipeline tests and for exercising the MCP
-//! `voice/pipeline_run` method without setting up a real model or
-//! external service. Selected via TOML config:
+//! Useful for end-to-end pipeline tests and for exercising the
+//! `voice/pipeline_run` JSON-RPC method without setting up a real
+//! model or external service. Selected via TOML config:
 //!
 //! ```toml
 //! [stt_provider.test]


### PR DESCRIPTION
Closes #80.

## Summary

- Move sapphire-agent's JSON-RPC control surface (`initialize`, `chat`, `get_session`, `list_sessions`, `voice/*`) from `/mcp` to `/rpc`, and rename the session header `Mcp-Session-Id` → `Session-Id`. None of those methods actually speak MCP, so the old path was misleading and squatted on a name that's about to be used for real.
- Reserve `/mcp` for the MCP server (memory-sharing tools, #79) and leave `/a2a` reserved for a future Agent-to-Agent endpoint. The router setup in `serve::run` makes both extension points explicit.
- Update `sapphire-agent-api` (used by both `sapphire-agent call` and the standalone `sapphire-call`) in lockstep — no compatibility shim, since CLI + server ship together.
- Drop MCP-specific vocabulary from comments and doc strings inside the control-API surface. The outbound MCP client (`src/mcp_client/`) is unrelated and untouched.
- Tag-along: drop `config::tests::test_configs_parse_and_validate`. `test-configs/` was untracked in 2d83ead but the test that walked it was left behind, so the suite has been failing on a fresh checkout. `shipped_example_parses` still covers the shipped TOML.

Authentication separation (`/rpc` vs `/mcp` API keys) and the actual MCP server implementation are intentionally out of scope — those come with #79.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace` (115 → 115 passing; the previously-failing `test_configs_parse_and_validate` is gone)
- [ ] Manual: `sapphire-agent serve` + `sapphire-call` REPL round-trip against `/rpc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)