### PR TITLE
feat(voice): listen-state UX + heartbeat→satellite push (#83)

### DIFF
--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -17,7 +17,10 @@ use std::borrow::Cow;
 use std::io::{Write, stderr, stdout};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-pub use voice::{VoiceEvent, WakeWordConfig, WakeWordModel, voice_config, voice_pipeline_run};
+pub use voice::{
+    VoiceEvent, VoicePushEvent, WakeWordConfig, WakeWordModel, voice_config, voice_pipeline_run,
+    voice_subscribe,
+};
 
 /// Client-side description of the device running this satellite. Sent
 /// to the agent via the `device` block on `initialize` and

--- a/crates/sapphire-agent-api/src/voice.rs
+++ b/crates/sapphire-agent-api/src/voice.rs
@@ -149,6 +149,31 @@ pub enum VoiceEvent {
     Error { message: String },
 }
 
+/// Server-initiated push delivered over `voice/subscribe`. One push
+/// represents a single TTS-able message (typically a heartbeat fire) —
+/// it begins with `PushStart`, streams `AudioChunk`s, optionally
+/// includes an `AssistantText` for transcript logging, and ends with
+/// `PushDone`. The subscription stays open across multiple pushes; the
+/// satellite uses `PushDone` to flush playback and re-enter listening
+/// state.
+#[derive(Debug, Clone)]
+pub enum VoicePushEvent {
+    /// A new push is starting; `task` is the heartbeat task name when
+    /// the push originates from cron, or `None` for ad-hoc pushes.
+    PushStart { task: Option<String> },
+    /// Assistant's text reply (echo of what gets synthesized to audio).
+    AssistantText { text: String },
+    /// One chunk of synthesized speech (mono s16le @ 16 kHz).
+    AudioChunk { pcm: Vec<i16> },
+    /// Push completed. The satellite should drain the playback queue
+    /// and enter follow-up listening (so the user can reply to the
+    /// notification without uttering the wake word).
+    PushDone,
+    /// Push failed. The satellite should log and continue waiting for
+    /// the next push.
+    Error { message: String },
+}
+
 /// Run one voice pipeline pass: upload `pcm` as a single utterance,
 /// stream progress events into `event_tx`, and return when the
 /// server emits its final JSON-RPC result. Closing `event_tx` is the
@@ -226,6 +251,119 @@ fn parse_sse_data(raw: &str) -> Option<Value> {
     let data_line = raw.lines().find(|l| l.starts_with("data:"))?;
     let data = data_line.strip_prefix("data:").unwrap_or("").trim();
     serde_json::from_str(data).ok()
+}
+
+/// Open a long-lived subscription for server-initiated voice pushes.
+/// `event_tx` receives one [`VoicePushEvent`] per server notification
+/// until the connection closes. Caller is expected to spawn this on a
+/// background task and reconnect (with backoff) when the future
+/// returns — the typical flow is "until satellite shuts down."
+///
+/// Routing is by `(device_id, room_profile)` — the same key
+/// `voice/pipeline_run` uses to derive its session id. A new
+/// subscription supersedes any prior subscription for the same key, so
+/// reconnecting after a network blip just re-binds the channel.
+pub async fn voice_subscribe(
+    client: &reqwest::Client,
+    base: &str,
+    device_id: &str,
+    room_profile: &str,
+    event_tx: mpsc::Sender<VoicePushEvent>,
+) -> Result<()> {
+    let base = base.trim_end_matches('/');
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": "voice/subscribe",
+        "params": {
+            "device_id": device_id,
+            "room_profile": room_profile,
+        },
+    });
+
+    let resp = client
+        .post(format!("{base}/rpc"))
+        .header("accept", "text/event-stream")
+        .json(&body)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+    while let Some(chunk) = stream.next().await {
+        buf.push_str(&String::from_utf8_lossy(&chunk?));
+        while let Some(pos) = buf.find("\n\n") {
+            let raw: String = buf.drain(..pos + 2).collect();
+            let Some(value) = parse_sse_data(&raw) else {
+                continue;
+            };
+            if dispatch_push_event(&value, &event_tx).await {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Map one parsed JSON-RPC frame on the subscribe stream to a
+/// [`VoicePushEvent`]. Returns `true` when the stream should be
+/// considered closed (final result / error / `unsubscribe` notice).
+async fn dispatch_push_event(val: &Value, tx: &mpsc::Sender<VoicePushEvent>) -> bool {
+    if let Some(method) = val["method"].as_str() {
+        let params = &val["params"];
+        let evt = match method {
+            "notifications/voice_push" => {
+                let kind = params["kind"].as_str().unwrap_or("");
+                match kind {
+                    "push_start" => Some(VoicePushEvent::PushStart {
+                        task: params["task"].as_str().map(String::from),
+                    }),
+                    "assistant_text" => params["text"]
+                        .as_str()
+                        .map(|s| VoicePushEvent::AssistantText { text: s.to_string() }),
+                    "audio_chunk" => params["data"].as_str().and_then(decode_push_audio_chunk),
+                    "push_done" => Some(VoicePushEvent::PushDone),
+                    "error" => Some(VoicePushEvent::Error {
+                        message: params["message"]
+                            .as_str()
+                            .unwrap_or("unknown error")
+                            .to_string(),
+                    }),
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        if let Some(evt) = evt {
+            let _ = tx.send(evt).await;
+        }
+        return false;
+    }
+    if let Some(err) = val.get("error") {
+        let message = err["message"]
+            .as_str()
+            .unwrap_or("unknown error")
+            .to_string();
+        let _ = tx.send(VoicePushEvent::Error { message }).await;
+        return true;
+    }
+    // Final result on the subscribe channel means the server is closing us.
+    val.get("result").is_some()
+}
+
+fn decode_push_audio_chunk(b64: &str) -> Option<VoicePushEvent> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64.as_bytes())
+        .ok()?;
+    if bytes.len() % 2 != 0 {
+        return None;
+    }
+    let pcm: Vec<i16> = bytes
+        .chunks_exact(2)
+        .map(|c| i16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    Some(VoicePushEvent::AudioChunk { pcm })
 }
 
 /// Map one parsed JSON-RPC frame to a `VoiceEvent` and push it. Returns

--- a/crates/sapphire-call/config.example.toml
+++ b/crates/sapphire-call/config.example.toml
@@ -32,3 +32,11 @@ room_profile = "home_voice"
 # are optional; the block is only emitted when `name` is set.
 # name        = "living-room-speaker"
 # description = "Speakerphone in the living room; STT may produce typos due to ambient noise"
+
+[behavior]
+# Confirmation beeps and follow-up listening window. Defaults shown.
+# beep_on_wake          = true   # rising tone right after the wake word fires
+# beep_on_capture_end   = true   # falling tone when the VAD ships an utterance to STT
+# follow_up_listen_seconds = 5   # keep the mic open this long after the AI finishes
+#                                  speaking, so the user can reply without re-waking.
+#                                  Set to 0 to require a wake word for every turn.

--- a/crates/sapphire-call/src/config.rs
+++ b/crates/sapphire-call/src/config.rs
@@ -32,6 +32,12 @@ pub struct CallConfig {
     /// satellite host describe itself.
     #[serde(default)]
     pub device: DeviceConfig,
+    /// Listen-state UX knobs: confirmation beeps and the post-reply
+    /// follow-up listening window. All defaults are on / 5 seconds so
+    /// fresh installs get the conversational behaviour described in
+    /// issue #83 without explicit opt-in.
+    #[serde(default)]
+    pub behavior: BehaviorConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -95,6 +101,45 @@ impl DeviceConfig {
     }
 }
 
+/// Listen-state UX behaviour. See issue #83.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BehaviorConfig {
+    /// Play a short rising beep right after the wake word fires so the
+    /// user knows the satellite is now capturing their command.
+    #[serde(default = "default_true")]
+    pub beep_on_wake: bool,
+    /// Play a short falling beep when the VAD detects the end of an
+    /// utterance and ships it to STT. Confirms "I heard you, processing".
+    #[serde(default = "default_true")]
+    pub beep_on_capture_end: bool,
+    /// After the assistant's TTS reply finishes playing, keep the mic
+    /// open for this many seconds without requiring the wake word —
+    /// captures conversational follow-ups. Set to `0` to disable
+    /// (every turn requires re-waking). Only takes effect in
+    /// wake-word mode; VAD-only mode is always continuously listening.
+    #[serde(default = "default_follow_up_seconds")]
+    pub follow_up_listen_seconds: u32,
+}
+
+impl Default for BehaviorConfig {
+    fn default() -> Self {
+        Self {
+            beep_on_wake: default_true(),
+            beep_on_capture_end: default_true(),
+            follow_up_listen_seconds: default_follow_up_seconds(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_follow_up_seconds() -> u32 {
+    5
+}
+
 impl CallConfig {
     /// Load a config file from `path`. The caller is expected to
     /// short-circuit when the file doesn't exist — missing-config is
@@ -149,6 +194,11 @@ stt = "ja"
 [device]
 name = "living-room-speaker"
 description = "Speakerphone in the living room; STT may produce typos"
+
+[behavior]
+beep_on_wake = false
+beep_on_capture_end = true
+follow_up_listen_seconds = 8
 "#;
         let cfg: CallConfig = toml::from_str(raw).unwrap();
         assert_eq!(cfg.server.room_profile.as_deref(), Some("home_voice"));
@@ -159,6 +209,17 @@ description = "Speakerphone in the living room; STT may produce typos"
         assert_eq!(cfg.language.stt.as_deref(), Some("ja"));
         assert_eq!(cfg.device.name.as_deref(), Some("living-room-speaker"));
         assert!(cfg.device.description.is_some());
+        assert!(!cfg.behavior.beep_on_wake);
+        assert!(cfg.behavior.beep_on_capture_end);
+        assert_eq!(cfg.behavior.follow_up_listen_seconds, 8);
+    }
+
+    #[test]
+    fn behavior_defaults_when_block_omitted() {
+        let cfg: CallConfig = toml::from_str("").unwrap();
+        assert!(cfg.behavior.beep_on_wake);
+        assert!(cfg.behavior.beep_on_capture_end);
+        assert_eq!(cfg.behavior.follow_up_listen_seconds, 5);
     }
 
     #[test]

--- a/crates/sapphire-call/src/main.rs
+++ b/crates/sapphire-call/src/main.rs
@@ -141,6 +141,7 @@ async fn main() -> Result<()> {
                 input_device: input_device.or(file_cfg.audio.input_device),
                 output_device: output_device.or(file_cfg.audio.output_device),
                 device,
+                behavior: file_cfg.behavior,
             },
         )
         .await;

--- a/crates/sapphire-call/src/voice/mod.rs
+++ b/crates/sapphire-call/src/voice/mod.rs
@@ -20,15 +20,31 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
 use cpal::SampleFormat;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use sapphire_agent_api::{VoiceEvent, voice::PIPELINE_SAMPLE_RATE, voice_pipeline_run};
+use sapphire_agent_api::{
+    VoiceEvent, VoicePushEvent, voice::PIPELINE_SAMPLE_RATE, voice_pipeline_run, voice_subscribe,
+};
 use sherpa_onnx::{
     SileroVadModelConfig, VadModelConfig, VoiceActivityDetector,
 };
 use tokio::sync::mpsc;
+
+/// Command sent from the `voice/subscribe` consumer task into the
+/// listen loop so server-initiated pushes (heartbeat fires) can route
+/// audio through the same playback gate the regular reply path uses.
+enum ListenCommand {
+    /// One PCM chunk from the server push, at [`PIPELINE_SAMPLE_RATE`].
+    /// The listen loop mutes the mic on the first chunk of a push and
+    /// appends to the playback queue.
+    PushAudio(Vec<i16>),
+    /// Server has finished pushing; listen loop should drain playback
+    /// and arm the follow-up listening window.
+    PushDone,
+}
 
 /// Silero VAD frame size in samples. Required by the model.
 const VAD_WINDOW_SAMPLES: usize = 512;
@@ -60,7 +76,17 @@ pub struct VoiceOptions {
     /// Optional device identity sent in every `voice/pipeline_run` so the
     /// agent can render "voice channel with <name>" in the system prompt.
     pub device: Option<sapphire_agent_api::DeviceMetadata>,
+    /// Listen-state UX: confirmation beeps + post-reply follow-up
+    /// listening window. See [`crate::config::BehaviorConfig`].
+    pub behavior: crate::config::BehaviorConfig,
 }
+
+/// Frequency / duration of the confirmation beeps. Picked to be
+/// distinct (rising vs falling) and short enough not to clip the start
+/// of a quick command.
+const BEEP_DURATION_MS: u32 = 150;
+const BEEP_WAKE_HZ: f32 = 880.0;
+const BEEP_CAPTURE_END_HZ: f32 = 660.0;
 
 /// Entry point for `sapphire-call voice`.
 pub async fn run(
@@ -189,8 +215,22 @@ pub async fn run(
         });
     }
 
+    // ── Background voice/subscribe consumer ──────────────────────────────
+    // Heartbeat pushes (morning calls etc.) land here. The consumer
+    // translates push events into ListenCommands so the listen loop
+    // owns the playback queue / mic gate as it does for regular replies.
+    let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<ListenCommand>();
+    let subscribe_handle = tokio::spawn(subscribe_loop(
+        client.clone(),
+        base.clone(),
+        device_id.clone(),
+        room_profile.clone(),
+        cmd_tx,
+        Arc::clone(&shutdown),
+    ));
+
     let awaiting_wake = wake_detector.is_some();
-    listen_loop(ListenCtx {
+    let listen_result = listen_loop(ListenCtx {
         audio_rx,
         input_rate,
         input_channels,
@@ -207,8 +247,14 @@ pub async fn run(
         vad,
         wake: wake_detector,
         awaiting_wake,
+        behavior: options.behavior,
+        follow_up_until: None,
+        cmd_rx,
+        push_active: false,
     })
-    .await?;
+    .await;
+    subscribe_handle.abort();
+    listen_result?;
 
     Ok(())
 }
@@ -235,13 +281,79 @@ struct ListenCtx {
     /// trigger, false once it fires and we're capturing the utterance.
     /// Always false in VAD-only mode.
     awaiting_wake: bool,
+    /// Listen-state UX (beeps + follow-up window).
+    behavior: crate::config::BehaviorConfig,
+    /// In wake-word mode, when set, the satellite is in the post-reply
+    /// follow-up window: VAD is active without requiring another wake
+    /// word until this deadline. Cleared when a follow-up utterance
+    /// starts being processed (and re-armed once that turn finishes)
+    /// or when the deadline elapses without speech.
+    follow_up_until: Option<Instant>,
+    /// Server-initiated push commands (heartbeat fires) from the
+    /// `voice/subscribe` consumer task. Multiplexed alongside
+    /// `audio_rx` via `tokio::select!` so the listen loop stays the
+    /// single owner of the mic gate and playback queue.
+    cmd_rx: mpsc::UnboundedReceiver<ListenCommand>,
+    /// True between the first `PushAudio` of a server push and the
+    /// matching `PushDone`. While set, the listen loop has muted the
+    /// mic and is buffering the pushed PCM in the playback queue.
+    push_active: bool,
 }
 
 async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
     let mut window_buf: Vec<f32> = Vec::with_capacity(VAD_WINDOW_SAMPLES);
     while !ctx.shutdown.load(Ordering::SeqCst) {
-        let Some(raw) = ctx.audio_rx.recv().await else {
-            break;
+        // Race the mic stream against any pending server push command
+        // (heartbeat fires from voice/subscribe). In the post-reply
+        // follow-up window, the recv branch is wrapped in a deadline
+        // so silence eventually drops us back into wake-listening mode.
+        let event = match ctx.follow_up_until {
+            Some(deadline) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    expire_follow_up(&mut ctx, &mut window_buf);
+                    continue;
+                }
+                let remaining = deadline - now;
+                tokio::select! {
+                    biased;
+                    cmd = ctx.cmd_rx.recv() => match cmd {
+                        Some(c) => ListenEvent::Command(c),
+                        None => ListenEvent::CommandClosed,
+                    },
+                    audio = tokio::time::timeout(remaining, ctx.audio_rx.recv()) => match audio {
+                        Ok(Some(buf)) => ListenEvent::Audio(buf),
+                        Ok(None) => break,
+                        Err(_) => {
+                            expire_follow_up(&mut ctx, &mut window_buf);
+                            continue;
+                        }
+                    },
+                }
+            }
+            None => tokio::select! {
+                biased;
+                cmd = ctx.cmd_rx.recv() => match cmd {
+                    Some(c) => ListenEvent::Command(c),
+                    None => ListenEvent::CommandClosed,
+                },
+                audio = ctx.audio_rx.recv() => match audio {
+                    Some(buf) => ListenEvent::Audio(buf),
+                    None => break,
+                },
+            },
+        };
+
+        let raw = match event {
+            ListenEvent::Audio(buf) => buf,
+            ListenEvent::Command(cmd) => {
+                handle_push_command(&mut ctx, cmd, &mut window_buf).await;
+                continue;
+            }
+            // Subscribe loop ended (it errored / was aborted). Carry
+            // on listening normally — the satellite still works as a
+            // pure command station.
+            ListenEvent::CommandClosed => continue,
         };
         if !ctx.mic_enabled.load(Ordering::SeqCst) {
             continue;
@@ -263,6 +375,19 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
                     // the VAD starts on the post-wake utterance.
                     ctx.vad.reset();
                     window_buf.clear();
+                    if ctx.behavior.beep_on_wake {
+                        // Mute, play the rising tone, drain anything
+                        // already in flight, then re-open. A residual
+                        // input frame queued before the mute would
+                        // otherwise be re-processed as part of the
+                        // command itself.
+                        ctx.mic_enabled.store(false, Ordering::SeqCst);
+                        while ctx.audio_rx.try_recv().is_ok() {}
+                        enqueue_beep(&ctx.playback_queue, BEEP_WAKE_HZ, ctx.output_rate);
+                        wait_for_playback_drain(&ctx.playback_queue).await;
+                        while ctx.audio_rx.try_recv().is_ok() {}
+                        ctx.mic_enabled.store(true, Ordering::SeqCst);
+                    }
                 }
             }
             continue;
@@ -293,6 +418,17 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
             while ctx.audio_rx.try_recv().is_ok() {}
             ctx.vad.reset();
             window_buf.clear();
+            // Capturing this utterance means any pending follow-up window
+            // is being consumed; clear it so it can't fire mid-process.
+            // It will be re-armed after playback if behavior allows.
+            ctx.follow_up_until = None;
+
+            // Capture-end beep: queued onto the playback path so it plays
+            // before the TTS reply that arrives a moment later. No drain
+            // wait here — the inevitable post-reply drain covers both.
+            if ctx.behavior.beep_on_capture_end {
+                enqueue_beep(&ctx.playback_queue, BEEP_CAPTURE_END_HZ, ctx.output_rate);
+            }
 
             eprintln!(
                 "→ uploading {} samples ({:.2}s)",
@@ -318,19 +454,184 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
             while ctx.audio_rx.try_recv().is_ok() {}
             ctx.vad.reset();
             window_buf.clear();
-            // In wake-word mode, return to wake-listening for the next
-            // command. In VAD-only mode, stay in capture mode.
-            if let Some(ref mut wake) = ctx.wake {
-                wake.reset();
-                ctx.awaiting_wake = true;
-                eprintln!("Waiting for wake word.");
-            } else {
-                eprintln!("Listening.");
+            // In wake-word mode, optionally stay in a short follow-up
+            // window so the user can reply without re-waking; otherwise
+            // (or in VAD-only mode) keep the existing behaviour.
+            match (ctx.wake.as_mut(), ctx.behavior.follow_up_listen_seconds) {
+                (Some(wake), 0) => {
+                    wake.reset();
+                    ctx.awaiting_wake = true;
+                    eprintln!("Waiting for wake word.");
+                }
+                (Some(_), secs) => {
+                    ctx.awaiting_wake = false;
+                    ctx.follow_up_until =
+                        Some(Instant::now() + Duration::from_secs(secs as u64));
+                    eprintln!("Listening for follow-up... ({secs}s)");
+                }
+                (None, _) => {
+                    eprintln!("Listening.");
+                }
             }
             ctx.mic_enabled.store(true, Ordering::SeqCst);
         }
     }
     Ok(())
+}
+
+/// What the listen loop's main `select!` produced this iteration.
+enum ListenEvent {
+    Audio(Vec<i16>),
+    Command(ListenCommand),
+    CommandClosed,
+}
+
+/// Apply a server push command. The first `PushAudio` of a push mutes
+/// the mic and starts buffering pushed PCM in the playback queue;
+/// `PushDone` waits for the queue to drain and arms the follow-up
+/// listening window so the user can reply without re-waking.
+async fn handle_push_command(
+    ctx: &mut ListenCtx,
+    cmd: ListenCommand,
+    window_buf: &mut Vec<f32>,
+) {
+    match cmd {
+        ListenCommand::PushAudio(pcm) => {
+            if !ctx.push_active {
+                ctx.push_active = true;
+                // Mute mic for the duration of the push so the AI's
+                // own audio doesn't feed back into VAD as a new
+                // utterance. Drain anything already queued in
+                // audio_rx — that's pre-mute audio that would
+                // otherwise pollute the next VAD window.
+                ctx.mic_enabled.store(false, Ordering::SeqCst);
+                while ctx.audio_rx.try_recv().is_ok() {}
+                ctx.vad.reset();
+                window_buf.clear();
+            }
+            let upsampled = resample_to(&pcm, PIPELINE_SAMPLE_RATE, ctx.output_rate);
+            if let Ok(mut q) = ctx.playback_queue.lock() {
+                q.extend(upsampled);
+            }
+        }
+        ListenCommand::PushDone => {
+            wait_for_playback_drain(&ctx.playback_queue).await;
+            while ctx.audio_rx.try_recv().is_ok() {}
+            ctx.vad.reset();
+            window_buf.clear();
+            ctx.push_active = false;
+            // Same follow-up arming as the regular reply path: in
+            // wake-word mode, give the user a window to reply
+            // without re-waking; otherwise just keep listening.
+            match (ctx.wake.as_mut(), ctx.behavior.follow_up_listen_seconds) {
+                (Some(wake), 0) => {
+                    wake.reset();
+                    ctx.awaiting_wake = true;
+                    ctx.follow_up_until = None;
+                    eprintln!("Push complete. Waiting for wake word.");
+                }
+                (Some(_), secs) => {
+                    ctx.awaiting_wake = false;
+                    ctx.follow_up_until =
+                        Some(Instant::now() + Duration::from_secs(secs as u64));
+                    eprintln!("Push complete. Listening for follow-up... ({secs}s)");
+                }
+                (None, _) => {
+                    eprintln!("Push complete. Listening.");
+                }
+            }
+            ctx.mic_enabled.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+/// Background task: keep a `voice/subscribe` SSE stream open and
+/// translate incoming push events into [`ListenCommand`]s for the
+/// listen loop. Reconnects with a small backoff on disconnection so a
+/// flaky network doesn't permanently silence heartbeat notifications.
+async fn subscribe_loop(
+    client: reqwest::Client,
+    base: String,
+    device_id: String,
+    room_profile: String,
+    cmd_tx: mpsc::UnboundedSender<ListenCommand>,
+    shutdown: Arc<AtomicBool>,
+) {
+    let mut backoff_secs: u64 = 1;
+    while !shutdown.load(Ordering::SeqCst) {
+        let (push_tx, mut push_rx) = mpsc::channel::<VoicePushEvent>(32);
+        let conn = voice_subscribe(
+            &client,
+            &base,
+            &device_id,
+            &room_profile,
+            push_tx,
+        );
+        // Forward push events as ListenCommands while the subscribe
+        // call runs to completion in parallel.
+        let forwarder = {
+            let cmd_tx = cmd_tx.clone();
+            tokio::spawn(async move {
+                while let Some(evt) = push_rx.recv().await {
+                    match evt {
+                        VoicePushEvent::PushStart { task } => {
+                            eprintln!(
+                                "[push start{}]",
+                                task.as_deref().map(|t| format!(": {t}")).unwrap_or_default()
+                            );
+                        }
+                        VoicePushEvent::AssistantText { text } => {
+                            eprintln!("(push) {text}");
+                        }
+                        VoicePushEvent::AudioChunk { pcm } => {
+                            if cmd_tx.send(ListenCommand::PushAudio(pcm)).is_err() {
+                                break;
+                            }
+                        }
+                        VoicePushEvent::PushDone => {
+                            let _ = cmd_tx.send(ListenCommand::PushDone);
+                        }
+                        VoicePushEvent::Error { message } => {
+                            eprintln!("[push error: {message}]");
+                            // Still emit PushDone so the listen loop
+                            // can flush any partial playback and reset.
+                            let _ = cmd_tx.send(ListenCommand::PushDone);
+                        }
+                    }
+                }
+            })
+        };
+
+        match conn.await {
+            Ok(()) => {
+                // Server closed cleanly. Reset backoff and reconnect.
+                backoff_secs = 1;
+            }
+            Err(e) => {
+                eprintln!("voice/subscribe disconnected: {e:#}");
+            }
+        }
+        forwarder.abort();
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+        backoff_secs = (backoff_secs * 2).min(30);
+    }
+}
+
+/// Time-out hook for the follow-up window: silence elapsed without a
+/// new utterance, so reset transcription state and return to
+/// wake-listening. Caller `continue`s after this.
+fn expire_follow_up(ctx: &mut ListenCtx, window_buf: &mut Vec<f32>) {
+    ctx.follow_up_until = None;
+    ctx.vad.reset();
+    window_buf.clear();
+    if let Some(ref mut wake) = ctx.wake {
+        wake.reset();
+        ctx.awaiting_wake = true;
+        eprintln!("Follow-up window elapsed. Waiting for wake word.");
+    }
 }
 
 async fn wait_for_playback_drain(queue: &Arc<std::sync::Mutex<VecDeque<i16>>>) {
@@ -683,9 +984,10 @@ async fn process_utterance(
     playback_queue: Arc<std::sync::Mutex<VecDeque<i16>>>,
     output_rate: u32,
 ) -> Result<()> {
-    if let Ok(mut q) = playback_queue.lock() {
-        q.clear();
-    }
+    // Note: the playback queue is intentionally NOT cleared here. The
+    // listen loop wait_for_playback_drain'd the previous reply before
+    // calling us, and a capture-end beep may have been enqueued in the
+    // meantime — it must survive until the cpal callback consumes it.
 
     let (event_tx, mut event_rx) = mpsc::channel::<VoiceEvent>(64);
     let server_call = tokio::spawn({
@@ -748,6 +1050,49 @@ async fn process_utterance(
     Ok(())
 }
 
+// ── Beep helpers ────────────────────────────────────────────────────────
+
+/// Synthesise a short sine-wave beep at the pipeline rate. Amplitude
+/// is intentionally modest (0.4 of full-scale) — confirmation tones
+/// shouldn't blow ears even on a turned-up speakerphone — and the
+/// envelope tapers in/out over 8 ms to avoid the click an abrupt
+/// square-edge waveform would produce.
+fn generate_beep(freq_hz: f32, duration_ms: u32) -> Vec<i16> {
+    let sr = PIPELINE_SAMPLE_RATE as f32;
+    let total = (sr * duration_ms as f32 / 1000.0) as usize;
+    let fade = ((sr * 0.008) as usize).min(total / 2);
+    let amp = 0.4;
+    let mut out = Vec::with_capacity(total);
+    for i in 0..total {
+        let t = i as f32 / sr;
+        let env = if i < fade {
+            i as f32 / fade as f32
+        } else if i >= total - fade {
+            (total - i) as f32 / fade as f32
+        } else {
+            1.0
+        };
+        let v = (2.0 * std::f32::consts::PI * freq_hz * t).sin() * amp * env;
+        out.push((v * i16::MAX as f32) as i16);
+    }
+    out
+}
+
+/// Generate a beep at the pipeline rate and append it to the playback
+/// queue, resampling to the output rate so the cpal callback can
+/// consume it without a per-sample rate convert.
+fn enqueue_beep(
+    queue: &Arc<std::sync::Mutex<VecDeque<i16>>>,
+    freq_hz: f32,
+    output_rate: u32,
+) {
+    let pcm = generate_beep(freq_hz, BEEP_DURATION_MS);
+    let upsampled = resample_to(&pcm, PIPELINE_SAMPLE_RATE, output_rate);
+    if let Ok(mut q) = queue.lock() {
+        q.extend(upsampled);
+    }
+}
+
 // ── Format helpers ──────────────────────────────────────────────────────
 
 fn to_mono(samples: &[i16], channels: u16) -> Vec<i16> {
@@ -804,5 +1149,48 @@ mod tests {
     fn resample_no_op_on_equal_rates() {
         let frames: Vec<i16> = vec![1, 2, 3];
         assert_eq!(resample_to(&frames, 16000, 16000), frames);
+    }
+
+    #[test]
+    fn beep_length_matches_duration() {
+        let pcm = generate_beep(880.0, 150);
+        // 150 ms @ 16 kHz = 2400 samples.
+        assert_eq!(pcm.len(), (PIPELINE_SAMPLE_RATE as usize) * 150 / 1000);
+    }
+
+    #[test]
+    fn beep_envelope_starts_and_ends_silent() {
+        let pcm = generate_beep(880.0, 150);
+        // First and last samples should be near zero — the linear
+        // fade-in/out reaches the edge of the envelope. Tolerance
+        // accounts for the final sample landing 1/fade short of 0.
+        let edge_limit = i16::MAX / 200;
+        assert!(
+            pcm.first().copied().unwrap_or(0).abs() < edge_limit,
+            "first sample too loud: {:?}",
+            pcm.first()
+        );
+        assert!(
+            pcm.last().copied().unwrap_or(0).abs() < edge_limit,
+            "last sample too loud: {:?}",
+            pcm.last()
+        );
+        // Plateau region should swing through real amplitude. Look at
+        // peak magnitude over the central third instead of one sample
+        // (zero-crossings of the sine land on individual samples at
+        // certain frequency/rate combos).
+        let lo = pcm.len() / 3;
+        let hi = pcm.len() * 2 / 3;
+        let peak = pcm[lo..hi].iter().map(|s| s.abs()).max().unwrap_or(0);
+        assert!(peak > i16::MAX / 4, "plateau peak too quiet: {peak}");
+    }
+
+    #[test]
+    fn enqueue_beep_appends_to_queue() {
+        let q = Arc::new(std::sync::Mutex::new(VecDeque::new()));
+        enqueue_beep(&q, 660.0, PIPELINE_SAMPLE_RATE);
+        let len = q.lock().unwrap().len();
+        // Equal sample rates → no resample → exact pipeline-rate length.
+        assert_eq!(len, generate_beep(660.0, BEEP_DURATION_MS).len());
     }
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -9,7 +9,7 @@
 
 use crate::agent::Agent;
 use crate::config::{Config, DigestConfig};
-use crate::heartbeat_config::{load_heartbeat_dir, next_due};
+use crate::heartbeat_config::{HeartbeatVoiceTarget, load_heartbeat_dir, next_due};
 use crate::memory_compaction::compact_memory;
 use crate::periodic_log::{
     catchup_missing_daily_digests, catchup_pending_daily_logs, catchup_pending_monthly_logs,
@@ -29,6 +29,17 @@ use tracing::{info, warn};
 /// How often the catchup loop scans for missing daily logs.
 const CATCHUP_INTERVAL: StdDuration = StdDuration::from_secs(60 * 60);
 
+/// A heartbeat task that's due to fire on this tick.
+struct DueTask {
+    name: String,
+    body: String,
+    /// Per-task chat room override; falls through to `default_room_id`.
+    room_id: Option<String>,
+    /// Voice satellite target, when this task should be delivered as
+    /// TTS audio instead of (or in addition to, on failure) chat.
+    voice: Option<HeartbeatVoiceTarget>,
+}
+
 pub struct Heartbeat {
     pub workspace_dir: PathBuf,
     pub ws_state: Arc<Mutex<WorkspaceState>>,
@@ -47,6 +58,11 @@ pub struct Heartbeat {
     /// Config snapshot used to enumerate memory namespaces and resolve
     /// per-room namespace assignment for periodic-log catch-up.
     pub config: Config,
+    /// Shared API server state, when voice is configured. Cron tasks
+    /// targeting a `voice:` satellite go through `serve.rs`'s push
+    /// helper; absent (no voice providers, or chat-only build) the
+    /// voice path is skipped and `room_id` is used as the only target.
+    pub serve_state: Option<Arc<crate::serve::ServeState>>,
 }
 
 impl Heartbeat {
@@ -301,9 +317,9 @@ impl Heartbeat {
             let enabled: Vec<_> = tasks.into_iter().filter(|t| t.meta.enabled).collect();
 
             let now = Local::now();
-            let (next_at, due_names): (
+            let (next_at, due_tasks): (
                 chrono::DateTime<Local>,
-                Vec<(String, String, Option<String>)>,
+                Vec<DueTask>,
             ) = match next_due(&enabled, now) {
                 None => {
                     // No tasks (or none with valid schedules); poll the
@@ -314,7 +330,12 @@ impl Heartbeat {
                 Some((at, due)) => {
                     let extracted = due
                         .into_iter()
-                        .map(|t| (t.name.clone(), t.body.clone(), t.meta.room_id.clone()))
+                        .map(|t| DueTask {
+                            name: t.name.clone(),
+                            body: t.body.clone(),
+                            room_id: t.meta.room_id.clone(),
+                            voice: t.meta.voice.clone(),
+                        })
                         .collect();
                     (at, extracted)
                 }
@@ -326,25 +347,86 @@ impl Heartbeat {
             info!(
                 "Heartbeat cron: next fire in {:.0}s ({} task(s))",
                 wait.as_secs_f64(),
-                due_names.len()
+                due_tasks.len()
             );
             tokio::time::sleep(wait).await;
 
-            for (name, body, task_room) in due_names {
-                let room = task_room.or_else(|| self.default_room_id.clone());
-                match room {
-                    Some(room) => {
-                        info!("Heartbeat cron: firing task {name} -> {room}");
-                        if let Err(e) = self.agent.trigger(&name, &body, &room).await {
-                            warn!("Heartbeat cron: task {name} failed: {e:#}");
-                        }
-                    }
-                    None => {
+            for task in due_tasks {
+                self.fire_task(task).await;
+            }
+        }
+    }
+
+    /// Dispatch a single fired task to the right channel — voice push
+    /// when configured and a satellite is online, with a chat-room
+    /// fallback when the satellite is offline (per issue #83 4(b)).
+    async fn fire_task(self: &Arc<Self>, task: DueTask) {
+        let DueTask {
+            name,
+            body,
+            room_id,
+            voice,
+        } = task;
+
+        // Voice path: only attempted when a `voice:` target was set on
+        // the task AND the server has voice providers configured.
+        if let (Some(voice), Some(serve_state)) = (voice, self.serve_state.as_ref()) {
+            info!(
+                "Heartbeat cron: firing voice task {name} -> device={}",
+                voice.device_id
+            );
+            let prompt = format!("[Heartbeat: {name}]\n\n{body}");
+            match crate::serve::push_voice_text_to_subscriber(
+                Arc::clone(serve_state),
+                voice.device_id.clone(),
+                Some(name.clone()),
+                prompt,
+            )
+            .await
+            {
+                Ok(()) => return,
+                Err(crate::serve::VoicePushError::Offline) => {
+                    if room_id.is_some() || self.default_room_id.is_some() {
                         warn!(
-                            "Heartbeat cron: task {name} has no room_id and no default; skipping"
+                            "Heartbeat cron: voice satellite offline (device={}); falling back to chat",
+                            voice.device_id
                         );
+                    } else {
+                        warn!(
+                            "Heartbeat cron: voice satellite offline (device={}); no chat fallback configured, dropping",
+                            voice.device_id
+                        );
+                        return;
                     }
                 }
+                Err(crate::serve::VoicePushError::NoVoice) => {
+                    warn!(
+                        "Heartbeat cron: voice push unavailable (no STT/TTS providers); falling back to chat for {name}"
+                    );
+                }
+                Err(crate::serve::VoicePushError::NotConfigured) => {
+                    warn!(
+                        "Heartbeat cron: subscribed satellite's room_profile has no voice_pipeline; falling back to chat for {name}"
+                    );
+                }
+                Err(crate::serve::VoicePushError::Other(msg)) => {
+                    warn!("Heartbeat cron: voice push failed for {name}: {msg}; falling back to chat");
+                }
+            }
+        }
+
+        // Chat path: original behaviour. Used both when no voice target
+        // is set and when the voice push fell through.
+        let room = room_id.or_else(|| self.default_room_id.clone());
+        match room {
+            Some(room) => {
+                info!("Heartbeat cron: firing task {name} -> {room}");
+                if let Err(e) = self.agent.trigger(&name, &body, &room).await {
+                    warn!("Heartbeat cron: task {name} failed: {e:#}");
+                }
+            }
+            None => {
+                warn!("Heartbeat cron: task {name} has no room_id and no default; skipping");
             }
         }
     }

--- a/src/heartbeat_config.rs
+++ b/src/heartbeat_config.rs
@@ -5,7 +5,9 @@
 //! ```markdown
 //! ---
 //! schedule: "0 8 * * *"
-//! room_id: "..."          # optional, defaults to channel default
+//! room_id: "..."          # optional chat target, defaults to channel default
+//! voice:                   # optional voice satellite target
+//!   device_id: "01J..."   # the satellite's device id (see sapphire-call)
 //! enabled: true            # optional, default true
 //! ---
 //!
@@ -13,7 +15,10 @@
 //! ...body...
 //! ```
 //!
-//! The body is used verbatim as the trigger prompt fed to the agent.
+//! When both `voice:` and `room_id` are set, the cron loop tries the
+//! voice satellite first and falls back to the chat room if the
+//! satellite is offline. The body is used verbatim as the trigger
+//! prompt fed to the agent.
 
 use chrono::{DateTime, Local};
 use cron::Schedule;
@@ -31,6 +36,23 @@ pub struct HeartbeatTaskMeta {
     pub room_id: Option<String>,
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Optional voice satellite target. When set, the cron loop tries
+    /// to push the rendered TTS audio to the matching `voice/subscribe`
+    /// subscriber. A satellite that's offline causes a fall-through to
+    /// `room_id` when both are set; otherwise the fire is logged and
+    /// dropped.
+    #[serde(default)]
+    pub voice: Option<HeartbeatVoiceTarget>,
+}
+
+/// Voice satellite target, identified by `device_id`. The
+/// `room_profile` to use is reverse-looked-up from the active
+/// `voice/subscribe` registration, so heartbeat tasks don't have to
+/// duplicate it. A device only ever has one active voice session at a
+/// time, which makes the lookup unambiguous.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HeartbeatVoiceTarget {
+    pub device_id: String,
 }
 
 fn default_true() -> bool {
@@ -185,6 +207,26 @@ mod tests {
         let task = parse_task("t".to_string(), raw).unwrap();
         assert_eq!(task.meta.room_id.as_deref(), Some("!room:example"));
         assert!(!task.meta.enabled);
+        assert!(task.meta.voice.is_none());
+    }
+
+    #[test]
+    fn parse_with_voice_target() {
+        // NB: raw string — line-continuation `\` would otherwise eat
+        // the leading indentation under `voice:` and reparent the
+        // fields to the top level.
+        let raw = r#"---
+schedule: "0 7 * * *"
+room_id: "!chat:example"
+voice:
+  device_id: "01J..."
+---
+body"#;
+        let task = parse_task("morning".to_string(), raw).unwrap();
+        let voice = task.meta.voice.as_ref().unwrap();
+        assert_eq!(voice.device_id, "01J...");
+        // room_id remains as the chat fallback target.
+        assert_eq!(task.meta.room_id.as_deref(), Some("!chat:example"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,35 @@ async fn main() -> Result<()> {
                 Arc::clone(&ws_state),
             ));
 
+            // ── Voice providers + ServeState (built early) ──────────────────
+            // ServeState owns the voice_subscribers registry that heartbeat
+            // pushes through, so it has to exist before heartbeat is spawned.
+            // The STT/TTS bundle download still happens once, on the
+            // blocking pool, before any channel/heartbeat task starts —
+            // a small startup-latency cost in exchange for a heartbeat
+            // path that can target voice satellites.
+            let voice_providers = if config.stt_providers.is_empty()
+                && config.tts_providers.is_empty()
+                || config.standby_mode
+            {
+                None
+            } else {
+                let cfg = config.clone();
+                let providers =
+                    tokio::task::spawn_blocking(move || voice::VoiceProviders::from_config(&cfg))
+                        .await
+                        .map_err(|e| anyhow::anyhow!("voice provider init panicked: {e}"))??;
+                Some(Arc::new(providers))
+            };
+            let serve_state = Arc::new(serve::ServeState::new(
+                config.clone(),
+                Arc::clone(&registry),
+                Arc::clone(&workspace),
+                Arc::clone(&tool_set),
+                Arc::clone(&api_session_store),
+                voice_providers,
+            ));
+
             if config.standby_mode {
                 tracing::info!(
                     "Standby mode enabled: git sync only, skipping channel and heartbeat"
@@ -511,6 +540,7 @@ async fn main() -> Result<()> {
                     agent: Arc::clone(&agent),
                     default_room_id,
                     config: config.clone(),
+                    serve_state: Some(Arc::clone(&serve_state)),
                 };
                 if config.heartbeat_enabled {
                     heartbeat.spawn();
@@ -545,32 +575,7 @@ async fn main() -> Result<()> {
                     })
                     .unwrap_or_else(|| "127.0.0.1:9000".to_string());
 
-                let voice_providers = if config.stt_providers.is_empty()
-                    && config.tts_providers.is_empty()
-                {
-                    None
-                } else {
-                    // Voice provider construction may download model bundles
-                    // through `reqwest::blocking`, which spawns its own tokio
-                    // runtime. Offload to the blocking pool so the inner
-                    // runtime can be dropped outside our #[tokio::main].
-                    let cfg = config.clone();
-                    let providers =
-                        tokio::task::spawn_blocking(move || voice::VoiceProviders::from_config(&cfg))
-                            .await
-                            .map_err(|e| anyhow::anyhow!("voice provider init panicked: {e}"))??;
-                    Some(Arc::new(providers))
-                };
-
-                let serve_state = Arc::new(serve::ServeState::new(
-                    config,
-                    Arc::clone(&registry),
-                    workspace,
-                    tool_set,
-                    api_session_store,
-                    voice_providers,
-                ));
-                serve::run(addr, serve_state).await?;
+                serve::run(addr, Arc::clone(&serve_state)).await?;
             }
 
             // Wait for the agent task's graceful shutdown to finish so its

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -37,6 +37,19 @@ const MAX_TOOL_ROUNDS: usize = 10;
 // Shared server state
 // ---------------------------------------------------------------------------
 
+/// Map of `device_id` → (`room_profile`, push channel), populated by
+/// `voice/subscribe`. Heartbeat (and any future server-initiated voice
+/// notifier) looks up subscribers here to deliver TTS audio.
+///
+/// Keyed by `device_id` alone because a single satellite only ever
+/// holds one active voice session at a time — the satellite tells us
+/// which room_profile it's bound to when it subscribes, and we keep
+/// that around as the reverse index so heartbeat tasks don't have to
+/// duplicate the value.
+pub type VoiceSubscribers = tokio::sync::Mutex<
+    HashMap<String, (String, mpsc::Sender<crate::voice::VoicePushItem>)>,
+>;
+
 pub struct ServeState {
     pub(crate) config: Config,
     pub(crate) registry: Arc<ProviderRegistry>,
@@ -68,6 +81,10 @@ pub struct ServeState {
     /// `[tts_provider.*]` blocks are configured — in that case the
     /// `voice/pipeline_run` method returns a method-not-available error.
     pub(crate) voice: Option<Arc<VoiceProviders>>,
+    /// Active satellites, keyed by `(device_id, room_profile)`. Inserted
+    /// by `voice/subscribe`, removed by the per-subscription writer task
+    /// when its SSE channel closes (i.e. satellite disconnects).
+    pub(crate) voice_subscribers: Arc<VoiceSubscribers>,
 }
 
 impl ServeState {
@@ -94,6 +111,7 @@ impl ServeState {
             session_room_profiles: tokio::sync::Mutex::new(HashMap::new()),
             session_room_metadata: tokio::sync::Mutex::new(HashMap::new()),
             voice,
+            voice_subscribers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -264,6 +282,7 @@ async fn rpc_post(
         "voice/pipeline_run" => {
             handle_voice_pipeline_run(state, req_id, req.params).await
         }
+        "voice/subscribe" => handle_voice_subscribe(state, req_id, req.params).await,
         _ => {
             let body = error_response(req_id, -32601, "Method not found");
             body.into_response()
@@ -738,13 +757,134 @@ async fn handle_voice_pipeline_run(
         .into_response()
 }
 
+// ---------------------------------------------------------------------------
+// voice/subscribe — long-lived SSE for server→satellite voice pushes
+// ---------------------------------------------------------------------------
+
+async fn handle_voice_subscribe(
+    state: Arc<ServeState>,
+    req_id: Value,
+    params: Option<Value>,
+) -> axum::response::Response {
+    let params = params.unwrap_or(Value::Null);
+    let device_id = match params["device_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => {
+            let body = error_response(req_id, -32602, "Missing params.device_id");
+            return body.into_response();
+        }
+    };
+    let room_profile = match params["room_profile"].as_str() {
+        Some(s) => s.to_string(),
+        None => {
+            let body = error_response(req_id, -32602, "Missing params.room_profile");
+            return body.into_response();
+        }
+    };
+    if state.config.room_profile(&room_profile).is_none() {
+        let body = error_response(
+            req_id,
+            -32602,
+            &format!("Unknown room_profile '{room_profile}'"),
+        );
+        return body.into_response();
+    }
+
+    // Replace any prior subscription for this device (typical case:
+    // the same satellite reconnects after a brief network blip). The
+    // old sender is dropped; its writer task exits on the first
+    // failed send. The room_profile may also have changed across
+    // reconnect, so the freshest value wins — that's the satellite's
+    // current binding.
+    let (push_tx, push_rx) = mpsc::channel::<crate::voice::VoicePushItem>(32);
+    {
+        let mut subs = state.voice_subscribers.lock().await;
+        subs.insert(device_id.clone(), (room_profile.clone(), push_tx));
+    }
+    info!(
+        "voice/subscribe: registered (device={device_id}, room_profile={room_profile})"
+    );
+
+    let (sse_tx, sse_rx) = mpsc::channel::<Result<Event, Infallible>>(32);
+    let cleanup_state = Arc::clone(&state);
+    let cleanup_device = device_id.clone();
+    tokio::spawn(async move {
+        translate_voice_pushes(push_rx, sse_tx).await;
+        // SSE writer exited (satellite disconnected or push channel
+        // closed). Remove the subscriber entry — but only if it still
+        // points at our (now-dropped) sender, since a subsequent
+        // reconnect may have already replaced it.
+        let mut subs = cleanup_state.voice_subscribers.lock().await;
+        if subs
+            .get(&cleanup_device)
+            .map(|(_, tx)| tx.is_closed())
+            .unwrap_or(false)
+        {
+            if let Some((rp, _)) = subs.remove(&cleanup_device) {
+                info!(
+                    "voice/subscribe: unregistered (device={cleanup_device}, room_profile={rp})"
+                );
+            }
+        }
+    });
+
+    let stream = ReceiverStream::new(sse_rx);
+    Sse::new(stream)
+        .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(15)))
+        .into_response()
+}
+
+/// Forward [`VoicePushItem`]s from the per-subscriber mpsc channel into
+/// SSE notification events. Exits when either the push channel closes
+/// (server cleanup) or the SSE channel closes (client disconnect).
+async fn translate_voice_pushes(
+    mut push_rx: mpsc::Receiver<crate::voice::VoicePushItem>,
+    sse_tx: mpsc::Sender<Result<Event, Infallible>>,
+) {
+    use base64::Engine;
+    while let Some(item) = push_rx.recv().await {
+        let evt = match item {
+            crate::voice::VoicePushItem::Start { task } => {
+                let mut params = json!({"kind": "push_start"});
+                if let Some(t) = task {
+                    params["task"] = json!(t);
+                }
+                notification_event("notifications/voice_push", params)
+            }
+            crate::voice::VoicePushItem::AssistantText(text) => notification_event(
+                "notifications/voice_push",
+                json!({"kind": "assistant_text", "text": text}),
+            ),
+            crate::voice::VoicePushItem::AudioChunk(pcm) => {
+                let bytes: Vec<u8> = pcm.iter().flat_map(|s| s.to_le_bytes()).collect();
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                notification_event(
+                    "notifications/voice_push",
+                    json!({"kind": "audio_chunk", "data": b64}),
+                )
+            }
+            crate::voice::VoicePushItem::Done => notification_event(
+                "notifications/voice_push",
+                json!({"kind": "push_done"}),
+            ),
+            crate::voice::VoicePushItem::Error(message) => notification_event(
+                "notifications/voice_push",
+                json!({"kind": "error", "message": message}),
+            ),
+        };
+        if sse_tx.send(Ok(evt)).await.is_err() {
+            break;
+        }
+    }
+}
+
 /// Deterministic session id derived from `(device_id, room_profile)`.
 /// Always-same input ⇒ always-same id, so a satellite reconnecting
 /// after a crash or day rollover resumes the same conversation file.
 ///
 /// Format: `voice-<first 16 hex chars of SHA-256>`. Filesystem-safe,
 /// unique enough for any realistic deployment.
-fn voice_session_id(device_id: &str, room_profile: &str) -> String {
+pub(crate) fn voice_session_id(device_id: &str, room_profile: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(b"voice:");
@@ -778,10 +918,10 @@ async fn run_voice_turn(
         }
     };
 
-    // Resolve voice providers from the session's pinned room_profile.
-    let voice_registry = match state.voice.as_ref() {
-        Some(v) => Arc::clone(v),
-        None => {
+    // Resolve voice pipeline (need STT here; from_text resolves TTS again).
+    let pipeline = match resolve_voice_pipeline(&state, &session_id).await {
+        Ok(p) => p,
+        Err(VoicePipelineLookup::NoVoice) => {
             send(error_event(
                 &req_id,
                 -32601,
@@ -790,20 +930,7 @@ async fn run_voice_turn(
             .await;
             return;
         }
-    };
-
-    let rp_name = state
-        .session_room_profiles
-        .lock()
-        .await
-        .get(&session_id)
-        .cloned();
-    let pipeline = rp_name
-        .as_deref()
-        .and_then(|n| state.config.voice_pipeline_for_room_profile(n));
-    let pipeline = match pipeline {
-        Some(p) => p.clone(),
-        None => {
+        Err(VoicePipelineLookup::NotConfigured) => {
             send(error_event(
                 &req_id,
                 -32602,
@@ -813,6 +940,7 @@ async fn run_voice_turn(
             return;
         }
     };
+    let voice_registry = state.voice.as_ref().expect("checked above").clone();
     let stt = match voice_registry.stt(&pipeline.stt_provider) {
         Some(p) => p,
         None => {
@@ -822,21 +950,6 @@ async fn run_voice_turn(
                 &format!(
                     "stt_provider '{}' not instantiated",
                     pipeline.stt_provider
-                ),
-            ))
-            .await;
-            return;
-        }
-    };
-    let tts = match voice_registry.tts(&pipeline.tts_provider) {
-        Some(p) => p,
-        None => {
-            send(error_event(
-                &req_id,
-                -32603,
-                &format!(
-                    "tts_provider '{}' not instantiated",
-                    pipeline.tts_provider
                 ),
             ))
             .await;
@@ -903,6 +1016,93 @@ async fn run_voice_turn(
     ))
     .await;
 
+    // Hand off to the from-text path for everything past STT.
+    run_voice_turn_from_text_sse(state, session_id, transcript, req_id, tx).await;
+}
+
+/// Voice pipeline failure when looking up the per-session config.
+enum VoicePipelineLookup {
+    NoVoice,
+    NotConfigured,
+}
+
+async fn resolve_voice_pipeline(
+    state: &Arc<ServeState>,
+    session_id: &str,
+) -> Result<crate::config::VoicePipelineConfig, VoicePipelineLookup> {
+    if state.voice.is_none() {
+        return Err(VoicePipelineLookup::NoVoice);
+    }
+    let rp_name = state
+        .session_room_profiles
+        .lock()
+        .await
+        .get(session_id)
+        .cloned();
+    rp_name
+        .as_deref()
+        .and_then(|n| state.config.voice_pipeline_for_room_profile(n))
+        .cloned()
+        .ok_or(VoicePipelineLookup::NotConfigured)
+}
+
+/// LLM turn + TTS streaming, with progress emitted as SSE notifications
+/// for the original `voice/pipeline_run` caller. The final JSON-RPC
+/// result event ends the stream.
+async fn run_voice_turn_from_text_sse(
+    state: Arc<ServeState>,
+    session_id: String,
+    user_text: String,
+    req_id: Value,
+    tx: mpsc::Sender<Result<Event, Infallible>>,
+) {
+    use base64::Engine;
+
+    let send = |evt: Event| {
+        let tx = tx.clone();
+        async move {
+            let _ = tx.send(Ok(evt)).await;
+        }
+    };
+
+    let pipeline = match resolve_voice_pipeline(&state, &session_id).await {
+        Ok(p) => p,
+        Err(VoicePipelineLookup::NoVoice) => {
+            send(error_event(
+                &req_id,
+                -32601,
+                "voice unavailable: no STT/TTS providers configured",
+            ))
+            .await;
+            return;
+        }
+        Err(VoicePipelineLookup::NotConfigured) => {
+            send(error_event(
+                &req_id,
+                -32602,
+                "Session's room_profile has no voice_pipeline configured",
+            ))
+            .await;
+            return;
+        }
+    };
+    let voice_registry = state.voice.as_ref().expect("checked above").clone();
+    let tts = match voice_registry.tts(&pipeline.tts_provider) {
+        Some(p) => p,
+        None => {
+            send(error_event(
+                &req_id,
+                -32603,
+                &format!(
+                    "tts_provider '{}' not instantiated",
+                    pipeline.tts_provider
+                ),
+            ))
+            .await;
+            return;
+        }
+    };
+
     // Stage: LLM (intent)
     send(notification_event(
         "notifications/progress",
@@ -912,7 +1112,7 @@ async fn run_voice_turn(
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        transcript.clone(),
+        user_text.clone(),
         req_id.clone(),
         tx.clone(),
     )
@@ -1018,7 +1218,7 @@ async fn run_voice_turn(
     send(result_event(
         &req_id,
         json!({
-            "transcript": transcript,
+            "transcript": user_text,
             "assistant_text": reply_text,
         }),
     ))
@@ -1028,17 +1228,180 @@ async fn run_voice_turn(
     if outcome.was_first_turn {
         let state2 = Arc::clone(&state);
         let sid = session_id.clone();
-        let user_msg = transcript.clone();
         let reply = reply_text.clone();
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
-            if let Some(title) = generate_session_title(&*p, &user_msg, &reply).await {
+            if let Some(title) = generate_session_title(&*p, &user_text, &reply).await {
                 if let Err(e) = state2.api_session_store.set_title(&sid, &title) {
                     warn!("Failed to store session title: {e}");
                 }
             }
         });
     }
+}
+
+/// Failure modes for [`push_voice_text_to_subscriber`]. `Offline` lets
+/// the heartbeat caller decide whether to fall back to a chat room.
+pub enum VoicePushError {
+    /// The server has no `[stt_provider.*]` / `[tts_provider.*]` blocks
+    /// configured at all — voice push is fundamentally unavailable.
+    NoVoice,
+    /// The room_profile is unknown or has no `voice_pipeline` set.
+    NotConfigured,
+    /// No satellite is currently subscribed for this `(device_id,
+    /// room_profile)` pair. Caller should fall back to chat if the
+    /// heartbeat task has a `room_id`, or log and skip otherwise.
+    Offline,
+    /// Any other failure (TTS, LLM, etc.) surfaced for logging.
+    Other(String),
+}
+
+/// Server-initiated voice push: run the LLM turn against the voice
+/// session bound to `device_id` and stream the TTS audio to the
+/// satellite subscribed via `voice/subscribe`.
+///
+/// The satellite supplied its current `room_profile` when it
+/// subscribed — that value is the authoritative reverse index, so the
+/// caller never has to duplicate it (a satellite's room_profile can
+/// only change via a fresh subscription, which atomically replaces
+/// the binding).
+///
+/// `task_name` becomes the heartbeat task identifier echoed in the
+/// `PushStart` event so the satellite can label notifications.
+pub(crate) async fn push_voice_text_to_subscriber(
+    state: Arc<ServeState>,
+    device_id: String,
+    task_name: Option<String>,
+    user_text: String,
+) -> Result<(), VoicePushError> {
+    // Look up the active subscription up front — if the satellite is
+    // offline, surface that without burning an LLM call. The map also
+    // tells us which room_profile the satellite is bound to.
+    let (room_profile, push_tx) = {
+        let subs = state.voice_subscribers.lock().await;
+        match subs.get(&device_id) {
+            Some((rp, tx)) => (rp.clone(), tx.clone()),
+            None => return Err(VoicePushError::Offline),
+        }
+    };
+    if state.config.room_profile(&room_profile).is_none() {
+        return Err(VoicePushError::NotConfigured);
+    }
+
+    // Pin the room_profile on the synthetic session id so
+    // `resolve_voice_pipeline` and `run_llm_turn` find the right config.
+    let session_id = voice_session_id(&device_id, &room_profile);
+    state
+        .session_room_profiles
+        .lock()
+        .await
+        .insert(session_id.clone(), room_profile.clone());
+
+    let pipeline = match resolve_voice_pipeline(&state, &session_id).await {
+        Ok(p) => p,
+        Err(VoicePipelineLookup::NoVoice) => return Err(VoicePushError::NoVoice),
+        Err(VoicePipelineLookup::NotConfigured) => return Err(VoicePushError::NotConfigured),
+    };
+    let voice_registry = state.voice.as_ref().ok_or(VoicePushError::NoVoice)?.clone();
+    let tts = voice_registry.tts(&pipeline.tts_provider).ok_or_else(|| {
+        VoicePushError::Other(format!(
+            "tts_provider '{}' not instantiated",
+            pipeline.tts_provider
+        ))
+    })?;
+
+    // Notify the satellite that a push is starting so it can mute the
+    // mic before the first audio chunk lands.
+    let _ = push_tx
+        .send(crate::voice::VoicePushItem::Start {
+            task: task_name.clone(),
+        })
+        .await;
+
+    // LLM turn (no SSE response channel — discard tool_start/tool_end
+    // notifications by draining the sink in a background task).
+    let (sink_tx, mut sink_rx) = mpsc::channel::<Result<Event, Infallible>>(32);
+    let drain_handle = tokio::spawn(async move {
+        while sink_rx.recv().await.is_some() {}
+    });
+    let outcome = run_llm_turn(
+        Arc::clone(&state),
+        session_id.clone(),
+        user_text.clone(),
+        Value::Null,
+        sink_tx,
+    )
+    .await;
+    drain_handle.abort();
+    let reply_text = match outcome.text {
+        Some(t) => t,
+        None => {
+            let msg = "LLM turn produced no text".to_string();
+            let _ = push_tx
+                .send(crate::voice::VoicePushItem::Error(msg.clone()))
+                .await;
+            let _ = push_tx.send(crate::voice::VoicePushItem::Done).await;
+            return Err(VoicePushError::Other(msg));
+        }
+    };
+    let _ = push_tx
+        .send(crate::voice::VoicePushItem::AssistantText(reply_text.clone()))
+        .await;
+
+    // TTS: stream chunks to the subscriber as soon as they're synthesised.
+    let (pcm_tx, mut pcm_rx) = mpsc::channel::<Vec<i16>>(32);
+    let reply_for_tts = reply_text.clone();
+    let synth_handle =
+        tokio::spawn(async move { tts.synthesize_stream(&reply_for_tts, pcm_tx).await });
+    let mut chunks_emitted = 0usize;
+    while let Some(chunk) = pcm_rx.recv().await {
+        if push_tx
+            .send(crate::voice::VoicePushItem::AudioChunk(chunk))
+            .await
+            .is_err()
+        {
+            // Satellite disconnected mid-stream; abort the synth task.
+            synth_handle.abort();
+            return Err(VoicePushError::Offline);
+        }
+        chunks_emitted += 1;
+    }
+    match synth_handle.await {
+        Ok(Ok(())) if chunks_emitted == 0 => {
+            let msg = format!(
+                "TTS provider '{}' produced no audio",
+                pipeline.tts_provider
+            );
+            warn!("{msg}");
+            let _ = push_tx
+                .send(crate::voice::VoicePushItem::Error(msg.clone()))
+                .await;
+            let _ = push_tx.send(crate::voice::VoicePushItem::Done).await;
+            return Err(VoicePushError::Other(msg));
+        }
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            let msg = format!("TTS synthesis failed: {e:#}");
+            error!("{msg}");
+            let _ = push_tx
+                .send(crate::voice::VoicePushItem::Error(msg.clone()))
+                .await;
+            let _ = push_tx.send(crate::voice::VoicePushItem::Done).await;
+            return Err(VoicePushError::Other(msg));
+        }
+        Err(join_err) => {
+            let msg = format!("TTS task panicked: {join_err}");
+            error!("{msg}");
+            let _ = push_tx
+                .send(crate::voice::VoicePushItem::Error(msg.clone()))
+                .await;
+            let _ = push_tx.send(crate::voice::VoicePushItem::Done).await;
+            return Err(VoicePushError::Other(msg));
+        }
+    }
+
+    let _ = push_tx.send(crate::voice::VoicePushItem::Done).await;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -32,6 +32,25 @@ pub use tts::TtsProvider;
 /// Fixed pipeline sample rate. Providers must produce/consume at this rate.
 pub const PIPELINE_SAMPLE_RATE: u32 = 16_000;
 
+/// Server-internal push event delivered to a `voice/subscribe` writer
+/// task, which translates to wire-format SSE notifications. Mirrors the
+/// public `sapphire_agent_api::VoicePushEvent` plus enough metadata to
+/// reconstruct the heartbeat task name on the wire.
+#[derive(Debug, Clone)]
+pub enum VoicePushItem {
+    /// Begin a new push (e.g. heartbeat fire).
+    Start { task: Option<String> },
+    /// Assistant text reply (echo of synthesized audio, for transcript).
+    AssistantText(String),
+    /// One synthesized audio chunk at [`PIPELINE_SAMPLE_RATE`].
+    AudioChunk(Vec<i16>),
+    /// Push complete; satellite should drain playback and enter
+    /// follow-up listen.
+    Done,
+    /// Push failed.
+    Error(String),
+}
+
 /// Holds every voice provider instantiated from config, keyed by the
 /// user-chosen name (e.g. `"whisper_local"`, `"irodori"`).
 pub struct VoiceProviders {


### PR DESCRIPTION
## Summary

PR #82 で voice channel が動くようになった後の運用フィードバックを反映する PR。Issue #83 と関連する UX 改善 2 件をまとめて解決する。

- **サテライト側 UX**: ウェイクワード検知 / VAD 発話終端検知でビープを鳴らし、AI 応答後 5 秒間ウェイクワード無しで聞き続ける follow-up listen を追加
- **Heartbeat → voice satellite push**: cron 駆動のモーニングコールなどを家のスピーカーフォンに音声で読み上げる経路を新設 (`voice/subscribe` SSE)

Closes #83.

## 主な変更

### サテライト UX (`crates/sapphire-call`)

- 上昇/下降ビープ (150 ms / 880 Hz / 660 Hz、8 ms 線形エンベロープ) を embed なしで合成、playback queue 経由で再生。ウェイクワード時は mic を一時 mute して beep が自身に被らないようにしている
- 新規 `[behavior]` config ブロック: `beep_on_wake` / `beep_on_capture_end` / `follow_up_listen_seconds` (default すべて on / 5 秒)
- Wake-word モードで AI 応答後、5 秒 VAD のみで聞く follow-up window を追加。発話あれば process_utterance ループへ、無ければ自動的に awaiting_wake に戻る (eprintln \"Follow-up window elapsed. Waiting for wake word.\")

### Heartbeat push (`src/serve.rs`, `src/heartbeat*.rs`)

- `voice/subscribe` RPC method (POST /rpc + SSE 応答) — サテライト起動時に永続接続、サーバが TTS PCM チャンクを push
- `ServeState.voice_subscribers: device_id → (room_profile, mpsc push channel)` — ユーザー指摘どおり key は device_id だけ、room_profile は subscribe 時に貰ったものを逆引きで使う (1 device = 1 active voice session 前提)
- Heartbeat task frontmatter で `voice: { device_id: \"...\" }` を指定可能に
- `push_voice_text_to_subscriber` ヘルパー (in `serve.rs`) が voice session_id を導出 → LLM turn → TTS → subscriber に push
- **チャットフォールバック**: subscriber が居なければ (オフライン)、`room_id` または `default_room_id` 経由でチャットに warn 付きでフォールバック (issue 案 4(b))

### リファクタ

- `run_voice_turn` を分割: audio entry (decode + STT) → `run_voice_turn_from_text_sse` (LLM + TTS streaming). heartbeat 経路は別関数 (`push_voice_text_to_subscriber`) で同じ LLM/TTS パターンを mpsc<VoicePushItem> に流す
- `main.rs` で `ServeState` 構築を heartbeat 構築より前に移動 — heartbeat が `Arc<ServeState>` を持って voice subscriber lookup できるように

## 後追い issue

- #86 quiet_hours (将来のメール受信通知 / 監視エラー通知向け、cron で時刻指定できる現状は不要)
- #87 mic gain / wake threshold / VAD threshold の設定 (ハードコードを設定可能に)

## Test plan

- [x] \`cargo build\` (workspace) — warning 0 件 (既存 dead_code 警告のみ)
- [x] \`cargo build -p sapphire-call\` — 同上
- [x] \`cargo test\` (workspace) — 116 passing
- [x] \`cargo test -p sapphire-call\` — 14 passing (ビープ生成 / config パース / 既存テスト)
- [ ] サテライト E2E (USB speakerphone): ウェイクワード → 上昇 beep → 発話 → 下降 beep → AI 応答 → 5 秒間 follow-up listen → 再発話で続き / silence で wake 待ち
- [ ] Heartbeat E2E: \`heartbeat/morning_voice.md\` に \`voice: { device_id: ... }\` 付きタスクを書いて発火、サテライト側で TTS が再生 + follow-up listen 動作確認
- [ ] Heartbeat フォールバック: サテライト停止状態で同タスク発火 → warn + チャットへフォールバック確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)