### PR TITLE
chore(ci): unblock CI — rustfmt + clippy clean-up, install ALSA dev libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
@@ -33,5 +35,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace

--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -108,6 +108,7 @@ fn next_id() -> u64 {
 ///
 /// This is the shared entry point used by both `sapphire-agent call` and
 /// the standalone `sapphire-call` binary.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     server: String,
     session: Option<String>,

--- a/crates/sapphire-agent-api/src/voice.rs
+++ b/crates/sapphire-agent-api/src/voice.rs
@@ -58,10 +58,7 @@ pub struct WakeWordModel {
 /// No session token needed — wake-word config is the same for every
 /// satellite regardless of room_profile, so this is a stateless
 /// GET-like call.
-pub async fn voice_config(
-    client: &reqwest::Client,
-    base: &str,
-) -> Result<WakeWordConfig> {
+pub async fn voice_config(client: &reqwest::Client, base: &str) -> Result<WakeWordConfig> {
     let base = base.trim_end_matches('/');
     let body = json!({
         "jsonrpc": "2.0",
@@ -185,6 +182,7 @@ pub enum VoicePushEvent {
 /// server derives a deterministic session id from this pair so the
 /// satellite can resume the same conversation across restarts /
 /// network blips without juggling explicit session tokens.
+#[allow(clippy::too_many_arguments)]
 pub async fn voice_pipeline_run(
     client: &reqwest::Client,
     base: &str,
@@ -319,9 +317,13 @@ async fn dispatch_push_event(val: &Value, tx: &mpsc::Sender<VoicePushEvent>) -> 
                     "push_start" => Some(VoicePushEvent::PushStart {
                         task: params["task"].as_str().map(String::from),
                     }),
-                    "assistant_text" => params["text"]
-                        .as_str()
-                        .map(|s| VoicePushEvent::AssistantText { text: s.to_string() }),
+                    "assistant_text" => {
+                        params["text"]
+                            .as_str()
+                            .map(|s| VoicePushEvent::AssistantText {
+                                text: s.to_string(),
+                            })
+                    }
                     "audio_chunk" => params["data"].as_str().and_then(decode_push_audio_chunk),
                     "push_done" => Some(VoicePushEvent::PushDone),
                     "error" => Some(VoicePushEvent::Error {

--- a/crates/sapphire-call/src/config.rs
+++ b/crates/sapphire-call/src/config.rs
@@ -145,10 +145,10 @@ impl CallConfig {
     /// short-circuit when the file doesn't exist — missing-config is
     /// the default state and shouldn't surface as an error.
     pub fn load(path: &Path) -> Result<Self> {
-        let raw = std::fs::read_to_string(path)
-            .with_context(|| format!("read {}", path.display()))?;
-        let cfg: CallConfig = toml::from_str(&raw)
-            .with_context(|| format!("parse {}", path.display()))?;
+        let raw =
+            std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        let cfg: CallConfig =
+            toml::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
         Ok(cfg)
     }
 

--- a/crates/sapphire-call/src/device_id.rs
+++ b/crates/sapphire-call/src/device_id.rs
@@ -20,8 +20,8 @@ use uuid::Uuid;
 pub fn ensure_device_id() -> Result<String> {
     let path = path()?;
     if path.exists() {
-        let raw = std::fs::read_to_string(&path)
-            .with_context(|| format!("read {}", path.display()))?;
+        let raw =
+            std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
         let id = raw.trim().to_string();
         if !id.is_empty() {
             return Ok(id);
@@ -34,8 +34,7 @@ pub fn ensure_device_id() -> Result<String> {
     }
     let id = Uuid::now_v7().to_string();
     let tmp = path.with_extension("partial");
-    std::fs::write(&tmp, &id)
-        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::write(&tmp, &id).with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
     Ok(id)

--- a/crates/sapphire-call/src/voice/mod.rs
+++ b/crates/sapphire-call/src/voice/mod.rs
@@ -28,9 +28,7 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use sapphire_agent_api::{
     VoiceEvent, VoicePushEvent, voice::PIPELINE_SAMPLE_RATE, voice_pipeline_run, voice_subscribe,
 };
-use sherpa_onnx::{
-    SileroVadModelConfig, VadModelConfig, VoiceActivityDetector,
-};
+use sherpa_onnx::{SileroVadModelConfig, VadModelConfig, VoiceActivityDetector};
 use tokio::sync::mpsc;
 
 /// Command sent from the `voice/subscribe` consumer task into the
@@ -115,9 +113,7 @@ pub async fn run(
              or pass --room-profile <name>"
         )
     })?;
-    eprintln!(
-        "sapphire-call voice (device: {device_id}, room_profile: {room_profile})",
-    );
+    eprintln!("sapphire-call voice (device: {device_id}, room_profile: {room_profile})",);
 
     // ── Wake-word config: fetch the inline ONNX from the server ─────────
     let server_wake = sapphire_agent_api::voice_config(&client, &base)
@@ -198,9 +194,7 @@ pub async fn run(
     )?;
     output_stream.play()?;
 
-    eprintln!(
-        "input: {input_rate} Hz × {input_channels}ch  output: {output_rate} Hz",
-    );
+    eprintln!("input: {input_rate} Hz × {input_channels}ch  output: {output_rate} Hz",);
     eprintln!("Listening. Ctrl-C to quit.");
 
     // ── Ctrl-C handler ──────────────────────────────────────────────────
@@ -367,27 +361,27 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
         // audio to the openWakeWord detector only — VAD doesn't see
         // the stream until the wake fires.
         if ctx.awaiting_wake {
-            if let Some(ref mut wake) = ctx.wake {
-                if let Some(keyword) = wake.feed(&pcm16k)? {
-                    eprintln!("[wake: {keyword}] now listening for command...");
-                    ctx.awaiting_wake = false;
-                    // Clear any audio left over from before the wake so
-                    // the VAD starts on the post-wake utterance.
-                    ctx.vad.reset();
-                    window_buf.clear();
-                    if ctx.behavior.beep_on_wake {
-                        // Mute, play the rising tone, drain anything
-                        // already in flight, then re-open. A residual
-                        // input frame queued before the mute would
-                        // otherwise be re-processed as part of the
-                        // command itself.
-                        ctx.mic_enabled.store(false, Ordering::SeqCst);
-                        while ctx.audio_rx.try_recv().is_ok() {}
-                        enqueue_beep(&ctx.playback_queue, BEEP_WAKE_HZ, ctx.output_rate);
-                        wait_for_playback_drain(&ctx.playback_queue).await;
-                        while ctx.audio_rx.try_recv().is_ok() {}
-                        ctx.mic_enabled.store(true, Ordering::SeqCst);
-                    }
+            if let Some(ref mut wake) = ctx.wake
+                && let Some(keyword) = wake.feed(&pcm16k)?
+            {
+                eprintln!("[wake: {keyword}] now listening for command...");
+                ctx.awaiting_wake = false;
+                // Clear any audio left over from before the wake so
+                // the VAD starts on the post-wake utterance.
+                ctx.vad.reset();
+                window_buf.clear();
+                if ctx.behavior.beep_on_wake {
+                    // Mute, play the rising tone, drain anything
+                    // already in flight, then re-open. A residual
+                    // input frame queued before the mute would
+                    // otherwise be re-processed as part of the
+                    // command itself.
+                    ctx.mic_enabled.store(false, Ordering::SeqCst);
+                    while ctx.audio_rx.try_recv().is_ok() {}
+                    enqueue_beep(&ctx.playback_queue, BEEP_WAKE_HZ, ctx.output_rate);
+                    wait_for_playback_drain(&ctx.playback_queue).await;
+                    while ctx.audio_rx.try_recv().is_ok() {}
+                    ctx.mic_enabled.store(true, Ordering::SeqCst);
                 }
             }
             continue;
@@ -465,8 +459,7 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
                 }
                 (Some(_), secs) => {
                     ctx.awaiting_wake = false;
-                    ctx.follow_up_until =
-                        Some(Instant::now() + Duration::from_secs(secs as u64));
+                    ctx.follow_up_until = Some(Instant::now() + Duration::from_secs(secs as u64));
                     eprintln!("Listening for follow-up... ({secs}s)");
                 }
                 (None, _) => {
@@ -490,11 +483,7 @@ enum ListenEvent {
 /// the mic and starts buffering pushed PCM in the playback queue;
 /// `PushDone` waits for the queue to drain and arms the follow-up
 /// listening window so the user can reply without re-waking.
-async fn handle_push_command(
-    ctx: &mut ListenCtx,
-    cmd: ListenCommand,
-    window_buf: &mut Vec<f32>,
-) {
+async fn handle_push_command(ctx: &mut ListenCtx, cmd: ListenCommand, window_buf: &mut Vec<f32>) {
     match cmd {
         ListenCommand::PushAudio(pcm) => {
             if !ctx.push_active {
@@ -532,8 +521,7 @@ async fn handle_push_command(
                 }
                 (Some(_), secs) => {
                     ctx.awaiting_wake = false;
-                    ctx.follow_up_until =
-                        Some(Instant::now() + Duration::from_secs(secs as u64));
+                    ctx.follow_up_until = Some(Instant::now() + Duration::from_secs(secs as u64));
                     eprintln!("Push complete. Listening for follow-up... ({secs}s)");
                 }
                 (None, _) => {
@@ -560,13 +548,7 @@ async fn subscribe_loop(
     let mut backoff_secs: u64 = 1;
     while !shutdown.load(Ordering::SeqCst) {
         let (push_tx, mut push_rx) = mpsc::channel::<VoicePushEvent>(32);
-        let conn = voice_subscribe(
-            &client,
-            &base,
-            &device_id,
-            &room_profile,
-            push_tx,
-        );
+        let conn = voice_subscribe(&client, &base, &device_id, &room_profile, push_tx);
         // Forward push events as ListenCommands while the subscribe
         // call runs to completion in parallel.
         let forwarder = {
@@ -577,7 +559,9 @@ async fn subscribe_loop(
                         VoicePushEvent::PushStart { task } => {
                             eprintln!(
                                 "[push start{}]",
-                                task.as_deref().map(|t| format!(": {t}")).unwrap_or_default()
+                                task.as_deref()
+                                    .map(|t| format!(": {t}"))
+                                    .unwrap_or_default()
                             );
                         }
                         VoicePushEvent::AssistantText { text } => {
@@ -690,11 +674,7 @@ enum DeviceKind {
 /// underlying PCM during enumeration, which can fail transiently), so
 /// enumerating twice — once to match, once to report — can produce
 /// a list in the error that the matcher never actually saw.
-fn pick_device(
-    host: &cpal::Host,
-    name: Option<&str>,
-    kind: DeviceKind,
-) -> Result<cpal::Device> {
+fn pick_device(host: &cpal::Host, name: Option<&str>, kind: DeviceKind) -> Result<cpal::Device> {
     if let Some(want) = name {
         let candidates: Vec<cpal::Device> = match kind {
             DeviceKind::Input => host.input_devices()?.collect(),
@@ -735,12 +715,8 @@ fn pick_device(
 /// `--output-device`.
 fn list_devices() -> Result<()> {
     let host = cpal::default_host();
-    let default_in = host
-        .default_input_device()
-        .and_then(|d| d.name().ok());
-    let default_out = host
-        .default_output_device()
-        .and_then(|d| d.name().ok());
+    let default_in = host.default_input_device().and_then(|d| d.name().ok());
+    let default_out = host.default_output_device().and_then(|d| d.name().ok());
 
     println!("cpal host: {}", host.id().name());
     println!();
@@ -855,8 +831,7 @@ fn open_input_stream(
                     if !enabled.load(Ordering::SeqCst) {
                         return;
                     }
-                    let pcm: Vec<i16> =
-                        data.iter().map(|s| (*s as i32 - 32768) as i16).collect();
+                    let pcm: Vec<i16> = data.iter().map(|s| (*s as i32 - 32768) as i16).collect();
                     let _ = tx.send(pcm);
                 },
                 err_fn,
@@ -1081,11 +1056,7 @@ fn generate_beep(freq_hz: f32, duration_ms: u32) -> Vec<i16> {
 /// Generate a beep at the pipeline rate and append it to the playback
 /// queue, resampling to the output rate so the cpal callback can
 /// consume it without a per-sample rate convert.
-fn enqueue_beep(
-    queue: &Arc<std::sync::Mutex<VecDeque<i16>>>,
-    freq_hz: f32,
-    output_rate: u32,
-) {
+fn enqueue_beep(queue: &Arc<std::sync::Mutex<VecDeque<i16>>>, freq_hz: f32, output_rate: u32) {
     let pcm = generate_beep(freq_hz, BEEP_DURATION_MS);
     let upsampled = resample_to(&pcm, PIPELINE_SAMPLE_RATE, output_rate);
     if let Ok(mut q) = queue.lock() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -254,9 +254,9 @@ impl Agent {
                     // Also publish an intra-day digest line so the
                     // cross-session today_digest picks up what this
                     // session covered before we went down.
-                    if let Err(e) = self
-                        .session_store
-                        .append_intraday_digest(&session_id, &summary, None)
+                    if let Err(e) =
+                        self.session_store
+                            .append_intraday_digest(&session_id, &summary, None)
                     {
                         warn!("Failed to persist shutdown intra-day digest for {session_id}: {e}");
                     }
@@ -660,14 +660,14 @@ impl Agent {
 
         {
             let snapshots = self.snapshots.lock().await;
-            if let Some(snap) = snapshots.get(key) {
-                if snap.date == today {
-                    return if snap.system_prompt.is_empty() {
-                        None
-                    } else {
-                        Some(snap.system_prompt.clone())
-                    };
-                }
+            if let Some(snap) = snapshots.get(key)
+                && snap.date == today
+            {
+                return if snap.system_prompt.is_empty() {
+                    None
+                } else {
+                    Some(snap.system_prompt.clone())
+                };
             }
         }
 
@@ -820,7 +820,7 @@ impl Agent {
                 &*provider,
                 system_with_context.as_deref(),
                 &messages,
-                &compression_config,
+                compression_config,
             )
             .await
             {
@@ -900,21 +900,21 @@ impl Agent {
                     // tokio::spawn does not propagate task_local, so we
                     // re-bind it inside each spawned future.
                     let tools = Arc::clone(self.tools.as_ref().unwrap());
-                    let ns = self.config.namespace_for_room(&incoming.room_id).to_string();
+                    let ns = self
+                        .config
+                        .namespace_for_room(&incoming.room_id)
+                        .to_string();
                     let mut handles = Vec::with_capacity(tool_calls.len());
                     for call in tool_calls {
                         let tools = Arc::clone(&tools);
                         let ns = ns.clone();
                         handles.push(tokio::spawn(
-                            crate::tools::workspace_tools::scope_memory_namespace(
-                                ns,
-                                async move {
-                                    info!("Executing tool: {} (id={})", call.name, call.id);
-                                    let result = tools.execute(&call).await;
-                                    info!("Tool {} result: {}", call.name, result);
-                                    (call.id, result)
-                                },
-                            ),
+                            crate::tools::workspace_tools::scope_memory_namespace(ns, async move {
+                                info!("Executing tool: {} (id={})", call.name, call.id);
+                                let result = tools.execute(&call).await;
+                                info!("Tool {} result: {}", call.name, result);
+                                (call.id, result)
+                            }),
                         ));
                     }
 

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -180,13 +180,11 @@ async fn download_matrix_image(client: &Client, image: &ImageMessageEventContent
             } else {
                 match sniff_image_mime(&bytes) {
                     Some(t) => {
-                        if declared.is_some() {
+                        if let Some(d) = declared {
                             warn!(
                                 "Matrix image '{}' declared MIME '{}' is unsupported; \
                                  detected '{}' from bytes",
-                                image.body,
-                                declared.unwrap(),
-                                t
+                                image.body, d, t
                             );
                         }
                         t.to_string()

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -23,6 +23,7 @@ pub struct Attachment {
 }
 
 /// A message received from a channel.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct IncomingMessage {
     /// Platform-specific message ID.
@@ -83,6 +84,7 @@ pub struct RoomInfo {
 
 /// Core channel trait.
 #[async_trait]
+#[allow(dead_code)]
 pub trait Channel: Send + Sync {
     fn name(&self) -> &str;
 
@@ -137,6 +139,7 @@ impl Channels {
 
     /// True when no channels are registered (e.g. standby mode or
     /// API-only deployment).
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.list.is_empty()
     }
@@ -198,15 +201,13 @@ impl Channels {
     /// the same outgoing `tx`. Each forwarded message updates the
     /// routing map so the originating channel is locked in for any
     /// subsequent outgoing reply.
-    pub async fn listen_all(
-        self: Arc<Self>,
-        tx: mpsc::Sender<IncomingMessage>,
-    ) -> Result<()> {
+    pub async fn listen_all(self: Arc<Self>, tx: mpsc::Sender<IncomingMessage>) -> Result<()> {
         if self.list.is_empty() {
             return Err(anyhow!("listen_all called with no channels registered"));
         }
         let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-        for (name, ch) in self.list.iter().cloned().collect::<Vec<_>>() {
+        for entry in &self.list {
+            let (name, ch) = (entry.0.clone(), Arc::clone(&entry.1));
             let outer_tx = tx.clone();
             let me = Arc::clone(&self);
             let (inner_tx, mut inner_rx) = mpsc::channel::<IncomingMessage>(64);
@@ -260,4 +261,3 @@ pub fn seed_routing_from_config(config: &crate::config::Config) -> HashMap<Strin
     }
     seed
 }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -934,10 +934,9 @@ impl Config {
     ///
     /// Returns `None` if the profile is not defined. Caller is expected to
     /// fall back to the built-in anthropic provider in that case.
+    #[allow(dead_code)]
     pub fn provider_for_profile(&self, profile_name: &str) -> Option<&str> {
-        self.profiles
-            .get(profile_name)
-            .map(|p| p.provider.as_str())
+        self.profiles.get(profile_name).map(|p| p.provider.as_str())
     }
 
     /// Validate that every profile points to a known provider, and that
@@ -955,12 +954,12 @@ impl Config {
                     prof.provider
                 ));
             }
-            if let Some(fb) = &prof.fallback_provider {
-                if !known_provider(fb) {
-                    errors.push(format!(
-                        "profile '{pname}' references unknown fallback_provider '{fb}'"
-                    ));
-                }
+            if let Some(fb) = &prof.fallback_provider
+                && !known_provider(fb)
+            {
+                errors.push(format!(
+                    "profile '{pname}' references unknown fallback_provider '{fb}'"
+                ));
             }
         }
         // Room profile references and uniqueness of room_ids across profiles.
@@ -973,12 +972,12 @@ impl Config {
                     rp.profile
                 ));
             }
-            if let Some(ns) = &rp.memory_namespace {
-                if !self.namespace_is_defined(ns) {
-                    errors.push(format!(
-                        "room_profile '{rp_name}' references unknown memory_namespace '{ns}'"
-                    ));
-                }
+            if let Some(ns) = &rp.memory_namespace
+                && !self.namespace_is_defined(ns)
+            {
+                errors.push(format!(
+                    "room_profile '{rp_name}' references unknown memory_namespace '{ns}'"
+                ));
             }
             for room in &rp.rooms {
                 if let Some(prev) = seen_rooms.get(room) {
@@ -1014,12 +1013,12 @@ impl Config {
                     ));
                 }
             }
-            if let Some(prof) = &ns_cfg.background_profile {
-                if !self.profiles.contains_key(prof) {
-                    errors.push(format!(
-                        "memory_namespace '{ns_name}' references unknown background_profile '{prof}'"
-                    ));
-                }
+            if let Some(prof) = &ns_cfg.background_profile
+                && !self.profiles.contains_key(prof)
+            {
+                errors.push(format!(
+                    "memory_namespace '{ns_name}' references unknown background_profile '{prof}'"
+                ));
             }
         }
         for ns_name in self.memory_namespaces.keys() {
@@ -1032,12 +1031,12 @@ impl Config {
         }
         // Voice pipeline references.
         for (rp_name, rp) in &self.room_profiles {
-            if let Some(vp) = &rp.voice_pipeline {
-                if !self.voice_pipelines.contains_key(vp) {
-                    errors.push(format!(
-                        "room_profile '{rp_name}' references unknown voice_pipeline '{vp}'"
-                    ));
-                }
+            if let Some(vp) = &rp.voice_pipeline
+                && !self.voice_pipelines.contains_key(vp)
+            {
+                errors.push(format!(
+                    "room_profile '{rp_name}' references unknown voice_pipeline '{vp}'"
+                ));
             }
         }
         // Global [voice].wake_word_model must point at a real file so
@@ -1094,7 +1093,7 @@ impl Config {
                 .unwrap_or_default();
             for parent in parents {
                 if on_stack.contains(&parent) {
-                    let mut cycle: Vec<String> = stack.iter().cloned().collect();
+                    let mut cycle: Vec<String> = stack.to_vec();
                     cycle.push(parent);
                     return Some(cycle);
                 }
@@ -1521,7 +1520,11 @@ include = ["user"]
         );
         assert_eq!(
             cfg.resolve_namespace_chain("user_nsfw"),
-            vec!["user_nsfw".to_string(), "user".to_string(), "default".to_string()]
+            vec![
+                "user_nsfw".to_string(),
+                "user".to_string(),
+                "default".to_string()
+            ]
         );
         assert_eq!(
             cfg.resolve_namespace_chain("user"),
@@ -1806,7 +1809,10 @@ model  = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
         match stt {
             SttProviderConfig::SherpaOnnx(s) => {
                 assert!(matches!(s.kind, SherpaSttKind::SenseVoice));
-                assert_eq!(s.model.as_deref(), Some("sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"));
+                assert_eq!(
+                    s.model.as_deref(),
+                    Some("sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17")
+                );
                 assert_eq!(s.num_threads, 2);
                 assert_eq!(s.provider, "cpu");
                 assert!(s.language.is_none());
@@ -1830,10 +1836,7 @@ speaker_id  = 3
 speed       = 1.2
 "#,
         );
-        let tts = cfg
-            .tts_providers
-            .get("vits_ja")
-            .expect("provider parses");
+        let tts = cfg.tts_providers.get("vits_ja").expect("provider parses");
         match tts {
             TtsProviderConfig::SherpaOnnx(s) => {
                 assert!(matches!(s.kind, SherpaTtsKind::Vits));
@@ -1916,7 +1919,9 @@ wake_word_model = "/nonexistent/saphina.onnx"
         );
         let errors = cfg.validate_profiles();
         assert!(
-            errors.iter().any(|e| e.contains("/nonexistent/saphina.onnx")),
+            errors
+                .iter()
+                .any(|e| e.contains("/nonexistent/saphina.onnx")),
             "got: {errors:?}"
         );
     }

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -28,14 +28,14 @@ pub fn estimate_tokens(text: &str) -> usize {
     }
     // Rough estimate: ASCII ~4 chars/token, non-ASCII ~1.5 chars/token
     let ascii_tokens = ascii_chars / 4;
-    let non_ascii_tokens = (non_ascii_chars * 2 + 2) / 3; // ceil(n * 2/3)
+    let non_ascii_tokens = (non_ascii_chars * 2).div_ceil(3); // ceil(n * 2/3)
     ascii_tokens + non_ascii_tokens
 }
 
 /// Estimate the total token usage for a system prompt + message history.
 pub fn estimate_total_tokens(system: Option<&str>, messages: &[ChatMessage]) -> usize {
-    let system_tokens = system.map(|s| estimate_tokens(s)).unwrap_or(0);
-    let message_tokens: usize = messages.iter().map(|m| estimate_message_tokens(m)).sum();
+    let system_tokens = system.map(estimate_tokens).unwrap_or(0);
+    let message_tokens: usize = messages.iter().map(estimate_message_tokens).sum();
     // Add a small overhead for message framing (~4 tokens per message)
     system_tokens + message_tokens + messages.len() * 4
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -111,10 +111,8 @@ impl Heartbeat {
         tick.tick().await; // skip immediate fire — startup catchup already ran in main
         loop {
             tick.tick().await;
-            let today_local = crate::session::local_date_for_timestamp(
-                Local::now(),
-                self.day_boundary_hour,
-            );
+            let today_local =
+                crate::session::local_date_for_timestamp(Local::now(), self.day_boundary_hour);
             let mut total: usize = 0;
             for ns in self.config.all_memory_namespaces() {
                 let provider = self.provider_for_namespace(&ns);
@@ -317,29 +315,27 @@ impl Heartbeat {
             let enabled: Vec<_> = tasks.into_iter().filter(|t| t.meta.enabled).collect();
 
             let now = Local::now();
-            let (next_at, due_tasks): (
-                chrono::DateTime<Local>,
-                Vec<DueTask>,
-            ) = match next_due(&enabled, now) {
-                None => {
-                    // No tasks (or none with valid schedules); poll the
-                    // directory periodically in case files are added.
-                    tokio::time::sleep(StdDuration::from_secs(60)).await;
-                    continue;
-                }
-                Some((at, due)) => {
-                    let extracted = due
-                        .into_iter()
-                        .map(|t| DueTask {
-                            name: t.name.clone(),
-                            body: t.body.clone(),
-                            room_id: t.meta.room_id.clone(),
-                            voice: t.meta.voice.clone(),
-                        })
-                        .collect();
-                    (at, extracted)
-                }
-            };
+            let (next_at, due_tasks): (chrono::DateTime<Local>, Vec<DueTask>) =
+                match next_due(&enabled, now) {
+                    None => {
+                        // No tasks (or none with valid schedules); poll the
+                        // directory periodically in case files are added.
+                        tokio::time::sleep(StdDuration::from_secs(60)).await;
+                        continue;
+                    }
+                    Some((at, due)) => {
+                        let extracted = due
+                            .into_iter()
+                            .map(|t| DueTask {
+                                name: t.name.clone(),
+                                body: t.body.clone(),
+                                room_id: t.meta.room_id.clone(),
+                                voice: t.meta.voice.clone(),
+                            })
+                            .collect();
+                        (at, extracted)
+                    }
+                };
 
             let wait = (next_at - now)
                 .to_std()
@@ -410,7 +406,9 @@ impl Heartbeat {
                     );
                 }
                 Err(crate::serve::VoicePushError::Other(msg)) => {
-                    warn!("Heartbeat cron: voice push failed for {name}: {msg}; falling back to chat");
+                    warn!(
+                        "Heartbeat cron: voice push failed for {name}: {msg}; falling back to chat"
+                    );
                 }
             }
         }

--- a/src/heartbeat_config.rs
+++ b/src/heartbeat_config.rs
@@ -154,9 +154,7 @@ fn parse_task(name: String, raw: &str) -> Option<HeartbeatTask> {
     Some(HeartbeatTask {
         name,
         meta,
-        body: body
-            .trim_start_matches(|c: char| c == '\n' || c == '\r')
-            .to_string(),
+        body: body.trim_start_matches(['\n', '\r']).to_string(),
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,17 @@ async fn main() -> Result<()> {
         // The in-tree `sapphire-agent call` CLI has no per-device config
         // file, so no DeviceMetadata is forwarded; standalone callers
         // (sapphire-call) plumb their own `[device]` block through.
-        return call::run(server, session, list, message, history, json, room_profile, None)
-            .await;
+        return call::run(
+            server,
+            session,
+            list,
+            message,
+            history,
+            json,
+            room_profile,
+            None,
+        )
+        .await;
     }
 
     let config_path = cli.config.unwrap_or_else(Config::default_path);
@@ -259,7 +268,9 @@ async fn main() -> Result<()> {
             // with-channels code path replaces this with a richer loop
             // below that also rebuilds today_digests on the same tick
             // (so we don't pay periodic_sync twice per interval).
-            if config.standby_mode && let Some(dur) = ws_sync_interval {
+            if config.standby_mode
+                && let Some(dur) = ws_sync_interval
+            {
                 tracing::info!("Periodic workspace sync enabled: every {}s", dur.as_secs());
                 let ws = Arc::clone(&ws_state);
                 tokio::spawn(async move {
@@ -375,10 +386,7 @@ async fn main() -> Result<()> {
                     channel_list,
                     channel::seed_routing_from_config(&config),
                 ));
-                tracing::info!(
-                    "Channels active: {}",
-                    channels.names().join(", ")
-                );
+                tracing::info!("Channels active: {}", channels.names().join(", "));
 
                 // ── Catch-up: iterate every configured memory namespace ────
                 // Each namespace's background tasks run on its own provider
@@ -466,10 +474,7 @@ async fn main() -> Result<()> {
                 // "today's notes" become visible without waiting for the
                 // next day-boundary daily-log generation.
                 if let Some(dur) = ws_sync_interval {
-                    tracing::info!(
-                        "Periodic workspace sync enabled: every {}s",
-                        dur.as_secs()
-                    );
+                    tracing::info!("Periodic workspace sync enabled: every {}s", dur.as_secs());
                     let ws = Arc::clone(&ws_state);
                     let cfg_for_loop = config.clone();
                     let workspace_for_loop = Arc::clone(&workspace);
@@ -580,10 +585,10 @@ async fn main() -> Result<()> {
 
             // Wait for the agent task's graceful shutdown to finish so its
             // summarize_on_shutdown LLM call isn't aborted by runtime drop.
-            if let Some(handle) = agent_handle {
-                if let Err(e) = handle.await {
-                    tracing::warn!("Agent task did not finish cleanly: {e}");
-                }
+            if let Some(handle) = agent_handle
+                && let Err(e) = handle.await
+            {
+                tracing::warn!("Agent task did not finish cleanly: {e}");
             }
         }
         Command::Call { .. } => unreachable!(),
@@ -608,10 +613,7 @@ async fn rebuild_today_digests(
     api_store: &Arc<SessionStore>,
     agent: &Arc<Agent>,
 ) {
-    let today = session::local_date_for_timestamp(
-        chrono::Local::now(),
-        config.day_boundary_hour,
-    );
+    let today = session::local_date_for_timestamp(chrono::Local::now(), config.day_boundary_hour);
     let namespaces = config.all_memory_namespaces();
     let cfg = config.clone();
     let map = build_all_today_digests(
@@ -639,9 +641,7 @@ async fn rebuild_today_digests(
 /// files exist. Refuses to run when a target path is already occupied
 /// (extremely unlikely with ULID/UUID file names but handled for
 /// safety).
-fn migrate_sessions_to_namespaced_layout(
-    sessions_base: &std::path::Path,
-) -> anyhow::Result<()> {
+fn migrate_sessions_to_namespaced_layout(sessions_base: &std::path::Path) -> anyhow::Result<()> {
     use std::io::{BufRead, BufReader};
 
     for kind in ["channel", "api"] {
@@ -698,9 +698,8 @@ fn migrate_sessions_to_namespaced_layout(
                     dst.display(),
                 );
             }
-            std::fs::rename(&path, &dst).with_context(|| {
-                format!("rename {} -> {}", path.display(), dst.display())
-            })?;
+            std::fs::rename(&path, &dst)
+                .with_context(|| format!("rename {} -> {}", path.display(), dst.display()))?;
             moved += 1;
         }
         // Remove the now-empty flat directory; non-fatal if it still has
@@ -740,8 +739,7 @@ fn migrate_per_channel_sessions(sessions_base: &std::path::Path) -> anyhow::Resu
         return Ok(());
     }
 
-    std::fs::create_dir_all(&target)
-        .with_context(|| format!("create {}", target.display()))?;
+    std::fs::create_dir_all(&target).with_context(|| format!("create {}", target.display()))?;
 
     for src in sources {
         let entries = match std::fs::read_dir(&src) {
@@ -769,9 +767,8 @@ fn migrate_per_channel_sessions(sessions_base: &std::path::Path) -> anyhow::Resu
                     dst.display(),
                 );
             }
-            std::fs::rename(&path, &dst).with_context(|| {
-                format!("rename {} -> {}", path.display(), dst.display())
-            })?;
+            std::fs::rename(&path, &dst)
+                .with_context(|| format!("rename {} -> {}", path.display(), dst.display()))?;
             moved += 1;
         }
         // Remove the now-empty legacy directory; non-fatal if it has
@@ -835,9 +832,8 @@ fn migrate_pre_namespace_layout(workspace_dir: &std::path::Path) -> anyhow::Resu
     for kind in &pre_dirs {
         let src = memory_root.join(kind);
         let dst = default_root.join(kind);
-        std::fs::rename(&src, &dst).with_context(|| {
-            format!("rename {} -> {}", src.display(), dst.display())
-        })?;
+        std::fs::rename(&src, &dst)
+            .with_context(|| format!("rename {} -> {}", src.display(), dst.display()))?;
         tracing::info!(
             "Migrated memory subdir: {} -> {}",
             src.display(),
@@ -849,11 +845,7 @@ fn migrate_pre_namespace_layout(workspace_dir: &std::path::Path) -> anyhow::Resu
         let dst = default_root.join("MEMORY.md");
         std::fs::rename(&src, &dst)
             .with_context(|| format!("rename {} -> {}", src.display(), dst.display()))?;
-        tracing::info!(
-            "Migrated MEMORY.md: {} -> {}",
-            src.display(),
-            dst.display()
-        );
+        tracing::info!("Migrated MEMORY.md: {} -> {}", src.display(), dst.display());
     }
 
     Ok(())
@@ -978,8 +970,14 @@ mod tests {
             let path = base.join("channel").join(format!("{stem}.jsonl"));
             assert!(path.exists(), "missing: {}", path.display());
         }
-        assert!(!base.join("matrix").exists(), "matrix dir should be removed");
-        assert!(!base.join("discord").exists(), "discord dir should be removed");
+        assert!(
+            !base.join("matrix").exists(),
+            "matrix dir should be removed"
+        );
+        assert!(
+            !base.join("discord").exists(),
+            "discord dir should be removed"
+        );
     }
 
     #[test]

--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -287,6 +287,7 @@ impl McpClient {
     }
 
     /// Shut down the transport.
+    #[allow(dead_code)]
     pub async fn shutdown(&self) -> Result<()> {
         let transport = self.transport.read().await.clone();
         transport.shutdown().await

--- a/src/mcp_client/transport.rs
+++ b/src/mcp_client/transport.rs
@@ -125,10 +125,10 @@ impl McpTransport for HttpTransport {
             .context("Failed to send request to MCP server")?;
 
         // Capture session id from response header.
-        if let Some(sid) = resp.headers().get("mcp-session-id") {
-            if let Ok(s) = sid.to_str() {
-                *self.session_id.lock().await = Some(s.to_string());
-            }
+        if let Some(sid) = resp.headers().get("mcp-session-id")
+            && let Ok(s) = sid.to_str()
+        {
+            *self.session_id.lock().await = Some(s.to_string());
         }
 
         let content_type = resp

--- a/src/memory_compaction.rs
+++ b/src/memory_compaction.rs
@@ -26,21 +26,20 @@ Output ONLY the new contents of MEMORY.md, with no extra commentary, no code fen
 /// if the file doesn't exist or is effectively empty. Errors are logged
 /// but never returned.
 pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path, namespace: &str) {
-    let path = workspace_dir.join("memory").join(namespace).join("MEMORY.md");
+    let path = workspace_dir
+        .join("memory")
+        .join(namespace)
+        .join("MEMORY.md");
     let original = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(_) => {
-            info!(
-                "memory_compaction: no MEMORY.md found in namespace '{namespace}', skipping"
-            );
+            info!("memory_compaction: no MEMORY.md found in namespace '{namespace}', skipping");
             return;
         }
     };
 
     if original.trim().is_empty() {
-        info!(
-            "memory_compaction: MEMORY.md in namespace '{namespace}' is empty, skipping"
-        );
+        info!("memory_compaction: MEMORY.md in namespace '{namespace}' is empty, skipping");
         return;
     }
 
@@ -58,9 +57,7 @@ pub async fn compact_memory(provider: &dyn Provider, workspace_dir: &Path, names
     let new_content = match response.text {
         Some(t) if !t.trim().is_empty() => t,
         _ => {
-            warn!(
-                "memory_compaction: empty response for '{namespace}', leaving file unchanged"
-            );
+            warn!("memory_compaction: empty response for '{namespace}', leaving file unchanged");
             return;
         }
     };

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -68,12 +68,7 @@ pub fn log_rel_path(namespace: &str, kind: LogKind, stem: &str) -> PathBuf {
 }
 
 /// Absolute path to the log file under `workspace_dir`.
-pub fn log_abs_path(
-    workspace_dir: &Path,
-    namespace: &str,
-    kind: LogKind,
-    stem: &str,
-) -> PathBuf {
+pub fn log_abs_path(workspace_dir: &Path, namespace: &str, kind: LogKind, stem: &str) -> PathBuf {
     workspace_dir.join(log_rel_path(namespace, kind, stem))
 }
 
@@ -249,6 +244,7 @@ where
 ///
 /// Writes a YAML frontmatter `digest:` array (top-10 importance-ordered
 /// bullets) alongside the Markdown summary body.
+#[allow(clippy::too_many_arguments)]
 pub async fn generate_daily_log<F>(
     session_store: &SessionStore,
     provider: &dyn Provider,
@@ -492,6 +488,7 @@ pub fn read_digest_top_n(
 ///
 /// `input_body` is the concatenated source material (transcript, daily
 /// bodies, etc.) passed as the user message.
+#[allow(clippy::too_many_arguments)]
 async fn write_log_with_digest(
     provider: &dyn Provider,
     ws_state: &Arc<Mutex<WorkspaceState>>,
@@ -988,7 +985,13 @@ pub fn pending_iso_weeks(
     weeks
         .into_iter()
         .filter(|(y, w)| {
-            !log_abs_path(workspace_dir, namespace, LogKind::Weekly, &weekly_stem(*y, *w)).exists()
+            !log_abs_path(
+                workspace_dir,
+                namespace,
+                LogKind::Weekly,
+                &weekly_stem(*y, *w),
+            )
+            .exists()
         })
         .collect()
 }
@@ -996,11 +999,7 @@ pub fn pending_iso_weeks(
 /// Returns calendar (year, month) pairs that have at least one daily log on
 /// disk but no monthly log file yet, excluding `today`'s own month. Sorted
 /// ascending.
-pub fn pending_months(
-    workspace_dir: &Path,
-    namespace: &str,
-    today: NaiveDate,
-) -> Vec<(i32, u32)> {
+pub fn pending_months(workspace_dir: &Path, namespace: &str, today: NaiveDate) -> Vec<(i32, u32)> {
     use std::collections::BTreeSet;
     let current_key = (today.year(), today.month());
     let mut months: BTreeSet<(i32, u32)> = BTreeSet::new();
@@ -1014,8 +1013,13 @@ pub fn pending_months(
     months
         .into_iter()
         .filter(|(y, m)| {
-            !log_abs_path(workspace_dir, namespace, LogKind::Monthly, &monthly_stem(*y, *m))
-                .exists()
+            !log_abs_path(
+                workspace_dir,
+                namespace,
+                LogKind::Monthly,
+                &monthly_stem(*y, *m),
+            )
+            .exists()
         })
         .collect()
 }
@@ -1293,7 +1297,10 @@ mod tests {
         assert_eq!(rel, PathBuf::from("memory/default/monthly/2026-04.md"));
         // Non-default namespace.
         let abs = log_abs_path(Path::new("/ws"), "user_nsfw", LogKind::Daily, "2026-05-05");
-        assert_eq!(abs, PathBuf::from("/ws/memory/user_nsfw/daily/2026-05-05.md"));
+        assert_eq!(
+            abs,
+            PathBuf::from("/ws/memory/user_nsfw/daily/2026-05-05.md")
+        );
     }
 
     #[test]
@@ -1550,9 +1557,11 @@ mod tests {
         let td = make_tempdir();
         let root = td.path();
         for d in [
-            "2026-02-01", "2026-02-15", // Feb
-            "2026-03-05",               // Mar
-            "2026-04-02", "2026-04-16", // Apr (current)
+            "2026-02-01",
+            "2026-02-15", // Feb
+            "2026-03-05", // Mar
+            "2026-04-02",
+            "2026-04-16", // Apr (current)
         ] {
             write_stub(
                 &root.join("memory/default/daily").join(format!("{d}.md")),
@@ -1575,7 +1584,9 @@ mod tests {
         let root = td.path();
         for stem in ["2024-06", "2024-12", "2025-01", "2026-03"] {
             write_stub(
-                &root.join("memory/default/monthly").join(format!("{stem}.md")),
+                &root
+                    .join("memory/default/monthly")
+                    .join(format!("{stem}.md")),
                 "# body\n",
             );
         }

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -253,13 +253,13 @@ fn chat_message_to_api(msg: &ChatMessage) -> ApiMessage {
     };
 
     // If there's exactly one Text part and no other parts, use the wire shorthand.
-    if msg.parts.len() == 1 {
-        if let ContentPart::Text(text) = &msg.parts[0] {
-            return ApiMessage {
-                role: role.to_string(),
-                content: ApiContent::Text(text.clone()),
-            };
-        }
+    if msg.parts.len() == 1
+        && let ContentPart::Text(text) = &msg.parts[0]
+    {
+        return ApiMessage {
+            role: role.to_string(),
+            content: ApiContent::Text(text.clone()),
+        };
     }
 
     let parts: Vec<ApiPart> = msg

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -29,14 +29,14 @@ impl FallbackProvider {
 
 /// Heuristic check for a refusal response.
 ///
-/// Order of signals:
-/// 1. Provider-reported `stop_reason` of `"refusal"` (Anthropic) or
-///    `"content_filter"` (OpenAI-compatible). These are the strongest
-///    signals and match no legitimate response.
-/// 2. Short text-only response (no tool calls, capped length) whose
-///    leading sentence matches an apology pattern. The leading-pattern
-///    + length + no-tools combination keeps false positives down on
-///    legitimate "I can't find that file" style answers.
+/// First, a provider-reported `stop_reason` of `"refusal"` (Anthropic)
+/// or `"content_filter"` (OpenAI-compatible) is the strongest signal
+/// and matches no legitimate response.
+///
+/// Otherwise, fall back to a short text-only response (no tool calls,
+/// capped length) whose leading sentence matches an apology pattern.
+/// The leading-pattern + length + no-tools combination keeps false
+/// positives down on legitimate "I can't find that file" style answers.
 pub fn is_refusal(resp: &ChatResponse) -> bool {
     if matches!(
         resp.stop_reason.as_deref(),
@@ -213,8 +213,8 @@ mod tests {
 
     #[test]
     fn long_response_is_not_a_refusal_even_if_apology_appears() {
-        let mut text = "I'm unable to immediately answer, but here's a detailed walkthrough: "
-            .to_string();
+        let mut text =
+            "I'm unable to immediately answer, but here's a detailed walkthrough: ".to_string();
         text.push_str(&"x".repeat(800));
         let resp = ChatResponse {
             text: Some(text),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -178,6 +178,7 @@ pub struct ChatResponse {
 }
 
 impl ChatResponse {
+    #[allow(dead_code)]
     pub fn text_only(text: String) -> Self {
         Self {
             text: Some(text),
@@ -190,6 +191,7 @@ impl ChatResponse {
         !self.tool_calls.is_empty()
     }
 
+    #[allow(dead_code)]
     pub fn text_or_empty(&self) -> &str {
         self.text.as_deref().unwrap_or("")
     }

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -126,12 +126,8 @@ enum ApiContent {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ApiPart {
-    Text {
-        text: String,
-    },
-    ImageUrl {
-        image_url: ApiImageUrl,
-    },
+    Text { text: String },
+    ImageUrl { image_url: ApiImageUrl },
 }
 
 #[derive(Debug, Serialize)]
@@ -437,16 +433,16 @@ impl Provider for OpenAICompatibleProvider {
                         if let Some(deltas) = choice.delta.tool_calls {
                             for d in deltas {
                                 let entry = tool_acc.entry(d.index).or_default();
-                                if let Some(id) = d.id {
-                                    if !id.is_empty() {
-                                        entry.id = id;
-                                    }
+                                if let Some(id) = d.id
+                                    && !id.is_empty()
+                                {
+                                    entry.id = id;
                                 }
                                 if let Some(f) = d.function {
-                                    if let Some(n) = f.name {
-                                        if !n.is_empty() {
-                                            entry.name = n;
-                                        }
+                                    if let Some(n) = f.name
+                                        && !n.is_empty()
+                                    {
+                                        entry.name = n;
                                     }
                                     if let Some(a) = f.arguments {
                                         entry.arguments.push_str(&a);
@@ -556,8 +552,8 @@ mod tests {
         assert_eq!(calls[0]["id"], "call_1");
         assert_eq!(calls[0]["function"]["name"], "get_weather");
         // arguments is a JSON-encoded string per OpenAI spec.
-        let args: Value = serde_json::from_str(calls[0]["function"]["arguments"].as_str().unwrap())
-            .unwrap();
+        let args: Value =
+            serde_json::from_str(calls[0]["function"]["arguments"].as_str().unwrap()).unwrap();
         assert_eq!(args, json!({"city": "Tokyo"}));
     }
 
@@ -610,5 +606,4 @@ mod tests {
         assert!(json.get("content").is_none() || json["content"].is_null());
         assert!(json["tool_calls"].is_array());
     }
-
 }

--- a/src/provider/registry.rs
+++ b/src/provider/registry.rs
@@ -5,14 +5,12 @@
 //! provider is always present under the name [`ANTHROPIC_PROVIDER_NAME`];
 //! additional providers come from `[providers.<name>]` config entries.
 
-use crate::config::{
-    ANTHROPIC_PROVIDER_NAME, BACKGROUND_PROFILE_NAME, Config, ProviderConfig,
-};
+use crate::config::{ANTHROPIC_PROVIDER_NAME, BACKGROUND_PROFILE_NAME, Config, ProviderConfig};
 use crate::provider::Provider;
 use crate::provider::anthropic::AnthropicProvider;
 use crate::provider::fallback::FallbackProvider;
 use crate::provider::openai_compatible::OpenAICompatibleProvider;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -31,7 +29,10 @@ impl ProviderRegistry {
     pub fn from_config(config: &Config) -> Result<Self> {
         let errors = config.validate_profiles();
         if !errors.is_empty() {
-            anyhow::bail!("invalid profile configuration:\n  - {}", errors.join("\n  - "));
+            anyhow::bail!(
+                "invalid profile configuration:\n  - {}",
+                errors.join("\n  - ")
+            );
         }
 
         let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
@@ -193,7 +194,8 @@ api_key = "test"
 provider = "ghost"
 "#,
         );
-        let err = ProviderRegistry::from_config(&cfg).err()
+        let err = ProviderRegistry::from_config(&cfg)
+            .err()
             .expect("expected an error");
         assert!(format!("{err:#}").contains("ghost"));
     }
@@ -211,7 +213,8 @@ base_url = "http://x/v1"
 model = "y"
 "#,
         );
-        let err = ProviderRegistry::from_config(&cfg).err()
+        let err = ProviderRegistry::from_config(&cfg)
+            .err()
             .expect("expected an error");
         assert!(format!("{err:#}").contains("reserved"));
     }

--- a/src/serve/a2a.rs
+++ b/src/serve/a2a.rs
@@ -71,8 +71,7 @@ pub async fn handle_agent_card(State(state): State<Arc<ServeState>>) -> impl Int
         .clone()
         .unwrap_or_else(|| "sapphire-agent".to_string());
     let description = cfg.agent_description.clone().unwrap_or_else(|| {
-        "Personal partner AI agent with persistent character, memory, and tools."
-            .to_string()
+        "Personal partner AI agent with persistent character, memory, and tools.".to_string()
     });
     let url = cfg.public_url.clone().unwrap_or_default();
 
@@ -145,11 +144,7 @@ pub async fn handle_a2a_post(
     body: axum::body::Bytes,
 ) -> axum::response::Response {
     // 0. Feature gate
-    let enabled = state
-        .config
-        .a2a
-        .as_ref()
-        .is_some_and(|c| c.enabled);
+    let enabled = state.config.a2a.as_ref().is_some_and(|c| c.enabled);
     if !enabled {
         return (StatusCode::NOT_FOUND, "A2A disabled").into_response();
     }
@@ -295,7 +290,10 @@ async fn handle_send_message(
     let (state_enum, reply_text) = match outcome.text {
         Some(t) if !t.is_empty() => (TaskState::Completed, t),
         Some(_) => (TaskState::Failed, "(empty response)".to_string()),
-        None => (TaskState::Failed, "agent failed to generate a reply".to_string()),
+        None => (
+            TaskState::Failed,
+            "agent failed to generate a reply".to_string(),
+        ),
     };
 
     let reply_message = Message {
@@ -349,7 +347,9 @@ async fn handle_send_message(
 fn extract_bearer(headers: &HeaderMap) -> Option<String> {
     let value = headers.get(axum::http::header::AUTHORIZATION)?;
     let s = value.to_str().ok()?;
-    let token = s.strip_prefix("Bearer ").or_else(|| s.strip_prefix("bearer "))?;
+    let token = s
+        .strip_prefix("Bearer ")
+        .or_else(|| s.strip_prefix("bearer "))?;
     let trimmed = token.trim();
     if trimmed.is_empty() {
         None

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -50,9 +50,8 @@ const MAX_TOOL_ROUNDS: usize = 10;
 /// which room_profile it's bound to when it subscribes, and we keep
 /// that around as the reverse index so heartbeat tasks don't have to
 /// duplicate the value.
-pub type VoiceSubscribers = tokio::sync::Mutex<
-    HashMap<String, (String, mpsc::Sender<crate::voice::VoicePushItem>)>,
->;
+pub type VoiceSubscribers =
+    tokio::sync::Mutex<HashMap<String, (String, mpsc::Sender<crate::voice::VoicePushItem>)>>;
 
 pub struct ServeState {
     pub(crate) config: Config,
@@ -190,11 +189,7 @@ fn error_event(id: &Value, code: i32, message: &str) -> Event {
 // Router entry point
 // ---------------------------------------------------------------------------
 
-pub async fn run(
-    addr: String,
-    state: Arc<ServeState>,
-) -> anyhow::Result<()> {
-
+pub async fn run(addr: String, state: Arc<ServeState>) -> anyhow::Result<()> {
     // Routes are intentionally separated so future protocol endpoints
     // (`/mcp` for the MCP server in #79/#80) can be mounted alongside
     // `/rpc` without colliding with the control API methods (`chat`,
@@ -255,9 +250,10 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
                 {
                     warn!("Failed to persist shutdown summary for {session_id}: {e}");
                 }
-                if let Err(e) = state
-                    .api_session_store
-                    .append_intraday_digest(&session_id, &summary, None)
+                if let Err(e) =
+                    state
+                        .api_session_store
+                        .append_intraday_digest(&session_id, &summary, None)
                 {
                     warn!("Failed to persist shutdown intra-day digest for {session_id}: {e}");
                 }
@@ -290,9 +286,7 @@ async fn rpc_post(
         "list_sessions" => handle_list_sessions(state, req_id).await,
         "get_session" => handle_get_session(state, req_id, session_id).await,
         "voice/config" => handle_voice_config(state, req_id, req.params).await,
-        "voice/pipeline_run" => {
-            handle_voice_pipeline_run(state, req_id, req.params).await
-        }
+        "voice/pipeline_run" => handle_voice_pipeline_run(state, req_id, req.params).await,
         "voice/subscribe" => handle_voice_subscribe(state, req_id, req.params).await,
         _ => {
             let body = error_response(req_id, -32601, "Method not found");
@@ -330,12 +324,11 @@ async fn handle_initialize(
         .as_ref()
         .and_then(|p| p["room_profile"].as_str())
         .map(|s| s.to_string());
-    if let Some(name) = &requested_room_profile {
-        if state.config.room_profile(name).is_none() {
-            let body =
-                error_response(req_id, -32602, &format!("Unknown room_profile '{name}'"));
-            return body.into_response();
-        }
+    if let Some(name) = &requested_room_profile
+        && state.config.room_profile(name).is_none()
+    {
+        let body = error_response(req_id, -32602, &format!("Unknown room_profile '{name}'"));
+        return body.into_response();
     }
 
     // Resolve to an internal UUID session_id.
@@ -651,9 +644,7 @@ async fn handle_voice_config(
                 });
             }
             Err(e) => {
-                error!(
-                    "voice/config: failed to read openWakeWord model '{expanded}': {e}"
-                );
+                error!("voice/config: failed to read openWakeWord model '{expanded}': {e}");
                 let body = error_response(
                     req_id,
                     -32603,
@@ -737,7 +728,10 @@ async fn handle_voice_pipeline_run(
     // pipeline_run so satellites can update their description without a
     // separate handshake. Treated as room metadata for the session.
     if let Some(device) = params.get("device") {
-        let device_name = device.get("name").and_then(|v| v.as_str()).map(str::to_string);
+        let device_name = device
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
         let device_description = device
             .get("description")
             .and_then(|v| v.as_str())
@@ -812,9 +806,7 @@ async fn handle_voice_subscribe(
         let mut subs = state.voice_subscribers.lock().await;
         subs.insert(device_id.clone(), (room_profile.clone(), push_tx));
     }
-    info!(
-        "voice/subscribe: registered (device={device_id}, room_profile={room_profile})"
-    );
+    info!("voice/subscribe: registered (device={device_id}, room_profile={room_profile})");
 
     let (sse_tx, sse_rx) = mpsc::channel::<Result<Event, Infallible>>(32);
     let cleanup_state = Arc::clone(&state);
@@ -830,12 +822,9 @@ async fn handle_voice_subscribe(
             .get(&cleanup_device)
             .map(|(_, tx)| tx.is_closed())
             .unwrap_or(false)
+            && let Some((rp, _)) = subs.remove(&cleanup_device)
         {
-            if let Some((rp, _)) = subs.remove(&cleanup_device) {
-                info!(
-                    "voice/subscribe: unregistered (device={cleanup_device}, room_profile={rp})"
-                );
-            }
+            info!("voice/subscribe: unregistered (device={cleanup_device}, room_profile={rp})");
         }
     });
 
@@ -874,10 +863,9 @@ async fn translate_voice_pushes(
                     json!({"kind": "audio_chunk", "data": b64}),
                 )
             }
-            crate::voice::VoicePushItem::Done => notification_event(
-                "notifications/voice_push",
-                json!({"kind": "push_done"}),
-            ),
+            crate::voice::VoicePushItem::Done => {
+                notification_event("notifications/voice_push", json!({"kind": "push_done"}))
+            }
             crate::voice::VoicePushItem::Error(message) => notification_event(
                 "notifications/voice_push",
                 json!({"kind": "error", "message": message}),
@@ -958,10 +946,7 @@ async fn run_voice_turn(
             send(error_event(
                 &req_id,
                 -32603,
-                &format!(
-                    "stt_provider '{}' not instantiated",
-                    pipeline.stt_provider
-                ),
+                &format!("stt_provider '{}' not instantiated", pipeline.stt_provider),
             ))
             .await;
             return;
@@ -1104,10 +1089,7 @@ async fn run_voice_turn_from_text_sse(
             send(error_event(
                 &req_id,
                 -32603,
-                &format!(
-                    "tts_provider '{}' not instantiated",
-                    pipeline.tts_provider
-                ),
+                &format!("tts_provider '{}' not instantiated", pipeline.tts_provider),
             ))
             .await;
             return;
@@ -1163,10 +1145,7 @@ async fn run_voice_turn_from_text_sse(
         tokio::spawn(async move { tts.synthesize_stream(&reply_for_tts, pcm_tx).await });
     let mut chunks_emitted = 0usize;
     while let Some(chunk) = pcm_rx.recv().await {
-        let bytes: Vec<u8> = chunk
-            .iter()
-            .flat_map(|s| s.to_le_bytes())
-            .collect();
+        let bytes: Vec<u8> = chunk.iter().flat_map(|s| s.to_le_bytes()).collect();
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
         send(notification_event(
             "notifications/progress",
@@ -1242,10 +1221,10 @@ async fn run_voice_turn_from_text_sse(
         let reply = reply_text.clone();
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
-            if let Some(title) = generate_session_title(&*p, &user_text, &reply).await {
-                if let Err(e) = state2.api_session_store.set_title(&sid, &title) {
-                    warn!("Failed to store session title: {e}");
-                }
+            if let Some(title) = generate_session_title(&*p, &user_text, &reply).await
+                && let Err(e) = state2.api_session_store.set_title(&sid, &title)
+            {
+                warn!("Failed to store session title: {e}");
             }
         });
     }
@@ -1332,9 +1311,7 @@ pub(crate) async fn push_voice_text_to_subscriber(
     // LLM turn (no SSE response channel — discard tool_start/tool_end
     // notifications by draining the sink in a background task).
     let (sink_tx, mut sink_rx) = mpsc::channel::<Result<Event, Infallible>>(32);
-    let drain_handle = tokio::spawn(async move {
-        while sink_rx.recv().await.is_some() {}
-    });
+    let drain_handle = tokio::spawn(async move { while sink_rx.recv().await.is_some() {} });
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
@@ -1356,7 +1333,9 @@ pub(crate) async fn push_voice_text_to_subscriber(
         }
     };
     let _ = push_tx
-        .send(crate::voice::VoicePushItem::AssistantText(reply_text.clone()))
+        .send(crate::voice::VoicePushItem::AssistantText(
+            reply_text.clone(),
+        ))
         .await;
 
     // TTS: stream chunks to the subscriber as soon as they're synthesised.
@@ -1379,10 +1358,7 @@ pub(crate) async fn push_voice_text_to_subscriber(
     }
     match synth_handle.await {
         Ok(Ok(())) if chunks_emitted == 0 => {
-            let msg = format!(
-                "TTS provider '{}' produced no audio",
-                pipeline.tts_provider
-            );
+            let msg = format!("TTS provider '{}' produced no audio", pipeline.tts_provider);
             warn!("{msg}");
             let _ = push_tx
                 .send(crate::voice::VoicePushItem::Error(msg.clone()))
@@ -1539,14 +1515,7 @@ async fn run_llm_turn(
         }
 
         // Check if context compression is needed
-        match maybe_compress(
-            &*provider,
-            system.as_deref(),
-            &history,
-            &compression_config,
-        )
-        .await
-        {
+        match maybe_compress(&*provider, system.as_deref(), &history, compression_config).await {
             Ok(Some(result)) => {
                 history = result.compressed;
                 if let Err(e) = state
@@ -1688,20 +1657,20 @@ async fn run_turn(
     }
 
     // Generate and store session title after the first successful turn.
-    if outcome.was_first_turn {
-        if let Some(text) = outcome.text {
-            let state2 = Arc::clone(&state);
-            let sid = session_id.clone();
-            let user_msg = user_message.clone();
-            tokio::spawn(async move {
-                let p = state2.provider_for_session(&sid).await;
-                if let Some(title) = generate_session_title(&*p, &user_msg, &text).await {
-                    if let Err(e) = state2.api_session_store.set_title(&sid, &title) {
-                        warn!("Failed to store session title: {e}");
-                    }
-                }
-            });
-        }
+    if outcome.was_first_turn
+        && let Some(text) = outcome.text
+    {
+        let state2 = Arc::clone(&state);
+        let sid = session_id.clone();
+        let user_msg = user_message.clone();
+        tokio::spawn(async move {
+            let p = state2.provider_for_session(&sid).await;
+            if let Some(title) = generate_session_title(&*p, &user_msg, &text).await
+                && let Err(e) = state2.api_session_store.set_title(&sid, &title)
+            {
+                warn!("Failed to store session title: {e}");
+            }
+        });
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -155,6 +155,7 @@ pub struct SessionStore {
 }
 
 impl SessionStore {
+    #[allow(dead_code)]
     pub fn new(base_dir: PathBuf, kind: &'static str) -> Self {
         Self {
             base_dir,
@@ -244,6 +245,7 @@ impl SessionStore {
     }
 
     /// Notify sapphire-workspace that a session file was deleted.
+    #[allow(dead_code)]
     fn notify_deleted(&self, abs_path: &Path) {
         let Some(state) = &self.ws_state else { return };
         let guard = match state.lock() {
@@ -265,6 +267,7 @@ impl SessionStore {
     }
 
     /// Delete a session file (used when an empty session is discarded).
+    #[allow(dead_code)]
     pub fn delete_session(&self, session_id: &str) -> anyhow::Result<()> {
         if let Some(path) = self.resolve_path(session_id) {
             if path.exists() {
@@ -429,6 +432,7 @@ impl SessionStore {
     /// - `fallback_messages`: raw `ChatMessage` list for active sessions that
     ///   have NO summary yet — Agent bootstrap uses these to synthesize a
     ///   summary on startup (e.g. after a crash that skipped graceful shutdown)
+    #[allow(clippy::type_complexity)]
     pub fn load_all(
         &self,
     ) -> (
@@ -584,10 +588,10 @@ impl SessionStore {
     /// Returns the internal UUID `session_id` if found.
     pub fn find_by_public_id(&self, public_id: &str) -> Option<String> {
         for path in collect_session_files(&self.base_dir, self.kind) {
-            if let Some((meta, _, _, _)) = load_session_file(&path) {
-                if meta.public_id.as_deref() == Some(public_id) {
-                    return Some(meta.session_id);
-                }
+            if let Some((meta, _, _, _)) = load_session_file(&path)
+                && meta.public_id.as_deref() == Some(public_id)
+            {
+                return Some(meta.session_id);
             }
         }
         None
@@ -654,11 +658,7 @@ impl SessionStore {
     /// Like `all_session_dates`, but only counts sessions whose `meta`
     /// satisfies `predicate`. Used so per-namespace daily-log catch-up
     /// only enumerates dates that have at least one in-namespace session.
-    pub fn all_session_dates_filtered<F>(
-        &self,
-        boundary_hour: u8,
-        predicate: F,
-    ) -> Vec<NaiveDate>
+    pub fn all_session_dates_filtered<F>(&self, boundary_hour: u8, predicate: F) -> Vec<NaiveDate>
     where
         F: Fn(&SessionMeta) -> bool,
     {
@@ -684,6 +684,7 @@ impl SessionStore {
 
     /// Return all local dates for which at least one session message exists.
     /// Used by daily_log to find dates that need a log generated.
+    #[allow(dead_code)]
     pub fn all_session_dates(&self, boundary_hour: u8) -> Vec<NaiveDate> {
         let mut dates = std::collections::HashSet::new();
 
@@ -798,7 +799,7 @@ fn load_session_file(
     let mut is_closed = false;
     let mut latest_summary: Option<SummaryLine> = None;
 
-    for raw in lines.flatten() {
+    for raw in lines.map_while(Result::ok) {
         let raw = raw.trim().to_string();
         if raw.is_empty() {
             continue;
@@ -853,7 +854,7 @@ fn load_meta_and_latest_intraday_digest(
     let meta = meta_line.meta;
 
     let mut latest: Option<IntradayDigestLine> = None;
-    for raw in lines.flatten() {
+    for raw in lines.map_while(Result::ok) {
         let raw = raw.trim();
         if raw.is_empty() {
             continue;
@@ -862,10 +863,10 @@ fn load_meta_and_latest_intraday_digest(
             Ok(v) => v,
             Err(_) => continue,
         };
-        if value.get("digest_at").is_some() {
-            if let Ok(d) = serde_json::from_value::<IntradayDigestLine>(value) {
-                latest = Some(d);
-            }
+        if value.get("digest_at").is_some()
+            && let Ok(d) = serde_json::from_value::<IntradayDigestLine>(value)
+        {
+            latest = Some(d);
         }
     }
     Some((meta, latest))

--- a/src/tools/workspace_tools.rs
+++ b/src/tools/workspace_tools.rs
@@ -113,9 +113,7 @@ fn parse_memory_file(raw: &str) -> (MemoryMeta, String) {
     match crate::frontmatter::split(raw) {
         Some((fm, body)) => {
             let meta: MemoryMeta = serde_yaml::from_str(fm).unwrap_or_default();
-            let body = body
-                .trim_start_matches(|c: char| c == '\n' || c == '\r')
-                .to_string();
+            let body = body.trim_start_matches(['\n', '\r']).to_string();
             (meta, body)
         }
         None => (MemoryMeta::default(), raw.to_string()),
@@ -125,7 +123,7 @@ fn parse_memory_file(raw: &str) -> (MemoryMeta, String) {
 /// Serialize `(meta, body)` back into a Markdown file with YAML frontmatter.
 fn serialize_memory_file(meta: &MemoryMeta, body: &str) -> Result<String> {
     let fm = serde_yaml::to_string(meta).context("failed to serialize memory frontmatter")?;
-    let body_trimmed = body.trim_start_matches(|c: char| c == '\n' || c == '\r');
+    let body_trimmed = body.trim_start_matches(['\n', '\r']);
     Ok(format!("---\n{fm}---\n\n{body_trimmed}"))
 }
 
@@ -321,7 +319,7 @@ impl Tool for MemoryAppendTool {
             if meta.created_at.is_none() {
                 meta.created_at = Some(now);
             }
-            let trimmed = old_body.trim_end_matches(|c: char| c == '\n' || c == '\r');
+            let trimmed = old_body.trim_end_matches(['\n', '\r']);
             let new_body = if trimmed.is_empty() {
                 content.to_string()
             } else {
@@ -500,23 +498,23 @@ impl Tool for WorkspaceSearchTool {
 
         let state = lock(&self.state);
 
-        if mode == "semantic" {
-            if let Some(embedder) = state.embedder() {
-                let vq = VectorQuery::new(query, embedder).limit(limit);
-                let results = state
-                    .retrieve_db()
-                    .search_similar(&vq)
-                    .context("Vector similarity search failed")?;
+        if mode == "semantic"
+            && let Some(embedder) = state.embedder()
+        {
+            let vq = VectorQuery::new(query, embedder).limit(limit);
+            let results = state
+                .retrieve_db()
+                .search_similar(&vq)
+                .context("Vector similarity search failed")?;
 
-                if results.is_empty() {
-                    return Ok("No results found.".to_string());
-                }
-                let lines: Vec<String> = results
-                    .iter()
-                    .map(|r| format!("- {} [score: {:.4}]", r.path, r.score))
-                    .collect();
-                return Ok(format!("[semantic]\n{}", lines.join("\n")));
+            if results.is_empty() {
+                return Ok("No results found.".to_string());
             }
+            let lines: Vec<String> = results
+                .iter()
+                .map(|r| format!("- {} [score: {:.4}]", r.path, r.score))
+                .collect();
+            return Ok(format!("[semantic]\n{}", lines.join("\n")));
         }
 
         // FTS (default or fallback)

--- a/src/voice/providers/mock.rs
+++ b/src/voice/providers/mock.rs
@@ -80,8 +80,7 @@ impl TtsProvider for MockTts {
         // Generate a sine wave at `frequency_hz` lasting `duration_ms`.
         // Chunked at ~20ms (320 samples @ 16kHz) to exercise the
         // streaming code path.
-        let total_samples =
-            (PIPELINE_SAMPLE_RATE as u64 * self.duration_ms as u64 / 1000) as usize;
+        let total_samples = (PIPELINE_SAMPLE_RATE as u64 * self.duration_ms as u64 / 1000) as usize;
         let chunk_size = PIPELINE_SAMPLE_RATE as usize / 50; // 20ms
         let two_pi = std::f64::consts::TAU;
         let freq = self.frequency_hz as f64;

--- a/src/voice/providers/mod.rs
+++ b/src/voice/providers/mod.rs
@@ -10,11 +10,11 @@
 mod mock;
 mod openai_tts;
 #[cfg(feature = "voice-sherpa")]
+pub(crate) mod sherpa_download;
+#[cfg(feature = "voice-sherpa")]
 mod sherpa_stt;
 #[cfg(feature = "voice-sherpa")]
 mod sherpa_tts;
-#[cfg(feature = "voice-sherpa")]
-pub(crate) mod sherpa_download;
 mod wav_stream;
 
 pub(super) use mock::{MockStt, MockTts};

--- a/src/voice/providers/openai_tts.rs
+++ b/src/voice/providers/openai_tts.rs
@@ -47,12 +47,8 @@ impl OpenAiTts {
         let auth_header = match api_key_env {
             Some(var) => match std::env::var(var) {
                 Ok(k) if !k.is_empty() => Some(format!("Bearer {k}")),
-                Ok(_) => anyhow::bail!(
-                    "tts_provider '{name}': env var '{var}' is set but empty"
-                ),
-                Err(_) => anyhow::bail!(
-                    "tts_provider '{name}': env var '{var}' is not set"
-                ),
+                Ok(_) => anyhow::bail!("tts_provider '{name}': env var '{var}' is set but empty"),
+                Err(_) => anyhow::bail!("tts_provider '{name}': env var '{var}' is not set"),
             },
             None => None,
         };

--- a/src/voice/providers/sherpa_download.rs
+++ b/src/voice/providers/sherpa_download.rs
@@ -35,6 +35,7 @@ pub fn cache_dir() -> PathBuf {
 /// Categories on the sherpa-onnx releases page. Each ASR/TTS/KWS/VAD
 /// bundle is published under exactly one of these tags.
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub enum BundleCategory {
     Asr,
     Tts,
@@ -73,9 +74,7 @@ pub fn ensure_bundle(
         anyhow::anyhow!("either `model_dir` or `model` (bundle name) must be set")
     })?;
     if name.contains('/') || name.contains('~') || name.starts_with('.') {
-        anyhow::bail!(
-            "`model` looks like a path ('{name}'); use `model_dir` for explicit paths"
-        );
+        anyhow::bail!("`model` looks like a path ('{name}'); use `model_dir` for explicit paths");
     }
     let dest = cache_dir().join(name);
     if dest.exists() {
@@ -85,11 +84,7 @@ pub fn ensure_bundle(
     Ok(dest)
 }
 
-fn download_and_extract(
-    bundle: &str,
-    category: BundleCategory,
-    dest: &Path,
-) -> anyhow::Result<()> {
+fn download_and_extract(bundle: &str, category: BundleCategory, dest: &Path) -> anyhow::Result<()> {
     let url = format!(
         "https://github.com/k2-fsa/sherpa-onnx/releases/download/{}/{}.tar.bz2",
         category.tag(),

--- a/src/voice/providers/sherpa_stt.rs
+++ b/src/voice/providers/sherpa_stt.rs
@@ -58,23 +58,14 @@ impl SherpaOnnxStt {
     }
 }
 
-fn build_recognizer(
-    dir: &Path,
-    cfg: &SherpaSttConfig,
-) -> anyhow::Result<OfflineRecognizer> {
+fn build_recognizer(dir: &Path, cfg: &SherpaSttConfig) -> anyhow::Result<OfflineRecognizer> {
     let mut rec_cfg = OfflineRecognizerConfig::default();
     rec_cfg.model_config.num_threads = cfg.num_threads;
     rec_cfg.model_config.provider = Some(cfg.provider.clone());
 
     match cfg.kind {
         SherpaSttKind::SenseVoice => {
-            let model = pick_file(
-                dir,
-                &[
-                    "model.int8.onnx",
-                    "model.onnx",
-                ],
-            )?;
+            let model = pick_file(dir, &["model.int8.onnx", "model.onnx"])?;
             let tokens = pick_file(dir, &["tokens.txt"])?;
             rec_cfg.model_config.sense_voice = OfflineSenseVoiceModelConfig {
                 model: Some(path_string(&model)),
@@ -165,5 +156,5 @@ impl SttProvider for SherpaOnnxStt {
 }
 
 // Re-export the cache_dir helper for test diagnostics elsewhere.
-#[allow(dead_code)]
+#[allow(unused_imports)]
 pub(crate) use sherpa_download::cache_dir;

--- a/src/voice/providers/sherpa_tts.rs
+++ b/src/voice/providers/sherpa_tts.rs
@@ -42,8 +42,8 @@ impl SherpaOnnxTts {
             cfg.model.as_deref(),
             BundleCategory::Tts,
         )?;
-        let tts = build_tts(&dir, &cfg)
-            .map_err(|e| anyhow::anyhow!("tts_provider '{name}': {e:#}"))?;
+        let tts =
+            build_tts(&dir, &cfg).map_err(|e| anyhow::anyhow!("tts_provider '{name}': {e:#}"))?;
         let native_rate = tts.sample_rate() as u32;
         Ok(Self {
             name,
@@ -85,10 +85,9 @@ fn build_tts(dir: &Path, cfg: &SherpaTtsConfig) -> anyhow::Result<OfflineTts> {
             // Matcha bundles ship the acoustic model under a name like
             // `model-steps-3.onnx`; the vocoder (often `vocos-*.onnx`)
             // sits alongside or in the cache root.
-            let acoustic = find_by_substring(dir, "model-steps")
-                .or_else(|_| pick_onnx(dir))?;
-            let vocoder = find_by_substring(dir, "vocos")
-                .or_else(|_| find_by_substring(dir, "vocoder"))?;
+            let acoustic = find_by_substring(dir, "model-steps").or_else(|_| pick_onnx(dir))?;
+            let vocoder =
+                find_by_substring(dir, "vocos").or_else(|_| find_by_substring(dir, "vocoder"))?;
             let tokens = pick_file(dir, &["tokens.txt"])?;
             let lexicon = optional(dir, "lexicon.txt");
             let dict_dir = optional_dir(dir, "dict");

--- a/src/voice/providers/wav_stream.rs
+++ b/src/voice/providers/wav_stream.rs
@@ -18,14 +18,10 @@ use crate::voice::PIPELINE_SAMPLE_RATE;
 /// Errors only on WAV parse / sample-read failure. A `pcm_tx`
 /// receiver drop is treated as caller cancellation and short-circuits
 /// without returning an error.
-pub async fn stream_wav(
-    bytes: Vec<u8>,
-    pcm_tx: mpsc::Sender<Vec<i16>>,
-) -> anyhow::Result<()> {
-    let (samples, sample_rate, channels) =
-        tokio::task::spawn_blocking(move || decode_wav(&bytes))
-            .await
-            .map_err(|e| anyhow::anyhow!("WAV decode task panicked: {e}"))??;
+pub async fn stream_wav(bytes: Vec<u8>, pcm_tx: mpsc::Sender<Vec<i16>>) -> anyhow::Result<()> {
+    let (samples, sample_rate, channels) = tokio::task::spawn_blocking(move || decode_wav(&bytes))
+        .await
+        .map_err(|e| anyhow::anyhow!("WAV decode task panicked: {e}"))??;
 
     let mono = if channels == 1 {
         samples

--- a/src/voice/stt.rs
+++ b/src/voice/stt.rs
@@ -20,6 +20,7 @@ pub trait SttProvider: Send + Sync {
     /// pins this at [`super::PIPELINE_SAMPLE_RATE`] (16 kHz); providers
     /// that need a different rate should resample internally rather
     /// than imposing a different rate on the pipeline.
+    #[allow(dead_code)]
     fn sample_rate(&self) -> u32;
 
     /// Transcribe a single utterance. `pcm` is mono s16le at the

--- a/src/voice/tts.rs
+++ b/src/voice/tts.rs
@@ -18,6 +18,7 @@ pub trait TtsProvider: Send + Sync {
     /// [`super::PIPELINE_SAMPLE_RATE`] — providers that synthesize at
     /// a different rate should resample internally rather than
     /// imposing a different rate on the pipeline.
+    #[allow(dead_code)]
     fn sample_rate(&self) -> u32;
 
     /// Synthesize `text` and push PCM (mono s16le) frames into `pcm_tx`

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -314,7 +314,10 @@ impl Workspace {
                 }
             }
             if !subsections.is_empty() {
-                parts.push(format!("# Past Years' Digests\n\n{}", subsections.join("\n\n")));
+                parts.push(format!(
+                    "# Past Years' Digests\n\n{}",
+                    subsections.join("\n\n")
+                ));
             }
         }
     }
@@ -341,11 +344,11 @@ impl Workspace {
             Some(mtime) => {
                 {
                     let cache = self.cache.lock().await;
-                    if let Some(entry) = cache.get(&path) {
-                        if entry.mtime == mtime {
-                            debug!("Workspace cache hit: {filename}");
-                            return Some(entry.content.clone());
-                        }
+                    if let Some(entry) = cache.get(&path)
+                        && entry.mtime == mtime
+                    {
+                        debug!("Workspace cache hit: {filename}");
+                        return Some(entry.content.clone());
                     }
                 }
 


### PR DESCRIPTION
## Summary
Makes CI green so future PRs can rely on it as a real signal. CI on this repo has been red on every PR for a while because the Format job's first step (`cargo +nightly fmt --check --all`) was failing on ~25 files of pre-existing drift, masking ~50 clippy violations behind it; and the Test job didn't install `libasound2-dev`, so cpal failed at `alsa-sys`.

Three pieces:

- **ci.yml**: install `libasound2-dev` in both the Format and Test jobs.
- **rustfmt**: ran `cargo +nightly fmt --all` to flush the pre-existing drift. Mechanical reformat only, no semantic changes.
- **clippy**: ran `cargo clippy --workspace --fix` for the machine-applicable lints (collapsible_if ×20, manual char comparison, redundant closures, needless_borrow, etc.), then hand-fixed the rest. Highlights:
  - `clippy::lines_filter_map_ok`: `lines.flatten()` → `lines.map_while(Result::ok)` on `std::io::Lines` so an `EBADF` storm can't deadlock the loop (2 sites in `session.rs`).
  - `clippy::unnecessary_unwrap` in Matrix image-MIME warn path: `if declared.is_some() { … declared.unwrap() }` → `if let Some(d) = declared`.
  - `clippy::doc_lazy_continuation` in `is_refusal`: rewrote the numbered list as two prose paragraphs — the list-continuation indent fights with rustfmt's wrap behaviour, and the prose reads fine.
  - `#[allow(clippy::too_many_arguments)]` on four functions where the arg list is intentional (`voice_pipeline_run`, `sapphire-agent-api::run`, `generate_daily_log`, `write_log_with_digest`); splitting them up would be a real refactor.
  - `#[allow(clippy::type_complexity)]` on `SessionStore::load_all`'s three-`HashMap` return for the same reason.
  - `#[allow(dead_code)]` on intentionally-public-but-currently-unused API surface (`Channel::name`, `Channels::is_empty`, `ChatResponse::text_only` / `text_or_empty`, `SessionStore::{new,notify_deleted,delete_session,all_session_dates}`, `McpClient::shutdown`, `Config::provider_for_profile`, `SttProvider`/`TtsProvider`::`sample_rate`, `BundleCategory` variants, `IncomingMessage` id/timestamp fields), and on one `unused_imports` re-export kept for test diagnostics.

## Relationship to #101
Independent of #101 (cpal/bzip2/sha2/sapphire-workspace bumps). Either can land first; if #101 lands first, this PR will need a trivial rebase for the cpal `description()` / `sample_rate()` lines it already cleaned up.

## Test plan
- [x] `cargo +nightly fmt --check --all` (clean)
- [x] `cargo clippy --workspace -- -D warnings` (clean)
- [x] `cargo clippy --workspace --features voice-sherpa -- -D warnings` (clean)
- [x] `cargo test --workspace` (all 3 + 14 unit tests pass)
- [ ] First CI run on this PR is itself the integration test — Format and Test jobs should both go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)