### PR TITLE
feat(mcp): recall_memory / write_report tools for external AI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A personal AI assistant agent that lives in a [`sapphire-workspace`](https://cra
 - **Built-in tools**: `file_read`, `file_write`, `file_append`, `file_delete`, `dir_list`, `dir_walk`, `web_search`, `weather`, `shell`, plus workspace memory / search / sync tools.
 - **Sessions**: human-readable [`grain-id`](https://crates.io/crates/grain-id) aliases, auto-generated titles, history dump on resume.
 - **Background**: heartbeat cron tasks, periodic memory compaction, periodic workspace sync, daily logs.
+- **External AI integration**: `/mcp` endpoint publishes `write_report` and `recall_memory` tools so Claude Code (and other MCP clients) can share project context with the agent — see [docs/mcp-integration.md](docs/mcp-integration.md).
 - **Commands**:
   - `call` — interactive REPL (reedline)
   - `serve` — JSON-RPC over HTTP control API (`/rpc`)

--- a/config.example.toml
+++ b/config.example.toml
@@ -163,18 +163,30 @@ system_prompt = "You are a helpful personal assistant."
 # session_policy   = "compact"
 # rooms            = ["!nsfw:example.com"]
 #
-# A2A (Agent2Agent Protocol) clients reach a room_profile through
-# bearer tokens declared here. Each token must be unique across all
-# room profiles — startup fails if two profiles share one — and an
+# A2A (Agent2Agent Protocol) and MCP clients reach a room_profile
+# through bearer tokens declared here. Each token must be unique across
+# all room profiles — startup fails if two profiles share one — and an
 # incoming `Authorization: Bearer <token>` resolves implicitly to the
-# owning profile, so A2A clients never name room_profile themselves.
-# Leave `api_keys = []` (or omit) to deny A2A access to a profile.
+# owning profile, so external clients never name room_profile
+# themselves. Leave `api_keys = []` (or omit) to deny external access
+# to a profile.
 #
 # [room_profile.sapphire_world]
 # profile          = "default"
 # memory_namespace = "sapphire_world"
 # rooms            = []                       # A2A-only; no chat rooms map here
 # api_keys         = ["sa-a2a-<long random>"] # one token per allowed client
+#
+# A typical MCP setup for an external coding assistant (Claude Code
+# and similar) sharing the user's default memory namespace. The
+# profile pin is what the ねぎらい reply for `write_report` uses; pick
+# whichever model you want responding to project reports.
+#
+# [room_profile.claude_code]
+# profile          = "default"
+# memory_namespace = "default"                # share the everyday namespace
+# rooms            = []                       # MCP-only; no chat rooms map here
+# api_keys         = ["sa-mcp-<long random>"]
 #
 # Caveat: workspace retrieve (FTS / vector search) currently spans every
 # namespace because sapphire-workspace 0.10.x has no path_prefix filter.
@@ -195,6 +207,31 @@ system_prompt = "You are a helpful personal assistant."
 # public_url        = "https://agent.example.com/a2a"
 # agent_name        = "Sapphire"
 # agent_description = "Personal partner AI with persistent character and memory."
+
+# ─────────────────────────────────────────────────────────────────────
+# MCP (Model Context Protocol) server
+# ─────────────────────────────────────────────────────────────────────
+# Mounts `/mcp` (JSON-RPC) on the same HTTP server as `/rpc`. Always
+# enabled — there's no `[mcp]` block — but gated entirely by
+# `[room_profile.<n>].api_keys`: without a configured token, every
+# request returns 401. See the `[room_profile.claude_code]` example
+# above for the typical wiring.
+#
+# Two tools are exposed:
+#
+#   - `write_report` — external AI clients (Claude Code, etc.) report
+#     a unit of work back. Stored per-project under
+#     `sessions/<namespace>/mcp/<ULID>.jsonl`; the response is a
+#     ねぎらい (acknowledgement) generated through the room_profile's
+#     `profile`.
+#   - `recall_memory` — fetch a project's compact summary + recent
+#     reports at session start, so the external AI can pick up where
+#     the user left off (possibly across hosts).
+#
+# Trust boundary is asymmetric: writes flow into the namespace's
+# daily-digest pipeline normally, but `recall_memory` is scoped
+# strictly to the named project's session — namespace-wide memory
+# never leaks back to the external AI.
 
 # ─────────────────────────────────────────────────────────────────────
 # Voice pipeline (optional)

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -1,0 +1,150 @@
+# MCP integration (external AI clients)
+
+`sapphire-agent` exposes a small MCP (Model Context Protocol) server
+at `POST /mcp` so external AI coding assistants — Claude Code first
+and foremost — can share project context with the agent. Two tools
+are published:
+
+- **`write_report`** — file a unit of work back to sapphire-agent.
+  Returns a short acknowledgement (ねぎらい) generated through the
+  configured profile.
+- **`recall_memory`** — at session start, fetch the project's
+  compacted summary plus the most recent reports so the external AI
+  can pick up where the user left off — possibly across hosts.
+
+The point isn't to replace Claude Code's own memory; it's to give
+the agent enough thread of awareness that the user feels their
+work is being witnessed by something with continuity, and the
+external AI doesn't start from a blank slate on every new project
+session.
+
+## Setup
+
+### 1. Server side: declare a room_profile with an API key
+
+`sapphire-agent` reuses the `[room_profile.<n>].api_keys` mechanism
+(originally added for A2A) to authenticate MCP clients. Add a
+profile dedicated to MCP traffic in `config.toml`:
+
+```toml
+[room_profile.claude_code]
+profile          = "default"     # any [profiles.*]; drives the ねぎらい reply
+memory_namespace = "default"     # share the user's everyday namespace
+rooms            = []            # MCP-only; no chat rooms
+api_keys         = ["sa-mcp-<long random>"]
+```
+
+A few notes:
+
+- `memory_namespace = "default"` keeps MCP reports inside the same
+  namespace as everyday chat, so they participate in the regular
+  daily digest / `MEMORY.md` compaction — useful when you want
+  "today's reflection" to include your coding work.
+- If you'd rather isolate coding work into its own namespace,
+  declare one under `[memory_namespace.*]` and point this profile
+  at it. Recall is always project-scoped regardless of namespace,
+  so this is a write-side preference.
+- Tokens must be unique across all profiles. Sharing one across two
+  profiles is a startup error.
+
+### 2. Client side: register the MCP server
+
+The exact format depends on the client. For Claude Code's
+`.mcp.json`, a streamable-HTTP entry looks roughly like this:
+
+```json
+{
+  "mcpServers": {
+    "sapphire-agent": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer sa-mcp-<long random>"
+      }
+    }
+  }
+}
+```
+
+(Check your client's own MCP docs for the precise schema — the URL
+and bearer-token header are the two things that matter on the
+sapphire side.)
+
+### 3. (Recommended) tell the client how to use the tools
+
+The tools work without any prompt help, but the experience is much
+smoother if the client is nudged to call them at the right moments.
+A short `CLAUDE.md` snippet:
+
+```markdown
+This project's coding work is tracked through `sapphire-agent`.
+
+- At the start of a new session, call `recall_memory` with
+  `project: "<repo-name>"` so we pick up where we left off.
+- When you finish a coherent unit of work (a fix, a feature, a
+  refactor), call `write_report` with `project: "<repo-name>"` and
+  a one-line summary. Include `hostname` so multi-machine work
+  stays distinguishable.
+```
+
+For Claude Code specifically, a `SessionStart` hook can call
+`recall_memory` automatically; see Claude Code's hooks docs.
+
+## Tool reference
+
+### `write_report`
+
+| arg | type | required | notes |
+|---|---|---|---|
+| `project` | string | yes | Logical project key — typically the repo name. Stable across hosts and tools. |
+| `summary` | string | yes | One-line summary. |
+| `body` | string | no | Longer details / decisions / follow-ups. |
+| `files` | string[] | no | Files touched by the work. |
+| `source` | string | no | Calling tool identifier. Default `"claude-code"`. |
+| `hostname` | string | no | Originating machine. Recommended for multi-host workflows. |
+
+Returns a short text acknowledgement intended to be shown both to
+the assistant and to the user.
+
+### `recall_memory`
+
+| arg | type | required | notes |
+|---|---|---|---|
+| `project` | string | yes | Project key — must match what `write_report` was called with. |
+| `limit` | int | no | Max recent reports to return verbatim. Default 20, max 100. Older content is in `project_summary`. |
+
+Returns a Markdown-formatted briefing: the project's compacted
+summary (older history) plus the most recent reports verbatim.
+
+## Trust boundary
+
+The split is asymmetric on purpose:
+
+- **Writes** flow into the room_profile's namespace as ordinary
+  session traffic. Daily digests, MEMORY.md compaction, and any
+  retrieve index pick them up like any other session. This is what
+  lets "today's reflection" include your coding work.
+- **Reads** (`recall_memory`) are scoped strictly to the requested
+  project's MCP session. Namespace-wide memory (`MEMORY.md`,
+  cross-room daily digests, sapphire-agent's self-history) is
+  never returned. The external AI cannot ask the agent "what do
+  you remember about me" and get back general personal context.
+
+## Storage layout
+
+MCP sessions are written to:
+
+```
+<workspace>/sessions/<namespace>/mcp/<ULID>.jsonl
+```
+
+One file per project. The first line is `SessionMeta`, including
+the logical `project` key. Subsequent lines are reports (user
+role, with a `report_meta` sidecar carrying provenance and the
+structured fields) and acknowledgements (assistant role).
+
+The `(namespace, project) → session_id` reverse index is rebuilt
+on every server start by scanning these first lines — there is no
+side-channel index file, so a session file IS its own source of
+truth and can be moved or restored individually without dragging
+extra state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,17 @@ async fn main() -> Result<()> {
                 Arc::clone(&ws_state),
             ));
 
+            // ── MCP session store (sessions/<namespace>/mcp/) ──────────────
+            // External AI clients (Claude Code, etc.) reach this through
+            // the `/mcp` `write_report` / `recall_memory` tools. Kept in
+            // its own `kind` directory so the project-name reverse index
+            // and any future MCP-specific retention only scan MCP files.
+            let mcp_session_store = Arc::new(SessionStore::with_workspace(
+                sessions_base.clone(),
+                "mcp",
+                Arc::clone(&ws_state),
+            ));
+
             // ── Voice providers + ServeState (built early) ──────────────────
             // ServeState owns the voice_subscribers registry that heartbeat
             // pushes through, so it has to exist before heartbeat is spawned.
@@ -343,6 +354,7 @@ async fn main() -> Result<()> {
                 Arc::clone(&workspace),
                 Arc::clone(&tool_set),
                 Arc::clone(&api_session_store),
+                Arc::clone(&mcp_session_store),
                 voice_providers,
             ));
 

--- a/src/serve/mcp.rs
+++ b/src/serve/mcp.rs
@@ -1,0 +1,648 @@
+//! MCP (Model Context Protocol) server endpoint.
+//!
+//! Exposes:
+//!   - `POST /mcp` — JSON-RPC 2.0 dispatch for MCP `initialize`,
+//!     `tools/list`, `tools/call`, and `notifications/initialized`.
+//!
+//! Tools published here are aimed at external AI clients (Claude Code
+//! and similar) that want to share context with sapphire-agent:
+//!
+//!   - `write_report` — record a unit of work the external AI just
+//!     finished. Stored as a per-project session under
+//!     `sessions/<namespace>/mcp/<ULID>.jsonl` and returned with a
+//!     short acknowledgement from sapphire-agent.
+//!   - `recall_memory` — at session start, fetch the project's prior
+//!     compact summary plus the most recent reports so the external
+//!     AI can pick up where the user left off — possibly across
+//!     hosts.
+//!
+//! Auth: `Authorization: Bearer <token>` matched against
+//! `[room_profile.<n>].api_keys` (same mechanism as `/a2a`). The
+//! match implicitly resolves which room_profile this MCP session
+//! writes/reads as, so clients don't name the profile. Configure a
+//! room_profile with `rooms = []` (no chat rooms) for MCP-only use.
+//!
+//! Trust boundary (asymmetric):
+//!   - Writes flow into the room_profile's namespace as ordinary
+//!     session traffic and are included in daily digests / MEMORY.md
+//!     compaction.
+//!   - Reads (`recall_memory`) are scoped strictly to the requested
+//!     project's session — namespace-wide memory is never returned,
+//!     so general agent self-memory cannot leak back into the
+//!     external AI's context.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::{Json, response::Response};
+use serde_json::{Value, json};
+use tracing::warn;
+
+use super::ServeState;
+use crate::provider::ChatMessage;
+use crate::session::ReportMeta;
+
+/// MCP protocol revision this server implements. Matches the version
+/// the in-process MCP *client* (`src/mcp_client/`) speaks, so the same
+/// negotiation logic is exercised end-to-end during local testing.
+const PROTOCOL_VERSION: &str = "2025-03-26";
+
+/// JSON-RPC error codes. Standard 2.0 codes plus an
+/// application-level "auth required" code so token failures still
+/// come back inside a JSON-RPC envelope when the request already
+/// passed JSON parsing.
+mod codes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const AUTH_REQUIRED: i32 = -32001;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize)]
+struct JsonRpcEnvelope {
+    #[serde(default)]
+    jsonrpc: Option<String>,
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub async fn handle_mcp_post(
+    State(state): State<Arc<ServeState>>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let envelope: JsonRpcEnvelope = match serde_json::from_slice(&body) {
+        Ok(env) => env,
+        Err(e) => {
+            return jsonrpc_error(
+                Value::Null,
+                codes::PARSE_ERROR,
+                &format!("invalid JSON: {e}"),
+            );
+        }
+    };
+    let req_id = envelope.id.clone().unwrap_or(Value::Null);
+    if envelope.jsonrpc.as_deref() != Some("2.0") {
+        return jsonrpc_error(req_id, codes::INVALID_REQUEST, "jsonrpc field must be \"2.0\"");
+    }
+
+    // Notifications carry no id and expect no response body. MCP sends
+    // `notifications/initialized` after `initialize`; future spec
+    // revisions may add more. Anything we don't recognize is silently
+    // accepted because per JSON-RPC notifications never error back.
+    if envelope.id.is_none() {
+        return (StatusCode::ACCEPTED, "").into_response();
+    }
+
+    // Bearer auth: empty/missing token → 401 (HTTP layer), unknown
+    // token → JSON-RPC AUTH_REQUIRED so well-behaved clients can
+    // distinguish "no creds sent" from "creds rejected".
+    let bearer = match extract_bearer(&headers) {
+        Some(b) => b,
+        None => return (StatusCode::UNAUTHORIZED, "missing bearer token").into_response(),
+    };
+    let profile_name = match state.config.resolve_a2a_token(&bearer) {
+        Some(name) => name.to_string(),
+        None => {
+            return jsonrpc_error(
+                req_id,
+                codes::AUTH_REQUIRED,
+                "unknown or revoked bearer token",
+            );
+        }
+    };
+
+    match envelope.method.as_str() {
+        "initialize" => handle_initialize(req_id),
+        "tools/list" => handle_tools_list(req_id),
+        "tools/call" => {
+            handle_tools_call(state, req_id, envelope.params, profile_name).await
+        }
+        other => jsonrpc_error(
+            req_id,
+            codes::METHOD_NOT_FOUND,
+            &format!("MCP method '{other}' is not implemented"),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// initialize
+// ---------------------------------------------------------------------------
+
+fn handle_initialize(req_id: Value) -> Response {
+    let result = json!({
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": { "listChanged": false }
+        },
+        "serverInfo": {
+            "name": "sapphire-agent",
+            "version": env!("CARGO_PKG_VERSION"),
+        }
+    });
+    jsonrpc_result(req_id, result)
+}
+
+// ---------------------------------------------------------------------------
+// tools/list
+// ---------------------------------------------------------------------------
+
+fn handle_tools_list(req_id: Value) -> Response {
+    let tools = json!([
+        {
+            "name": "write_report",
+            "description":
+                "Report a unit of work back to sapphire-agent. The agent files it under \
+                 the named project's memory and replies with a brief acknowledgement \
+                 that can be shown to the user. Call this when a user-visible task is \
+                 complete or at the end of a coding session.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description":
+                            "Logical project key (typically the repository name). \
+                             Stable across hosts and tools — re-using the same value \
+                             continues the same project's session."
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "One-line summary of what was just done."
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Optional longer description, decisions, follow-ups."
+                    },
+                    "files": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of file paths touched by this work."
+                    },
+                    "source": {
+                        "type": "string",
+                        "description":
+                            "Identifier for the calling tool. Defaults to \"claude-code\" \
+                             when omitted."
+                    },
+                    "hostname": {
+                        "type": "string",
+                        "description":
+                            "Originating host. Recommended when the same project may be \
+                             worked on from multiple machines."
+                    }
+                },
+                "required": ["project", "summary"]
+            }
+        },
+        {
+            "name": "recall_memory",
+            "description":
+                "Recall prior context for a project from sapphire-agent. Returns the \
+                 project's compacted summary plus the most recent reports. Call this \
+                 at the start of a session to pick up where work was left off, \
+                 possibly on another host.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description":
+                            "Project key to recall. Should match what `write_report` \
+                             was called with for the same project."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description":
+                            "Maximum number of recent reports to return verbatim. \
+                             Older content is reflected in the project_summary. \
+                             Defaults to 20.",
+                        "minimum": 1
+                    }
+                },
+                "required": ["project"]
+            }
+        }
+    ]);
+    jsonrpc_result(req_id, json!({ "tools": tools }))
+}
+
+// ---------------------------------------------------------------------------
+// tools/call dispatcher
+// ---------------------------------------------------------------------------
+
+async fn handle_tools_call(
+    state: Arc<ServeState>,
+    req_id: Value,
+    params: Option<Value>,
+    profile_name: String,
+) -> Response {
+    let params = params.unwrap_or(Value::Null);
+    let name = match params.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n.to_string(),
+        None => {
+            return jsonrpc_error(
+                req_id,
+                codes::INVALID_PARAMS,
+                "tools/call requires a `name` field",
+            );
+        }
+    };
+    let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+
+    match name.as_str() {
+        "write_report" => {
+            let result = match call_write_report(state, profile_name, args).await {
+                Ok(v) => v,
+                Err(e) => tool_text_error(&format!("write_report failed: {e}")),
+            };
+            jsonrpc_result(req_id, result)
+        }
+        "recall_memory" => {
+            let result = match call_recall_memory(state, profile_name, args).await {
+                Ok(v) => v,
+                Err(e) => tool_text_error(&format!("recall_memory failed: {e}")),
+            };
+            jsonrpc_result(req_id, result)
+        }
+        other => jsonrpc_result(
+            req_id,
+            tool_text_error(&format!("unknown tool '{other}'")),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// write_report
+// ---------------------------------------------------------------------------
+
+/// Default `source` tag stamped onto reports that don't pass one.
+/// Chosen because Claude Code is the primary intended client and
+/// makes the wire shorter for that case.
+const DEFAULT_SOURCE: &str = "claude-code";
+
+/// System prompt for the ねぎらい (acknowledgement) reply. Kept
+/// short so the model focuses on warmth and brevity rather than
+/// reproducing the report content. Language is left to the model
+/// because reports themselves may come in any language.
+const ACK_SYSTEM_PROMPT: &str =
+    "You are sapphire-agent, the user's personal partner AI. Their external AI \
+     assistant (such as Claude Code) is reporting a unit of coding work it just \
+     completed on the user's behalf. Acknowledge the report warmly and briefly \
+     (1-3 sentences). Speak naturally — your reply is shown both to the assistant \
+     and to the user. Reply in the same language as the report's content.";
+
+async fn call_write_report(
+    state: Arc<ServeState>,
+    profile_name: String,
+    args: Value,
+) -> anyhow::Result<Value> {
+    let project = require_string(&args, "project")?;
+    let summary = require_string(&args, "summary")?;
+    let body = optional_string(&args, "body");
+    let files = optional_string_array(&args, "files");
+    let source = optional_string(&args, "source").unwrap_or_else(|| DEFAULT_SOURCE.to_string());
+    let hostname = optional_string(&args, "hostname");
+
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&profile_name)
+        .to_string();
+
+    let session_id = state
+        .mcp_session_for_project_or_create(&namespace, &project)
+        .await?;
+
+    let report_text = render_report(
+        &summary,
+        body.as_deref(),
+        files.as_deref(),
+        &source,
+        hostname.as_deref(),
+    );
+    let report_meta = ReportMeta {
+        source: source.clone(),
+        hostname: hostname.clone(),
+        summary: summary.clone(),
+        body: body.clone(),
+        files: files.clone(),
+    };
+
+    state
+        .mcp_session_store
+        .append_report(&session_id, &report_text, report_meta)?;
+
+    // Compose the ねぎらい. The model only sees the rendered report —
+    // we don't feed prior reports back here because the goal is a
+    // quick acknowledgement, not a session-aware response. Recall
+    // happens through `recall_memory`, not as a side effect of write.
+    let provider = state.registry.for_profile(&state.config, &profile_name);
+    let chat_response = provider
+        .chat(
+            Some(ACK_SYSTEM_PROMPT),
+            &[ChatMessage::user(report_text.clone())],
+            None,
+        )
+        .await;
+
+    let ack_text = match chat_response {
+        Ok(resp) => resp
+            .text
+            .filter(|t| !t.trim().is_empty())
+            .unwrap_or_else(|| default_ack(&project)),
+        Err(e) => {
+            // Don't fail the whole write — the report is already on
+            // disk. Falling back to a canned ack keeps the contract
+            // (always return a message) while the user still sees
+            // their work was filed.
+            warn!("MCP write_report: ack LLM call failed: {e}");
+            default_ack(&project)
+        }
+    };
+
+    // Persist the ack as the assistant's reply so the session reads
+    // back as a normal conversation in recall_memory output.
+    if let Err(e) = state
+        .mcp_session_store
+        .append(&session_id, &ChatMessage::assistant(ack_text.clone()))
+    {
+        warn!("MCP write_report: failed to persist ack to session {session_id}: {e}");
+    }
+
+    Ok(tool_text_ok(&ack_text))
+}
+
+fn render_report(
+    summary: &str,
+    body: Option<&str>,
+    files: Option<&[String]>,
+    source: &str,
+    hostname: Option<&str>,
+) -> String {
+    // Inline the source/hostname so the rendered text alone is
+    // self-describing — useful both for the ack-LLM context and for
+    // recall_memory's later replay.
+    let header = match hostname {
+        Some(h) => format!("[Report from {source} on {h}]"),
+        None => format!("[Report from {source}]"),
+    };
+    let mut out = format!("{header}\nSummary: {summary}");
+    if let Some(b) = body
+        && !b.trim().is_empty()
+    {
+        out.push_str("\n\nDetails:\n");
+        out.push_str(b);
+    }
+    if let Some(fs) = files
+        && !fs.is_empty()
+    {
+        out.push_str("\n\nFiles touched:");
+        for f in fs {
+            out.push_str(&format!("\n- {f}"));
+        }
+    }
+    out
+}
+
+fn default_ack(project: &str) -> String {
+    format!("ありがとう、{project} の作業お疲れさま。記録しておいたよ。")
+}
+
+// ---------------------------------------------------------------------------
+// recall_memory
+// ---------------------------------------------------------------------------
+
+/// Cap on `limit` regardless of what the caller asks. Picked to keep
+/// the rendered briefing under a few KB even with verbose reports —
+/// callers wanting more should rely on `project_summary` instead.
+const RECALL_LIMIT_MAX: usize = 100;
+const RECALL_LIMIT_DEFAULT: usize = 20;
+
+async fn call_recall_memory(
+    state: Arc<ServeState>,
+    profile_name: String,
+    args: Value,
+) -> anyhow::Result<Value> {
+    let project = require_string(&args, "project")?;
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(RECALL_LIMIT_DEFAULT)
+        .clamp(1, RECALL_LIMIT_MAX);
+
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&profile_name)
+        .to_string();
+
+    let session_id = state
+        .mcp_session_for_project(&namespace, &project)
+        .await;
+
+    let Some(session_id) = session_id else {
+        // Unknown project is the normal first-call shape — return an
+        // empty briefing rather than an error so the client can
+        // proceed (often into a fresh `write_report` cycle).
+        return Ok(tool_text_ok(&render_empty_briefing(&project)));
+    };
+
+    let (messages, summary_line) = state
+        .mcp_session_store
+        .load_session_full(&session_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "project '{project}' is indexed but session file {session_id} is missing"
+            )
+        })?;
+
+    let project_summary = summary_line.map(|s| s.summary).unwrap_or_default();
+
+    // Take the last `limit` user reports. Each has `report_meta`
+    // populated (assistant ack messages don't, so they're skipped —
+    // the recall view is about prior work, not the agent's prior
+    // replies).
+    let reports: Vec<_> = messages
+        .into_iter()
+        .filter(|m| m.report_meta.is_some())
+        .collect();
+    let recent: Vec<_> = reports
+        .into_iter()
+        .rev()
+        .take(limit)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
+    Ok(tool_text_ok(&render_briefing(
+        &project,
+        &project_summary,
+        &recent,
+    )))
+}
+
+fn render_empty_briefing(project: &str) -> String {
+    format!(
+        "# Recall for project: {project}\n\n\
+         No prior reports have been filed for this project yet. \
+         Use `write_report` to file the first one when work is complete."
+    )
+}
+
+fn render_briefing(
+    project: &str,
+    project_summary: &str,
+    reports: &[crate::session::StoredMessage],
+) -> String {
+    let mut out = format!("# Recall for project: {project}\n");
+
+    if !project_summary.trim().is_empty() {
+        out.push_str("\n## Project summary (older history, compacted)\n\n");
+        out.push_str(project_summary);
+        out.push('\n');
+    }
+
+    if reports.is_empty() {
+        out.push_str(
+            "\n## Recent reports\n\n(no recent reports — the project summary above is the full record)\n",
+        );
+        return out;
+    }
+
+    out.push_str(&format!("\n## Recent reports ({} entries)\n", reports.len()));
+    for (idx, msg) in reports.iter().enumerate() {
+        let Some(meta) = &msg.report_meta else {
+            continue;
+        };
+        let ts = msg.timestamp.format("%Y-%m-%d %H:%M UTC");
+        let origin = match &meta.hostname {
+            Some(h) => format!("{} on {}", meta.source, h),
+            None => meta.source.clone(),
+        };
+        out.push_str(&format!("\n### Report {} — {ts} ({origin})\n", idx + 1));
+        out.push_str(&format!("Summary: {}\n", meta.summary));
+        if let Some(body) = &meta.body
+            && !body.trim().is_empty()
+        {
+            out.push_str("\nDetails:\n");
+            out.push_str(body);
+            out.push('\n');
+        }
+        if let Some(files) = &meta.files
+            && !files.is_empty()
+        {
+            out.push_str("\nFiles:\n");
+            for f in files {
+                out.push_str(&format!("- {f}\n"));
+            }
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Argument helpers
+// ---------------------------------------------------------------------------
+
+fn require_string(args: &Value, field: &str) -> anyhow::Result<String> {
+    args.get(field)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("missing required string argument '{field}'"))
+}
+
+fn optional_string(args: &Value, field: &str) -> Option<String> {
+    args.get(field)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn optional_string_array(args: &Value, field: &str) -> Option<Vec<String>> {
+    args.get(field).and_then(|v| v.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn extract_bearer(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(axum::http::header::AUTHORIZATION)?;
+    let s = value.to_str().ok()?;
+    let token = s
+        .strip_prefix("Bearer ")
+        .or_else(|| s.strip_prefix("bearer "))?;
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn jsonrpc_result(id: Value, result: Value) -> Response {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    });
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+fn jsonrpc_error(id: Value, code: i32, message: &str) -> Response {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message },
+    });
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+/// Build a tools/call result that surfaces an in-tool error to the
+/// model. MCP convention is to return `isError: true` with a text
+/// content part, NOT a JSON-RPC error — the latter is reserved for
+/// protocol-level failures.
+fn tool_text_error(message: &str) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": message,
+        }],
+        "isError": true,
+    })
+}
+
+/// Successful tool result carrying a single text part. Used by tools
+/// whose output is a short rendered string (the ねぎらい reply, the
+/// recall payload).
+fn tool_text_ok(text: &str) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": text,
+        }],
+        "isError": false,
+    })
+}

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -10,6 +10,7 @@
 //! #79) and is intentionally not served here.
 
 pub mod a2a;
+pub mod mcp;
 
 use crate::channel::RoomInfo;
 use crate::config::Config;
@@ -59,6 +60,20 @@ pub struct ServeState {
     pub(crate) workspace: Arc<Workspace>,
     pub(crate) tools: Arc<ToolSet>,
     pub(crate) api_session_store: Arc<SessionStore>,
+    /// MCP session store (kind = `"mcp"`). Holds long-lived
+    /// per-project sessions written through `/mcp`'s `write_report`
+    /// tool — kept physically separate from `api_session_store` so the
+    /// project index scan and any future MCP-specific retention only
+    /// see MCP traffic.
+    pub(crate) mcp_session_store: Arc<SessionStore>,
+    /// Reverse index `(namespace, project) → session_id` for the MCP
+    /// session store. Seeded at startup from `SessionMeta.project` and
+    /// maintained on `create_mcp_session`. The mapping isn't
+    /// persisted to its own file: each session file's first-line meta
+    /// IS the source of truth, so a restart rebuilds the index by
+    /// scanning `sessions/<ns>/mcp/*.jsonl` meta lines.
+    pub(crate) mcp_project_index:
+        tokio::sync::Mutex<HashMap<(String, String), String>>,
     /// In-memory conversation history, keyed by session_id.
     /// Lazy-loaded from JSONL on first access.
     pub(crate) sessions: tokio::sync::Mutex<HashMap<String, Vec<ChatMessage>>>,
@@ -101,14 +116,34 @@ impl ServeState {
         workspace: Arc<Workspace>,
         tools: Arc<ToolSet>,
         api_session_store: Arc<SessionStore>,
+        mcp_session_store: Arc<SessionStore>,
         voice: Option<Arc<VoiceProviders>>,
     ) -> Self {
+        // Scan once on startup: each MCP session's first-line meta
+        // carries `namespace` + `project`, so this reproduces the
+        // logical mapping without a side-channel index file. The same
+        // map is updated in-place when `write_report` creates a new
+        // project session.
+        let mut mcp_index: HashMap<(String, String), String> = HashMap::new();
+        for meta in mcp_session_store.list_sessions() {
+            let (Some(ns), Some(proj)) = (meta.namespace.clone(), meta.project.clone()) else {
+                continue;
+            };
+            // `list_sessions` is sorted by `created_at`, so overwriting
+            // here keeps the most recent session per (ns, project) —
+            // matters only if a project ever ended up with multiple
+            // session files (manual surgery, future reset semantics).
+            mcp_index.insert((ns, proj), meta.session_id);
+        }
+
         Self {
             config,
             registry,
             workspace,
             tools,
             api_session_store,
+            mcp_session_store,
+            mcp_project_index: tokio::sync::Mutex::new(mcp_index),
             sessions: tokio::sync::Mutex::new(HashMap::new()),
             pending_sessions: tokio::sync::Mutex::new(HashMap::new()),
             session_room_profiles: tokio::sync::Mutex::new(HashMap::new()),
@@ -116,6 +151,52 @@ impl ServeState {
             voice,
             voice_subscribers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Look up the MCP session id for `(namespace, project)`. Returns
+    /// `None` if the project has never received a report.
+    pub(crate) async fn mcp_session_for_project(
+        &self,
+        namespace: &str,
+        project: &str,
+    ) -> Option<String> {
+        self.mcp_project_index
+            .lock()
+            .await
+            .get(&(namespace.to_string(), project.to_string()))
+            .cloned()
+    }
+
+    /// Look up (or create) the MCP session for `(namespace, project)`.
+    /// First call for a project creates the underlying session file
+    /// and registers it in the index; subsequent calls hit the index.
+    /// Concurrent calls for the same new project are serialized
+    /// through the index mutex so only one session file is created.
+    pub(crate) async fn mcp_session_for_project_or_create(
+        &self,
+        namespace: &str,
+        project: &str,
+    ) -> anyhow::Result<String> {
+        let key = (namespace.to_string(), project.to_string());
+        {
+            let idx = self.mcp_project_index.lock().await;
+            if let Some(id) = idx.get(&key) {
+                return Ok(id.clone());
+            }
+        }
+        // Hold the lock across creation so two simultaneous
+        // first-time writers for the same project don't each spawn
+        // a session file. Double-check inside the lock in case
+        // another task won the race between our two acquisitions.
+        let mut idx = self.mcp_project_index.lock().await;
+        if let Some(id) = idx.get(&key) {
+            return Ok(id.clone());
+        }
+        let session_id = self
+            .mcp_session_store
+            .create_mcp_session(namespace, project)?;
+        idx.insert(key, session_id.clone());
+        Ok(session_id)
     }
 
     /// Provider that should serve the given session. Resolves the
@@ -200,6 +281,7 @@ pub async fn run(addr: String, state: Arc<ServeState>) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/rpc", post(rpc_post).get(rpc_get))
         .route("/a2a", post(a2a::handle_a2a_post))
+        .route("/mcp", post(mcp::handle_mcp_post))
         .route(
             "/.well-known/agent-card.json",
             axum::routing::get(a2a::handle_agent_card),

--- a/src/session.rs
+++ b/src/session.rs
@@ -53,6 +53,13 @@ pub struct SessionMeta {
     /// field; consumers fall back to room-id derivation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+    /// External-AI logical project key for MCP-driven sessions
+    /// (`write_report` / `recall_memory`). Stable across hosts and
+    /// sources for the same project — the MCP layer reverse-looks-up
+    /// `(namespace, project) -> session_id` from this field. Absent on
+    /// chat/API/voice sessions.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub project: Option<String>,
     /// Short auto-generated title, populated from a later `session_title` line.
     #[serde(skip)]
     pub title: Option<String>,
@@ -64,6 +71,29 @@ pub struct StoredMessage {
     pub timestamp: DateTime<Utc>,
     pub role: Role,
     pub parts: Vec<ContentPart>,
+    /// Provenance for messages written through MCP `write_report`.
+    /// Absent on normal chat messages and on assistant-side replies.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub report_meta: Option<ReportMeta>,
+}
+
+/// Per-report provenance and structured fields. `source` distinguishes
+/// external AI clients (e.g. "claude-code"); `hostname` records the
+/// machine that originated the report, since a single project may
+/// legitimately be touched from multiple hosts. `summary`, `body`,
+/// and `files` mirror the `write_report` arguments so `recall_memory`
+/// can return structured data without re-parsing the rendered text
+/// that lives in the message's `parts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportMeta {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<String>>,
 }
 
 impl StoredMessage {
@@ -72,6 +102,7 @@ impl StoredMessage {
             timestamp: Utc::now(),
             role: msg.role.clone(),
             parts: msg.parts.clone(),
+            report_meta: None,
         }
     }
 
@@ -301,6 +332,7 @@ impl SessionStore {
             created_at: Utc::now(),
             public_id: None,
             namespace: Some(namespace.to_string()),
+            project: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -523,6 +555,87 @@ impl SessionStore {
         )
     }
 
+    /// Load a session preserving wall-clock timestamps and
+    /// `report_meta` provenance, alongside the latest `SummaryLine`
+    /// if one has been written. Used by `recall_memory`: the summary
+    /// becomes `project_summary` (older content compacted) and the
+    /// messages provide the recent verbatim reports. Plain
+    /// `load_session` is unsuitable because the `ChatMessage`
+    /// conversion drops both fields.
+    pub fn load_session_full(
+        &self,
+        session_id: &str,
+    ) -> Option<(Vec<StoredMessage>, Option<SummaryLine>)> {
+        let path = self.resolve_path(session_id)?;
+        let (_, messages, _, summary) = load_session_file(&path)?;
+        Some((messages, summary))
+    }
+
+    /// Create a new MCP-driven session for a logical `project`. Unlike
+    /// `create_session` there's no `ConversationKey` — MCP sessions
+    /// don't map to a chat room, so `room_id` is left empty and the
+    /// `project` field on `SessionMeta` serves as the reverse lookup
+    /// key. Files land under `<base_dir>/<namespace>/mcp/<ULID>.jsonl`
+    /// when this store is constructed with `kind = "mcp"`.
+    pub fn create_mcp_session(
+        &self,
+        namespace: &str,
+        project: &str,
+    ) -> anyhow::Result<String> {
+        let session_id = Uuid::now_v7().to_string();
+        let path = self.path_for_new(&session_id, namespace);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let meta = SessionMeta {
+            session_id: session_id.clone(),
+            room_id: String::new(),
+            thread_id: None,
+            channel: "mcp".to_string(),
+            created_at: Utc::now(),
+            public_id: None,
+            namespace: Some(namespace.to_string()),
+            project: Some(project.to_string()),
+            title: None,
+        };
+        let line = serde_json::to_string(&MetaLine { meta })?;
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        writeln!(file, "{line}")?;
+        drop(file);
+        self.notify_updated(&path);
+        Ok(session_id)
+    }
+
+    /// Append a user-role report message tagged with MCP provenance.
+    /// `rendered_text` is what lives in the message's `parts` (used
+    /// as LLM context for the ねぎらい reply and any future feature
+    /// that reads sessions as conversation); `meta` carries the
+    /// structured form `recall_memory` returns to clients. The
+    /// assistant's reply is written through the regular `append`
+    /// path so the session reads back as a normal conversation.
+    pub fn append_report(
+        &self,
+        session_id: &str,
+        rendered_text: &str,
+        meta: ReportMeta,
+    ) -> anyhow::Result<()> {
+        let stored = StoredMessage {
+            timestamp: Utc::now(),
+            role: Role::User,
+            parts: vec![ContentPart::Text(rendered_text.to_string())],
+            report_meta: Some(meta),
+        };
+        let line = serde_json::to_string(&stored)?;
+        let path = self
+            .resolve_path(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session file not found for {session_id}"))?;
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        writeln!(file, "{line}")?;
+        drop(file);
+        self.notify_updated(&path);
+        Ok(())
+    }
+
     /// Ensure a session file exists for the given caller-supplied ID.
     /// Unlike `create_session`, this uses the provided ID rather than generating a new UUID.
     ///
@@ -559,6 +672,7 @@ impl SessionStore {
             created_at: Utc::now(),
             public_id: public_id.clone(),
             namespace: Some(namespace.to_string()),
+            project: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;


### PR DESCRIPTION
Closes #79.

## Summary

- Add `/mcp` JSON-RPC endpoint with `initialize` / `tools/list` / `tools/call` dispatch, gated by the existing `[room_profile.<n>].api_keys` bearer-token mechanism.
- Publish two tools:
  - **`write_report`** — file a unit of coding work back to sapphire-agent. Stored as a per-project session and answered with a short ねぎらい generated through the room_profile's profile.
  - **`recall_memory`** — return the project's compacted summary plus the most recent reports verbatim, so the external AI can pick up where the user left off (possibly across hosts).
- New `kind = "mcp"` SessionStore: files live under `sessions/<namespace>/mcp/<ULID>.jsonl`, with `SessionMeta.project` as the logical key. The reverse index `(namespace, project) → session_id` is rebuilt at startup by scanning meta lines — each session file is its own source of truth, so no side-channel index file is persisted.
- Trust boundary is **asymmetric**: writes flow into the namespace's normal daily-digest / `MEMORY.md` compaction pipeline, but recall is scoped strictly to the named project's session. General agent self-memory never leaks back to the external AI.
- Reports carry per-row `source` + `hostname` provenance (same project may legitimately be touched from multiple hosts/tools); `project` lives on the session meta line only.
- Docs: new [docs/mcp-integration.md](docs/mcp-integration.md) covering server config, `.mcp.json` example, tool reference, trust boundary, storage layout. `config.example.toml` gains an MCP section and a `[room_profile.claude_code]` example.

## Test plan

- [x] `cargo check -p sapphire-agent` clean
- [x] `cargo test -p sapphire-agent` — 119/119 passing
- [ ] Manual smoke test against a running server:
  - Add `[room_profile.claude_code]` with `api_keys` to `config.toml`
  - `sapphire-agent serve`
  - `curl POST /mcp` with `initialize`, `tools/list`, `tools/call` for both tools
  - Verify `sessions/default/mcp/<ULID>.jsonl` is created with the expected meta + report lines
  - Verify `recall_memory` returns the report markdown briefing
- [ ] End-to-end test through Claude Code (`.mcp.json` entry, project session continuity across host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)