### PR TITLE
feat(a2a): FilePart vision routing + task_id compliance (#93)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -505,10 +505,9 @@ impl Agent {
     /// and we never reload raw history across restarts, so persisting them
     /// would only bloat the JSONL. Context survives via compaction summaries.
     ///
-    /// Messages with `Image` parts are persisted with the raw image data
-    /// stripped (replaced with a `[image: <media_type>]` text marker) so the
-    /// JSONL stays small while daily logs / summaries can still see that an
-    /// image was sent.
+    /// Image scrubbing (raw base64 → `[image: <media_type> sha256=...]` text
+    /// marker) happens centrally inside [`SessionStore::append`] so every
+    /// persist path (agent, A2A, MCP) inherits the same on-disk shape.
     fn persist(&self, session_id: &str, msg: &ChatMessage) {
         if session_id.is_empty() {
             return;
@@ -522,9 +521,7 @@ impl Agent {
         if has_tool_parts {
             return;
         }
-        let scrubbed = strip_image_data(msg);
-        let to_write = scrubbed.as_ref().unwrap_or(msg);
-        if let Err(e) = self.session_store.append(session_id, to_write) {
+        if let Err(e) = self.session_store.append(session_id, msg) {
             warn!("Failed to persist message: {e}");
         }
     }
@@ -992,32 +989,6 @@ fn build_user_message(text: &str, attachments: &[Attachment]) -> ChatMessage {
         .iter()
         .map(|a| (a.media_type.clone(), STANDARD.encode(&a.data)));
     ChatMessage::user_with_images(text, images)
-}
-
-/// Return a copy of `msg` with every `Image` part replaced by a small text
-/// marker, or `None` if the message has no `Image` parts (avoids cloning).
-fn strip_image_data(msg: &ChatMessage) -> Option<ChatMessage> {
-    if !msg
-        .parts
-        .iter()
-        .any(|p| matches!(p, ContentPart::Image { .. }))
-    {
-        return None;
-    }
-    let parts = msg
-        .parts
-        .iter()
-        .map(|p| match p {
-            ContentPart::Image { media_type, .. } => {
-                ContentPart::Text(format!("[image: {media_type}]"))
-            }
-            other => other.clone(),
-        })
-        .collect();
-    Some(ChatMessage {
-        role: msg.role.clone(),
-        parts,
-    })
 }
 
 /// Read the created_at date of a session file and convert to the local day.

--- a/src/main.rs
+++ b/src/main.rs
@@ -954,7 +954,7 @@ mod tests {
         write_stub(&root.join("memory/daily/2026-04-15.md"), "old");
         write_stub(&root.join("memory/default/daily/2026-04-16.md"), "new");
 
-        let err = migrate_pre_namespace_layout(root).err().expect("error");
+        let err = migrate_pre_namespace_layout(root).expect_err("error");
         assert!(format!("{err:#}").contains("Reconcile manually"));
         // Files untouched.
         assert!(root.join("memory/daily/2026-04-15.md").exists());
@@ -1008,7 +1008,7 @@ mod tests {
         let base = td.path();
         write_stub(&base.join("matrix/01H1.jsonl"), "matrix");
         write_stub(&base.join("channel/01H1.jsonl"), "pre-existing");
-        let err = migrate_per_channel_sessions(base).err().expect("error");
+        let err = migrate_per_channel_sessions(base).expect_err("error");
         assert!(
             format!("{err:#}").contains("already exists"),
             "got: {err:#}"

--- a/src/serve/a2a.rs
+++ b/src/serve/a2a.rs
@@ -12,10 +12,12 @@
 //! it. A token leak therefore exposes one profile, not all.
 //!
 //! Out of scope (v1): `SendStreamingMessage` (SSE), `GetTask`,
-//! `CancelTask`, `SubscribeToTask`, push notifications, `FilePart`
-//! (vision). Wire-format types come from `a2a-lf`; the JSON-RPC
-//! dispatch is hand-rolled here to share `ServeState` with the
-//! existing `/rpc` endpoint.
+//! `CancelTask`, `SubscribeToTask`, push notifications, `FilePart` `url`
+//! (privacy/security: requires explicit operator opt-in), `DataPart`.
+//! `FilePart` inline (`raw` base64) for `image/*` is supported and routes
+//! through the existing multimodal provider path. Wire-format types come
+//! from `a2a-lf`; the JSON-RPC dispatch is hand-rolled here to share
+//! `ServeState` with the existing `/rpc` endpoint.
 
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -28,12 +30,13 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::{Json, response::sse::Event};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::Utc;
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
-use tracing::warn;
 
 use super::ServeState;
+use crate::provider::ChatMessage;
 
 /// Method name for the only A2A method we implement. The A2A v1 spec
 /// uses PascalCase JSON-RPC method names (`SendMessage`, `GetTask`,
@@ -91,7 +94,7 @@ pub async fn handle_agent_card(State(state): State<Arc<ServeState>>) -> impl Int
             "pushNotifications": false,
             "extendedAgentCard": false,
         },
-        "defaultInputModes": ["text/plain"],
+        "defaultInputModes": ["text/plain", "image/jpeg", "image/png", "image/gif", "image/webp"],
         "defaultOutputModes": ["text/plain"],
         "skills": [
             {
@@ -99,9 +102,10 @@ pub async fn handle_agent_card(State(state): State<Arc<ServeState>>) -> impl Int
                 "name": "Chat with the agent",
                 "description":
                     "Hold a multi-turn conversation; the agent remembers context across calls \
-                     within the same contextId and applies its server-side persona / memory.",
-                "tags": ["chat", "conversation"],
-                "inputModes": ["text/plain"],
+                     within the same contextId and applies its server-side persona / memory. \
+                     Inline images (FilePart raw) are accepted for vision-capable backends.",
+                "tags": ["chat", "conversation", "vision"],
+                "inputModes": ["text/plain", "image/jpeg", "image/png", "image/gif", "image/webp"],
                 "outputModes": ["text/plain"]
             }
         ],
@@ -227,17 +231,28 @@ async fn handle_send_message(
         }
     };
 
-    // Extract plain-text content from message parts. v1 of this handler
-    // ignores non-text parts (FilePart vision, DataPart structured input);
-    // a future change will route those into the multimodal provider path.
-    let user_text = collect_text(&request.message.parts);
-    if user_text.trim().is_empty() {
+    // Extract text + inline image parts. `FilePart` with `url` is rejected
+    // (server-side URL fetch is a privacy/security choice that should
+    // require explicit operator opt-in); `DataPart` is rejected in v1
+    // until we have a structured-tool routing story.
+    let (user_text, images) = match collect_text_and_images(&request.message.parts) {
+        Ok(v) => v,
+        Err(e) => {
+            return jsonrpc_error_response(req_id, codes::INVALID_PARAMS, &e);
+        }
+    };
+    if user_text.trim().is_empty() && images.is_empty() {
         return jsonrpc_error_response(
             req_id,
             codes::INVALID_PARAMS,
-            "message must contain at least one non-empty text part",
+            "message must contain at least one non-empty text part or an inline image",
         );
     }
+    let user_msg = if images.is_empty() {
+        ChatMessage::user(&user_text)
+    } else {
+        ChatMessage::user_with_images(&user_text, images)
+    };
 
     // contextId: client-supplied (resume) or server-generated (new). The
     // params-level field wins over message-level if both are present —
@@ -278,7 +293,7 @@ async fn handle_send_message(
     let outcome = super::run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        user_text,
+        user_msg,
         req_id.clone(),
         tx,
     )
@@ -296,10 +311,16 @@ async fn handle_send_message(
         ),
     };
 
+    // Mint the new task id once and reference it from both the Task and
+    // the inner reply Message. Per A2A v1.0, `Message.taskId` identifies
+    // the task this message belongs to — without it, clients that key
+    // off `result.status.message.taskId` see `None` and may treat the
+    // reply as orphaned.
+    let task_id = new_task_id();
     let reply_message = Message {
         message_id: a2a::new_message_id(),
         context_id: Some(context_id.clone()),
-        task_id: None,
+        task_id: Some(task_id.clone()),
         role: Role::Agent,
         parts: vec![Part::text(reply_text)],
         metadata: None,
@@ -308,7 +329,7 @@ async fn handle_send_message(
     };
 
     let task = Task {
-        id: new_task_id(),
+        id: task_id,
         context_id,
         status: TaskStatus {
             state: state_enum,
@@ -358,22 +379,54 @@ fn extract_bearer(headers: &HeaderMap) -> Option<String> {
     }
 }
 
-fn collect_text(parts: &[Part]) -> String {
-    let mut out = String::new();
+/// Extract text and inline images from `parts`. Returns
+/// `(joined_text, Vec<(media_type, base64)>)` on success.
+///
+/// Rejects (with a caller-facing error string for JSON-RPC -32602):
+/// - `PartContent::Url`: server-side URL fetch is a privacy/security
+///   surface that needs explicit operator opt-in.
+/// - `PartContent::Data`: structured-input routing is out of scope for v1.
+/// - `PartContent::Raw` with a non-`image/*` `mediaType`: only the
+///   multimodal provider path (image) is wired through today.
+/// - `PartContent::Raw` without any `mediaType`: ambiguous; the spec
+///   makes it optional but we need it to dispatch.
+fn collect_text_and_images(parts: &[Part]) -> Result<(String, Vec<(String, String)>), String> {
+    let mut text = String::new();
+    let mut images: Vec<(String, String)> = Vec::new();
     for p in parts {
-        if let PartContent::Text(s) = &p.content {
-            if !out.is_empty() {
-                out.push('\n');
+        match &p.content {
+            PartContent::Text(s) => {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(s);
             }
-            out.push_str(s);
-        } else {
-            // Non-text part observed but unsupported; flag in logs so
-            // operators noticing missing context in replies have a
-            // pointer rather than having to deserialize the request.
-            warn!("a2a: ignoring non-text Part (vision/data unsupported in v1)");
+            PartContent::Raw(bytes) => {
+                let Some(media_type) = p.media_type.as_deref() else {
+                    return Err(
+                        "FilePart with raw content requires a mediaType (e.g. image/jpeg)"
+                            .to_string(),
+                    );
+                };
+                if !media_type.starts_with("image/") {
+                    return Err(format!(
+                        "unsupported mediaType '{media_type}' for inline FilePart \
+                         (v1 only routes image/* to the multimodal provider)"
+                    ));
+                }
+                images.push((media_type.to_string(), BASE64_STANDARD.encode(bytes)));
+            }
+            PartContent::Url(_) => {
+                return Err("FilePart with url is not supported (server-side URL fetch \
+                     requires explicit operator opt-in)"
+                    .to_string());
+            }
+            PartContent::Data(_) => {
+                return Err("DataPart is not supported in A2A v1 of this agent".to_string());
+            }
         }
     }
-    out
+    Ok((text, images))
 }
 
 fn jsonrpc_error_response(id: Value, code: i32, message: &str) -> axum::response::Response {
@@ -383,4 +436,62 @@ fn jsonrpc_error_response(id: Value, code: i32, message: &str) -> axum::response
         "error": { "code": code, "message": message },
     });
     (StatusCode::OK, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn collect_text_only() {
+        let parts = vec![Part::text("hello"), Part::text("world")];
+        let (text, images) = collect_text_and_images(&parts).unwrap();
+        assert_eq!(text, "hello\nworld");
+        assert!(images.is_empty());
+    }
+
+    #[test]
+    fn collect_text_plus_inline_image() {
+        let img_bytes = b"\xff\xd8\xff\xe0fake-jpeg".to_vec();
+        let parts = vec![
+            Part::text("look at this"),
+            Part::raw(img_bytes.clone()).with_media_type("image/jpeg"),
+        ];
+        let (text, images) = collect_text_and_images(&parts).unwrap();
+        assert_eq!(text, "look at this");
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].0, "image/jpeg");
+        // Round-trip: the encoded blob must decode back to the original bytes.
+        let decoded = BASE64_STANDARD.decode(&images[0].1).unwrap();
+        assert_eq!(decoded, img_bytes);
+    }
+
+    #[test]
+    fn raw_part_without_media_type_is_rejected() {
+        let parts = vec![Part::raw(vec![1, 2, 3])];
+        let err = collect_text_and_images(&parts).unwrap_err();
+        assert!(err.contains("mediaType"), "got: {err}");
+    }
+
+    #[test]
+    fn raw_part_with_non_image_media_type_is_rejected() {
+        let parts = vec![Part::raw(vec![1, 2, 3]).with_media_type("application/pdf")];
+        let err = collect_text_and_images(&parts).unwrap_err();
+        assert!(err.contains("application/pdf"), "got: {err}");
+    }
+
+    #[test]
+    fn url_part_is_rejected() {
+        let parts = vec![Part::url("https://example.com/foo.jpg").with_media_type("image/jpeg")];
+        let err = collect_text_and_images(&parts).unwrap_err();
+        assert!(err.contains("url"), "got: {err}");
+    }
+
+    #[test]
+    fn data_part_is_rejected() {
+        let parts = vec![Part::data(json!({"k": "v"}))];
+        let err = collect_text_and_images(&parts).unwrap_err();
+        assert!(err.to_lowercase().contains("datapart"), "got: {err}");
+    }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -72,8 +72,7 @@ pub struct ServeState {
     /// persisted to its own file: each session file's first-line meta
     /// IS the source of truth, so a restart rebuilds the index by
     /// scanning `sessions/<ns>/mcp/*.jsonl` meta lines.
-    pub(crate) mcp_project_index:
-        tokio::sync::Mutex<HashMap<(String, String), String>>,
+    pub(crate) mcp_project_index: tokio::sync::Mutex<HashMap<(String, String), String>>,
     /// In-memory conversation history, keyed by session_id.
     /// Lazy-loaded from JSONL on first access.
     pub(crate) sessions: tokio::sync::Mutex<HashMap<String, Vec<ChatMessage>>>,
@@ -1192,7 +1191,7 @@ async fn run_voice_turn_from_text_sse(
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        user_text.clone(),
+        ChatMessage::user(&user_text),
         req_id.clone(),
         tx.clone(),
     )
@@ -1402,7 +1401,7 @@ pub(crate) async fn push_voice_text_to_subscriber(
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        user_text.clone(),
+        ChatMessage::user(&user_text),
         Value::Null,
         sink_tx,
     )
@@ -1501,7 +1500,7 @@ struct LlmTurnOutcome {
 async fn run_llm_turn(
     state: Arc<ServeState>,
     session_id: String,
-    user_message: String,
+    user_msg: ChatMessage,
     req_id: Value,
     tx: mpsc::Sender<Result<Event, Infallible>>,
 ) -> LlmTurnOutcome {
@@ -1574,8 +1573,9 @@ async fn run_llm_turn(
         if sp.is_empty() { None } else { Some(sp) }
     };
 
-    // 4. Append user message
-    let user_msg = ChatMessage::user(&user_message);
+    // 4. Append user message. Image scrubbing for storage is handled inside
+    //    `SessionStore::append` so the in-memory history keeps full image
+    //    bytes for the provider call while JSONL gets a hash marker.
     history.push(user_msg.clone());
     if let Err(e) = state.api_session_store.append(&session_id, &user_msg) {
         warn!("Failed to persist user message: {e}");
@@ -1727,7 +1727,7 @@ async fn run_turn(
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        user_message.clone(),
+        ChatMessage::user(&user_message),
         req_id.clone(),
         tx.clone(),
     )

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,9 +17,11 @@
 //! of this line means the session is no longer active.
 
 use crate::provider::{ChatMessage, ContentPart, Role};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone, Timelike, Utc};
 use sapphire_workspace::WorkspaceState;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
@@ -345,7 +347,9 @@ impl SessionStore {
 
     /// Append a `ChatMessage` (with current timestamp) to an existing session.
     pub fn append(&self, session_id: &str, msg: &ChatMessage) -> anyhow::Result<()> {
-        let stored = StoredMessage::from_chat(msg);
+        let scrubbed = scrub_images_for_storage(msg);
+        let to_store = scrubbed.as_ref().unwrap_or(msg);
+        let stored = StoredMessage::from_chat(to_store);
         let line = serde_json::to_string(&stored)?;
         let path = self
             .resolve_path(session_id)
@@ -577,11 +581,7 @@ impl SessionStore {
     /// `project` field on `SessionMeta` serves as the reverse lookup
     /// key. Files land under `<base_dir>/<namespace>/mcp/<ULID>.jsonl`
     /// when this store is constructed with `kind = "mcp"`.
-    pub fn create_mcp_session(
-        &self,
-        namespace: &str,
-        project: &str,
-    ) -> anyhow::Result<String> {
+    pub fn create_mcp_session(&self, namespace: &str, project: &str) -> anyhow::Result<String> {
         let session_id = Uuid::now_v7().to_string();
         let path = self.path_for_new(&session_id, namespace);
         if let Some(parent) = path.parent() {
@@ -819,6 +819,66 @@ impl SessionStore {
 }
 
 // ---------------------------------------------------------------------------
+// Image scrubbing for persistence
+// ---------------------------------------------------------------------------
+
+/// Replace every `ContentPart::Image` in `msg` with a text marker that
+/// preserves the MIME type and a SHA-256 of the raw bytes, returning the
+/// rewritten message. Returns `None` when `msg` has no image parts (so
+/// callers can skip the allocation).
+///
+/// Format: `[image: <media_type> sha256=<hex>]` — the hash gives future
+/// out-of-band caches a stable key (planned follow-up: ImageRef +
+/// workspace-external cache) without dragging multi-MB base64 blobs into
+/// JSONL session files or the in-memory history on reload.
+///
+/// An undecodable `data_base64` is recorded as `sha256=invalid-base64`
+/// rather than failing the append — a corrupt image shouldn't lose the
+/// surrounding turn from persistence.
+pub(crate) fn scrub_images_for_storage(msg: &ChatMessage) -> Option<ChatMessage> {
+    if !msg
+        .parts
+        .iter()
+        .any(|p| matches!(p, ContentPart::Image { .. }))
+    {
+        return None;
+    }
+    let parts = msg
+        .parts
+        .iter()
+        .map(|p| match p {
+            ContentPart::Image {
+                media_type,
+                data_base64,
+            } => {
+                let hash = match BASE64_STANDARD.decode(data_base64) {
+                    Ok(bytes) => sha256_hex(&bytes),
+                    Err(_) => "invalid-base64".to_string(),
+                };
+                ContentPart::Text(format!("[image: {media_type} sha256={hash}]"))
+            }
+            other => other.clone(),
+        })
+        .collect();
+    Some(ChatMessage {
+        role: msg.role.clone(),
+        parts,
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let digest = h.finalize();
+    let mut s = String::with_capacity(64);
+    for b in digest.iter() {
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
 // Namespace-scoped filesystem walking
 // ---------------------------------------------------------------------------
 
@@ -984,4 +1044,62 @@ fn load_meta_and_latest_intraday_digest(
         }
     }
     Some((meta, latest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_returns_none_when_no_images() {
+        let msg = ChatMessage::user("plain text");
+        assert!(scrub_images_for_storage(&msg).is_none());
+    }
+
+    #[test]
+    fn scrub_replaces_image_with_hash_marker() {
+        let bytes = b"\xff\xd8\xff\xe0fake-jpeg".to_vec();
+        let b64 = BASE64_STANDARD.encode(&bytes);
+        let msg =
+            ChatMessage::user_with_images("look", std::iter::once(("image/jpeg".to_string(), b64)));
+        let scrubbed = scrub_images_for_storage(&msg).expect("scrub should rewrite");
+
+        // No Image parts remain on the persisted shape.
+        assert!(
+            !scrubbed
+                .parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::Image { .. })),
+            "scrubbed message still contains Image part"
+        );
+
+        // The marker is text and carries the expected hash.
+        let expected = sha256_hex(&bytes);
+        let has_marker = scrubbed
+            .parts
+            .iter()
+            .any(|p| matches!(p, ContentPart::Text(s) if s.contains(&expected) && s.contains("image/jpeg")));
+        assert!(
+            has_marker,
+            "missing hash marker; parts={:?}",
+            scrubbed.parts
+        );
+    }
+
+    #[test]
+    fn scrub_invalid_base64_records_marker_without_panic() {
+        let msg = ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::Image {
+                media_type: "image/png".to_string(),
+                data_base64: "@@@not-base64@@@".to_string(),
+            }],
+        };
+        let scrubbed = scrub_images_for_storage(&msg).expect("scrub should rewrite");
+        let has_marker = scrubbed
+            .parts
+            .iter()
+            .any(|p| matches!(p, ContentPart::Text(s) if s.contains("invalid-base64")));
+        assert!(has_marker, "expected invalid-base64 marker");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #93. Unblocks sapphire-world's vision channel (screenshot → agent reply) and aligns the A2A reply with v1.0's `Message.taskId` contract.

- **FilePart `raw` (image/*)** now routes through `ChatMessage::user_with_images` into the existing Anthropic / OpenAI multimodal path.
- **`Url`, `Data`, and non-image `mediaType`** are explicitly rejected with JSON-RPC -32602 so unwired channels surface (instead of being silently dropped, as they were before).
- **Agent card** advertises `image/jpeg`, `image/png`, `image/gif`, `image/webp` in both `defaultInputModes` and the chat skill's `inputModes`.
- **`Message.task_id`** in the reply is now `Some(task.id)` instead of `None` — v1.0 spec says it identifies the task this message belongs to.

## Persistence

Image scrubbing for JSONL persistence moves from `agent.rs::persist` into `SessionStore::append` so every channel (agent, A2A, MCP) inherits the same on-disk shape. The marker now carries a SHA-256 of the raw bytes — `[image: image/jpeg sha256=<hex>]` — which gives a stable key for a planned workspace-external image cache (follow-up issue).

In-memory history retains full base64 within a turn (so the provider call works); the cache + memory-side scrub is deferred to a follow-up PR.

## API change

`run_llm_turn` now takes `ChatMessage` instead of `String`. Three in-tree callers wrap with `ChatMessage::user(...)`.

## Drive-by

Two pre-existing `.err().expect()` → `.expect_err()` sites in `src/main.rs` tests, to keep `clippy --all-targets -- -D warnings` clean for the new files.

## Test plan

- [x] `cargo test --bin sapphire-agent` — 128 passed (6 new a2a + 3 new scrub)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Live test from sapphire-world: send a `SendMessage` with `[TextPart, FilePart(image/jpeg, raw)]` and confirm the agent describes the image
- [ ] Inspect the resulting JSONL: image part should be `[image: image/jpeg sha256=...]`, no base64

## Out of scope (separate follow-up)

- Workspace-external image cache keyed by sha256, `ContentPart::ImageRef` variant, post-turn memory scrub. The sha256 in the JSONL marker is forward-compatible with this design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)