### PR TITLE
feat(image-cache): workspace-external cache + in-memory ImageRef (#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7609,6 +7609,7 @@ dependencies = [
  "clap",
  "cron",
  "directories",
+ "dirs 6.0.0",
  "futures-util",
  "grain-id",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,5 +176,10 @@ hound = "3.5"
 # own JSON-RPC dispatch on the existing axum app in src/serve.
 a2a = { package = "a2a-lf", version = "0.3" }
 
+# OS-standard cache / data / config directory resolution. Used by the
+# image cache to default to `$XDG_CACHE_HOME/sapphire-agent/images/`
+# (or the platform equivalent) when no explicit dir is configured.
+dirs = "6"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::channel::{Attachment, Channels, OutgoingMessage};
 use crate::config::{Config, SessionPolicy};
 use crate::context_compression::{generate_summary, maybe_compress};
+use crate::image_cache::{ImageCache, hydrate_history, scrub_history_inplace};
 use crate::provider::registry::ProviderRegistry;
 use crate::provider::{ChatMessage, ContentPart, Provider, Role, ToolCall};
 use crate::session::{ConversationKey, SessionStore, local_date_for_timestamp};
@@ -44,6 +45,9 @@ pub struct Agent {
     workspace: Arc<Workspace>,
     tools: Option<Arc<ToolSet>>,
     session_store: Arc<SessionStore>,
+    /// Workspace-external image cache. `None` disables in-memory image
+    /// scrubbing entirely (PR1 hash-marker on disk still applies).
+    image_cache: Option<Arc<ImageCache>>,
     /// In-memory conversation history, keyed by (room_id, thread_id).
     /// Starts empty on process startup; raw history from disk is never reloaded
     /// (see `restart_summaries` for how prior context is carried across restarts).
@@ -86,6 +90,7 @@ impl Agent {
         workspace: Arc<Workspace>,
         tools: Option<Arc<ToolSet>>,
         session_store: Arc<SessionStore>,
+        image_cache: Option<Arc<ImageCache>>,
     ) -> Self {
         let (active_sessions, summaries, fallback) = session_store.load_all();
         info!(
@@ -101,6 +106,7 @@ impl Agent {
             workspace,
             tools,
             session_store,
+            image_cache,
             history: Mutex::new(HashMap::new()),
             active_sessions: Mutex::new(active_sessions),
             snapshots: Mutex::new(HashMap::new()),
@@ -840,10 +846,14 @@ impl Agent {
                 }
             };
 
+            // Hydrate `ImageRef` parts back to `Image` so the provider
+            // sees the actual bytes. Cache misses degrade to a text
+            // marker that preserves the hash for context references.
+            let messages_for_provider = hydrate_history(&messages, self.image_cache.as_deref());
             let response = provider
                 .chat(
                     system_with_context.as_deref(),
-                    &messages,
+                    &messages_for_provider,
                     tool_specs.as_deref(),
                 )
                 .await;
@@ -934,6 +944,19 @@ impl Agent {
                 }
             }
         };
+
+        // Scrub `Image` parts in the just-completed history into compact
+        // `ImageRef` references backed by the workspace-external image
+        // cache. Long-lived in-memory storage stays hash-only between
+        // turns; subsequent turns re-hydrate from cache for provider
+        // calls. No-op when the image cache is disabled (PR1 marker
+        // still applies on the persistence side).
+        {
+            let mut hist = self.history.lock().await;
+            if let Some(entry) = hist.get_mut(&key) {
+                scrub_history_inplace(entry, self.image_cache.as_deref());
+            }
+        }
 
         let _ = self.channels.stop_typing(&incoming.room_id).await;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,14 @@ pub struct Config {
     /// the `/a2a` and `/.well-known/agent-card.json` routes off.
     #[serde(default)]
     pub a2a: Option<A2aConfig>,
+    /// Workspace-external image cache. Holds raw bytes for vision
+    /// inputs by SHA-256 so in-memory `ChatMessage` history and JSONL
+    /// session files only carry compact references. When unset, the
+    /// cache uses `dirs::cache_dir() / "sapphire-agent" / "images"`.
+    /// Set `enabled = false` to fall back to the PR1 text-marker shape
+    /// (no re-display of past images, but no cache directory either).
+    #[serde(default)]
+    pub image_cache: ImageCacheConfig,
     /// Directory containing AGENT.md and MEMORY.md.
     /// Defaults to the config file's parent directory.
     pub workspace_dir: Option<String>,
@@ -228,6 +236,37 @@ pub struct A2aConfig {
     /// a generic personal-assistant description.
     #[serde(default)]
     pub agent_description: Option<String>,
+}
+
+/// Image cache settings. See [`Config::image_cache`] for an overview
+/// of how this interacts with persistence and provider calls.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageCacheConfig {
+    /// When false, no cache directory is opened and the image scrubbing
+    /// path becomes a no-op. JSONL still gets the SHA-256 text marker
+    /// from `SessionStore::append`; in-memory history keeps full base64
+    /// (same shape as before PR2).
+    #[serde(default = "default_image_cache_enabled")]
+    pub enabled: bool,
+    /// Override the default cache directory. `None` resolves to
+    /// `dirs::cache_dir() / "sapphire-agent" / "images"` at startup.
+    /// Path may be relative; resolved against the process cwd at open
+    /// time (typical configs use absolute paths).
+    #[serde(default)]
+    pub dir: Option<PathBuf>,
+}
+
+impl Default for ImageCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            dir: None,
+        }
+    }
+}
+
+fn default_image_cache_enabled() -> bool {
+    true
 }
 
 /// Voice-mode global settings — everything that's the same for every

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -48,6 +48,11 @@ fn estimate_message_tokens(msg: &ChatMessage) -> usize {
             ContentPart::Text(t) => estimate_tokens(t),
             // Anthropic charges per ~750x750 image tile; rough flat approximation.
             ContentPart::Image { .. } => 1600,
+            // ImageRef is the compact form held in long-lived history.
+            // If hydration succeeds at provider-call time, the bytes
+            // count as ~Image; until then it's a hash marker. Estimate
+            // as Image so we don't under-budget when the cache is hot.
+            ContentPart::ImageRef { .. } => 1600,
             ContentPart::ToolUse { name, input, .. } => {
                 estimate_tokens(name) + estimate_tokens(&input.to_string())
             }
@@ -196,6 +201,11 @@ pub async fn generate_summary(
                 }
                 ContentPart::Image { media_type, .. } => {
                     transcript.push_str(&format!("{role_label}: [image: {media_type}]\n\n"));
+                }
+                ContentPart::ImageRef { media_type, sha256 } => {
+                    transcript.push_str(&format!(
+                        "{role_label}: [image: {media_type} sha256={sha256}]\n\n"
+                    ));
                 }
                 ContentPart::ToolUse { name, .. } => {
                     transcript.push_str(&format!("{role_label}: [Called tool: {name}]\n\n"));

--- a/src/image_cache.rs
+++ b/src/image_cache.rs
@@ -1,0 +1,334 @@
+//! Workspace-external cache for inline image bytes.
+//!
+//! `ChatMessage` history is held in memory and persisted to JSONL.
+//! Carrying raw base64 image data through either path is expensive:
+//! megabyte-scale blobs balloon RAM, JSONL size, and per-turn token
+//! estimation. This module stores image bytes outside the workspace,
+//! keyed by SHA-256, and exposes scrub/hydrate helpers so the rest of
+//! the codebase can swap between [`ContentPart::Image`] (full bytes)
+//! and [`ContentPart::ImageRef`] (compact reference) without thinking
+//! about file I/O.
+//!
+//! Design choices:
+//! - **Filename is the sha256 hex**, with no extension. The MIME type
+//!   travels separately on the `ImageRef` itself; the cache file is a
+//!   raw byte blob keyed by content hash.
+//! - **Default location** comes from the platform's standard cache dir
+//!   (`dirs::cache_dir()` → `$XDG_CACHE_HOME/sapphire-agent/images/`
+//!   on Linux, `~/Library/Caches/sapphire-agent/images/` on macOS).
+//!   Overridable via `[image_cache] dir = "..."` in `config.toml`.
+//! - **No eviction yet**: deliberately. The user's stated concern is
+//!   in-memory bloat over long-running sessions, not disk bloat.
+//!   LRU/size-cap eviction is a planned follow-up.
+//! - **Failures don't panic**: cache write errors degrade gracefully —
+//!   the message keeps its `Image` part, which then falls back to the
+//!   `SessionStore::append` text-marker scrub on persist.
+//!
+//! The cache is **content-addressable**: identical bytes from different
+//! sessions share one file on disk.
+
+use anyhow::{Context, Result};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::warn;
+
+use crate::provider::{ChatMessage, ContentPart};
+
+/// Image cache rooted at a single directory. Cheap to clone via `Arc`.
+pub struct ImageCache {
+    dir: PathBuf,
+}
+
+impl ImageCache {
+    /// Create (or open) a cache rooted at `dir`. The directory is
+    /// created if it doesn't exist; missing parents are created too.
+    pub fn open(dir: PathBuf) -> Result<Arc<Self>> {
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating image cache dir {dir:?}"))?;
+        Ok(Arc::new(Self { dir }))
+    }
+
+    /// Platform-standard default location, suitable as a config default.
+    /// Returns `None` when the platform exposes no cache dir (rare —
+    /// effectively only headless edge cases).
+    pub fn default_dir() -> Option<PathBuf> {
+        dirs::cache_dir().map(|d| d.join("sapphire-agent").join("images"))
+    }
+
+    fn path_for(&self, sha256: &str) -> PathBuf {
+        self.dir.join(sha256)
+    }
+
+    /// Write `bytes` to the cache under `sha256`. Content-addressable:
+    /// if a file with the same hash already exists, this is a no-op
+    /// (no rewrite, no error).
+    pub fn put(&self, sha256: &str, bytes: &[u8]) -> Result<()> {
+        let path = self.path_for(sha256);
+        if path.exists() {
+            return Ok(());
+        }
+        std::fs::write(&path, bytes)
+            .with_context(|| format!("writing image cache file {path:?}"))?;
+        Ok(())
+    }
+
+    /// Read raw bytes for `sha256`. Returns `None` on cache miss
+    /// (file absent or unreadable for any reason).
+    pub fn get(&self, sha256: &str) -> Option<Vec<u8>> {
+        std::fs::read(self.path_for(sha256)).ok()
+    }
+}
+
+/// Compute the SHA-256 hex digest of `bytes`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let digest = h.finalize();
+    let mut s = String::with_capacity(64);
+    for b in digest.iter() {
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+/// Convert `ContentPart::Image` parts in `history` to `ImageRef`,
+/// writing the raw bytes to `cache` along the way. In-place mutation —
+/// the caller's history (the canonical in-memory store) shrinks to
+/// hash-only references after the call.
+///
+/// A no-op when `cache` is `None`. A cache write failure on a single
+/// image leaves THAT part as `Image` (with a warning) so the on-disk
+/// scrub fallback still produces a hash marker. Idempotent: existing
+/// `ImageRef` parts are left untouched.
+pub fn scrub_history_inplace(history: &mut [ChatMessage], cache: Option<&ImageCache>) {
+    let Some(cache) = cache else {
+        return;
+    };
+    for msg in history.iter_mut() {
+        for part in msg.parts.iter_mut() {
+            let ContentPart::Image {
+                media_type,
+                data_base64,
+            } = part
+            else {
+                continue;
+            };
+            let bytes = match BASE64_STANDARD.decode(data_base64.as_bytes()) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!("image_cache: skipping scrub for un-decodable base64: {e}");
+                    continue;
+                }
+            };
+            let sha = sha256_hex(&bytes);
+            if let Err(e) = cache.put(&sha, &bytes) {
+                warn!("image_cache: cache write failed (keeping inline bytes): {e}");
+                continue;
+            }
+            *part = ContentPart::ImageRef {
+                media_type: std::mem::take(media_type),
+                sha256: sha,
+            };
+        }
+    }
+}
+
+/// Build a hydrated copy of `history`: every `ImageRef` whose bytes
+/// live in `cache` becomes an `Image` again so the provider call sees
+/// the actual pixels. A cache miss is replaced with a `Text` marker
+/// (`[image: <media_type> sha256=<hex> (cache miss)]`) so the model
+/// retains a stable reference to the image even when the bytes are
+/// gone.
+///
+/// `Image` parts pass through unchanged (an image that arrived this
+/// turn hasn't been scrubbed yet but is already inline). When `cache`
+/// is `None`, every `ImageRef` falls back to the text marker — same
+/// degradation path as a cache miss.
+pub fn hydrate_history(history: &[ChatMessage], cache: Option<&ImageCache>) -> Vec<ChatMessage> {
+    history
+        .iter()
+        .map(|msg| ChatMessage {
+            role: msg.role.clone(),
+            parts: msg
+                .parts
+                .iter()
+                .map(|p| match p {
+                    ContentPart::ImageRef { media_type, sha256 } => {
+                        match cache.and_then(|c| c.get(sha256)) {
+                            Some(bytes) => ContentPart::Image {
+                                media_type: media_type.clone(),
+                                data_base64: BASE64_STANDARD.encode(&bytes),
+                            },
+                            None => ContentPart::Text(format!(
+                                "[image: {media_type} sha256={sha256} (cache miss)]"
+                            )),
+                        }
+                    }
+                    other => other.clone(),
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Role;
+    use tempfile::TempDir;
+
+    fn fake_image() -> Vec<u8> {
+        b"\xff\xd8\xff\xe0fake-jpeg-bytes".to_vec()
+    }
+
+    #[test]
+    fn put_and_get_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        let bytes = fake_image();
+        let sha = sha256_hex(&bytes);
+        cache.put(&sha, &bytes).unwrap();
+        assert_eq!(cache.get(&sha).unwrap(), bytes);
+    }
+
+    #[test]
+    fn put_is_idempotent_on_same_hash() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        let bytes = fake_image();
+        let sha = sha256_hex(&bytes);
+        cache.put(&sha, &bytes).unwrap();
+        cache.put(&sha, &bytes).unwrap();
+        assert_eq!(cache.get(&sha).unwrap(), bytes);
+    }
+
+    #[test]
+    fn get_returns_none_on_miss() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        assert!(cache.get("deadbeef").is_none());
+    }
+
+    #[test]
+    fn scrub_converts_image_to_ref_and_writes_cache() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        let bytes = fake_image();
+        let b64 = BASE64_STANDARD.encode(&bytes);
+        let mut history = vec![ChatMessage::user_with_images(
+            "describe",
+            std::iter::once(("image/jpeg".to_string(), b64.clone())),
+        )];
+
+        scrub_history_inplace(&mut history, Some(&cache));
+
+        let parts = &history[0].parts;
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::ImageRef { sha256, .. } if *sha256 == sha256_hex(&bytes))),
+            "history should contain ImageRef after scrub; got {parts:?}"
+        );
+        assert!(
+            !parts.iter().any(|p| matches!(p, ContentPart::Image { .. })),
+            "history should NOT still contain Image; got {parts:?}"
+        );
+
+        let stored = cache.get(&sha256_hex(&bytes)).expect("cache hit");
+        assert_eq!(stored, bytes);
+    }
+
+    #[test]
+    fn scrub_is_noop_when_cache_disabled() {
+        let bytes = fake_image();
+        let b64 = BASE64_STANDARD.encode(&bytes);
+        let mut history = vec![ChatMessage::user_with_images(
+            "describe",
+            std::iter::once(("image/png".to_string(), b64)),
+        )];
+        scrub_history_inplace(&mut history, None);
+        assert!(
+            history[0]
+                .parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::Image { .. })),
+            "Image should remain when cache is disabled"
+        );
+    }
+
+    #[test]
+    fn hydrate_revives_imageref_when_cache_hit() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        let bytes = fake_image();
+        let sha = sha256_hex(&bytes);
+        cache.put(&sha, &bytes).unwrap();
+
+        let history = vec![ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::ImageRef {
+                media_type: "image/jpeg".to_string(),
+                sha256: sha.clone(),
+            }],
+        }];
+        let hydrated = hydrate_history(&history, Some(&cache));
+        match &hydrated[0].parts[0] {
+            ContentPart::Image {
+                media_type,
+                data_base64,
+            } => {
+                assert_eq!(media_type, "image/jpeg");
+                assert_eq!(BASE64_STANDARD.decode(data_base64).unwrap(), bytes);
+            }
+            other => panic!("expected Image, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hydrate_degrades_to_text_on_cache_miss() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        // Note: cache is empty.
+
+        let history = vec![ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::ImageRef {
+                media_type: "image/jpeg".to_string(),
+                sha256: "missing".to_string(),
+            }],
+        }];
+        let hydrated = hydrate_history(&history, Some(&cache));
+        match &hydrated[0].parts[0] {
+            ContentPart::Text(s) => {
+                assert!(s.contains("cache miss"));
+                assert!(s.contains("image/jpeg"));
+                assert!(s.contains("sha256=missing"));
+            }
+            other => panic!("expected Text marker on miss, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hydrate_leaves_image_parts_alone() {
+        let bytes = fake_image();
+        let b64 = BASE64_STANDARD.encode(&bytes);
+        let history = vec![ChatMessage::user_with_images(
+            "now",
+            std::iter::once(("image/png".to_string(), b64.clone())),
+        )];
+        let hydrated = hydrate_history(&history, None);
+        match &hydrated[0].parts[0] {
+            ContentPart::Image {
+                media_type,
+                data_base64,
+            } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data_base64, &b64);
+            }
+            other => panic!("expected unchanged Image, got {other:?}"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod context_compression;
 mod frontmatter;
 mod heartbeat;
 mod heartbeat_config;
+mod image_cache;
 mod mcp_client;
 mod memory_compaction;
 mod periodic_log;
@@ -348,6 +349,42 @@ async fn main() -> Result<()> {
                         .map_err(|e| anyhow::anyhow!("voice provider init panicked: {e}"))??;
                 Some(Arc::new(providers))
             };
+            // ── Image cache (workspace-external) ──────────────────────────
+            // Resolves once at startup. A missing platform cache dir
+            // (rare; effectively only headless edge cases) or a config
+            // explicitly disabling the cache yields `None`, which makes
+            // the scrub / hydrate helpers no-op and persistence falls
+            // back to the SHA-256 text marker in SessionStore::append.
+            let image_cache: Option<Arc<image_cache::ImageCache>> = if config.image_cache.enabled {
+                let resolved = config
+                    .image_cache
+                    .dir
+                    .clone()
+                    .or_else(image_cache::ImageCache::default_dir);
+                match resolved {
+                    Some(dir) => match image_cache::ImageCache::open(dir.clone()) {
+                        Ok(cache) => {
+                            tracing::info!("Image cache opened at {dir:?}");
+                            Some(cache)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Image cache open failed ({e:?}); falling back to text-marker only"
+                            );
+                            None
+                        }
+                    },
+                    None => {
+                        tracing::warn!(
+                            "No platform cache dir resolvable; image cache disabled (set [image_cache] dir = \"...\" to override)"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
             let serve_state = Arc::new(serve::ServeState::new(
                 config.clone(),
                 Arc::clone(&registry),
@@ -356,6 +393,7 @@ async fn main() -> Result<()> {
                 Arc::clone(&api_session_store),
                 Arc::clone(&mcp_session_store),
                 voice_providers,
+                image_cache.clone(),
             ));
 
             if config.standby_mode {
@@ -476,6 +514,7 @@ async fn main() -> Result<()> {
                     Arc::clone(&workspace),
                     Some(Arc::clone(&tool_set)),
                     Arc::clone(&channel_session_store),
+                    image_cache.clone(),
                 ));
                 agent.bootstrap().await;
 

--- a/src/provider/anthropic.rs
+++ b/src/provider/anthropic.rs
@@ -276,6 +276,13 @@ fn chat_message_to_api(msg: &ChatMessage) -> ApiMessage {
                     data: data_base64.clone(),
                 },
             },
+            // ImageRef reaches this provider only when the image cache
+            // missed at re-hydration time. Surface it as a text marker
+            // so the model still has the hash for context-window
+            // references like "the picture above".
+            ContentPart::ImageRef { media_type, sha256 } => ApiPart::Text {
+                text: format!("[image: {media_type} sha256={sha256} (cache miss)]"),
+            },
             ContentPart::ToolUse { id, name, input } => ApiPart::ToolUse {
                 id: id.clone(),
                 name: name.clone(),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -44,9 +44,22 @@ pub enum Role {
 pub enum ContentPart {
     Text(String),
     /// Inline image, base64-encoded. `media_type` is the MIME type (e.g. `image/png`).
+    /// Carries the actual bytes; appears in in-flight `ChatMessage`s sent to a
+    /// provider. Persisted forms swap this for [`ContentPart::ImageRef`] (when
+    /// the image cache is enabled) to keep JSONL and long-lived in-memory
+    /// history small.
     Image {
         media_type: String,
         data_base64: String,
+    },
+    /// Reference to an image stored in the workspace-external image cache.
+    /// Persisted to JSONL as the canonical compact image representation
+    /// and held in long-lived in-memory history. Re-hydrated to
+    /// [`ContentPart::Image`] just before each provider call when the
+    /// cache still has the bytes; a cache miss degrades to a text marker.
+    ImageRef {
+        media_type: String,
+        sha256: String,
     },
     ToolUse {
         id: String,

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -230,6 +230,13 @@ fn convert_user_message(msg: &ChatMessage) -> Vec<ApiMessage> {
                     url: format!("data:{media_type};base64,{data_base64}"),
                 },
             }),
+            // ImageRef reaches this provider only when the image cache
+            // missed at re-hydration time. Surface it as a text marker
+            // so the model still has the hash for context-window
+            // references like "the picture above".
+            ContentPart::ImageRef { media_type, sha256 } => text_parts.push(ApiPart::Text {
+                text: format!("[image: {media_type} sha256={sha256} (cache miss)]"),
+            }),
             ContentPart::ToolResult {
                 tool_use_id,
                 content,
@@ -289,7 +296,9 @@ fn convert_assistant_message(msg: &ChatMessage) -> ApiMessage {
                 });
             }
             // Assistant should not carry images or tool results.
-            ContentPart::Image { .. } | ContentPart::ToolResult { .. } => {}
+            ContentPart::Image { .. }
+            | ContentPart::ImageRef { .. }
+            | ContentPart::ToolResult { .. } => {}
         }
     }
 

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -98,6 +98,12 @@ pub struct ServeState {
     /// `[tts_provider.*]` blocks are configured — in that case the
     /// `voice/pipeline_run` method returns a method-not-available error.
     pub(crate) voice: Option<Arc<VoiceProviders>>,
+    /// Workspace-external image cache. `None` when the operator set
+    /// `[image_cache] enabled = false`, when cache directory resolution
+    /// failed at startup, or when `dirs::cache_dir()` returned `None`
+    /// (rare). Absent → no in-memory scrub; on-disk persistence still
+    /// gets the hash-marker fallback from `SessionStore::append`.
+    pub(crate) image_cache: Option<Arc<crate::image_cache::ImageCache>>,
     /// Active satellites, keyed by `(device_id, room_profile)`. Inserted
     /// by `voice/subscribe`, removed by the per-subscription writer task
     /// when its SSE channel closes (i.e. satellite disconnects).
@@ -109,6 +115,7 @@ impl ServeState {
     /// the in-process channel handlers (Discord voice in particular).
     /// Shared across both so they read from the same session store /
     /// in-memory conversation map.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Config,
         registry: Arc<ProviderRegistry>,
@@ -117,6 +124,7 @@ impl ServeState {
         api_session_store: Arc<SessionStore>,
         mcp_session_store: Arc<SessionStore>,
         voice: Option<Arc<VoiceProviders>>,
+        image_cache: Option<Arc<crate::image_cache::ImageCache>>,
     ) -> Self {
         // Scan once on startup: each MCP session's first-line meta
         // carries `namespace` + `project`, so this reproduces the
@@ -149,6 +157,7 @@ impl ServeState {
             session_room_metadata: tokio::sync::Mutex::new(HashMap::new()),
             voice,
             voice_subscribers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            image_cache,
         }
     }
 
@@ -662,6 +671,11 @@ async fn handle_get_session(
                     ContentPart::Image { media_type, .. } => {
                         // Image bytes are not exposed via the API listing; surface a marker only.
                         json!({ "type": "image", "media_type": media_type })
+                    }
+                    ContentPart::ImageRef { media_type, sha256 } => {
+                        // Same shape as Image, with the cache key surfaced so
+                        // a caller can later fetch the bytes out of band.
+                        json!({ "type": "image", "media_type": media_type, "sha256": sha256 })
                     }
                     ContentPart::ToolUse { id, name, input } => {
                         json!({ "type": "tool_use", "id": id, "name": name, "input": input })
@@ -1618,8 +1632,15 @@ async fn run_llm_turn(
             }
         }
 
+        // Hydrate `ImageRef` parts from the image cache into full
+        // `Image` parts for the provider call. `Image` parts (just
+        // arrived this turn) and Text/Tool parts pass through. Cache
+        // misses degrade to text markers carrying the hash so the
+        // model still has a stable reference to the image.
+        let history_for_provider =
+            crate::image_cache::hydrate_history(&history, state.image_cache.as_deref());
         let response = provider
-            .chat(system.as_deref(), &history, Some(&tool_specs))
+            .chat(system.as_deref(), &history_for_provider, Some(&tool_specs))
             .await;
 
         match response {
@@ -1696,6 +1717,12 @@ async fn run_llm_turn(
             }
         }
     };
+
+    // Scrub `Image` parts in the just-completed history into compact
+    // `ImageRef` references backed by the workspace-external image
+    // cache. After this, long-lived in-memory storage is hash-only;
+    // the next turn re-hydrates from cache for the provider call.
+    crate::image_cache::scrub_history_inplace(&mut history, state.image_cache.as_deref());
 
     // Update in-memory sessions map
     state

--- a/src/session.rs
+++ b/src/session.rs
@@ -1102,4 +1102,21 @@ mod tests {
             .any(|p| matches!(p, ContentPart::Text(s) if s.contains("invalid-base64")));
         assert!(has_marker, "expected invalid-base64 marker");
     }
+
+    #[test]
+    fn scrub_passes_imageref_through_unchanged() {
+        let msg = ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::ImageRef {
+                media_type: "image/jpeg".to_string(),
+                sha256: "abc123".to_string(),
+            }],
+        };
+        // ImageRef carries no raw bytes — nothing to scrub, so the
+        // helper returns None and append serializes the variant as-is.
+        assert!(
+            scrub_images_for_storage(&msg).is_none(),
+            "scrub should leave ImageRef-only messages untouched"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #108. Follow-up to #93 / PR #107. Replaces the PR1 shape (raw base64 in memory, hash text-marker on disk) with a **content-addressed image cache** outside the workspace, so long-running sessions don't bloat RAM and reloaded JSONL stays small.

### Pipeline

1. **Ingress** (A2A `FilePart`, Matrix / Discord attachments) → `ContentPart::Image` (full base64) in current-turn history.
2. **`provider.chat()`** is called with a **hydrated** copy of history: `ImageRef` + cache hit → `Image`; miss → text marker `[image: <mt> sha256=<hex> (cache miss)]`.
3. **End of turn** — `scrub_history_inplace` writes each `Image`'s bytes to `<cache_dir>/<sha256>` and rewrites the part as `ContentPart::ImageRef`. Long-lived in-memory history and the next `SessionStore::append` write only see the compact ref.

Memory growth in a long session collapses from `N × image_bytes` to roughly `images_per_turn × image_bytes` (transient, only while the provider call is in flight).

## Configuration

```toml
[image_cache]
enabled = true                                  # default
# dir = "/custom/path"                          # default: $XDG_CACHE_HOME/sapphire-agent/images/ (or platform equivalent)
```

`enabled = false` falls back to the PR1 shape (Image in memory, text-marker on disk). A failed cache write or missing platform cache dir degrades to the same fallback.

## Files

- **New** `src/image_cache.rs` — `ImageCache` + `scrub_history_inplace` + `hydrate_history` + `sha256_hex`. 7 unit tests.
- `src/provider/mod.rs` — `ContentPart::ImageRef { media_type, sha256 }` variant.
- `src/provider/anthropic.rs`, `src/provider/openai_compatible.rs` — render `ImageRef` as a cache-miss text marker on the wire (defensive: this path only fires when re-hydration missed).
- `src/context_compression.rs` — token estimate + transcript handle `ImageRef`.
- `src/session.rs` — PR1 scrub leaves `ImageRef` untouched (test added).
- `src/serve/mod.rs` — `ServeState` carries `Option<Arc<ImageCache>>`; `run_llm_turn` hydrates before each `provider.chat` and scrubs after the loop.
- `src/agent.rs` — `Agent` carries `Option<Arc<ImageCache>>`; same hydrate + scrub hooks around its tool loop.
- `src/main.rs` — opens the cache from config (or `dirs::cache_dir()` fallback) and feeds both `ServeState` and `Agent`.
- `src/config.rs` — `ImageCacheConfig { enabled, dir }` with `Default`.
- `Cargo.toml` — `dirs = "6"` direct dep (was transitive).

## Test plan

- [x] `cargo test --bin sapphire-agent` — 137 passed (9 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] Live A2A session: send N image turns, confirm `du -sh <cache_dir>` grows by `unique_image_bytes`, `ls <sessions_dir>/.../foo.jsonl` stays small, RAM stays flat
- [ ] Cross-restart: kill the process mid-session, restart, confirm referring to an earlier image still works (cache hit on disk)
- [ ] Cache miss path: delete `<cache_dir>/<sha>`, reference the image in a follow-up turn, confirm the model gets the `(cache miss)` marker and doesn't crash

## Out of scope

- **Eviction** (LRU, size cap) — stated concern was in-memory bloat, not disk. Tracker TODO in `image_cache.rs`.
- **Migration of pre-PR2 sessions** — JSONL hash-marker text from PR1 sessions remains valid plain text; new sessions write `ImageRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)