### PR TITLE
feat(timer): single-slot in-memory timer + Pomodoro presets

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -303,3 +303,32 @@ system_prompt = "You are a helpful personal assistant."
 # # satellite fetches the bytes via voice/config and caches by SHA-256.
 # [voice]
 # wake_word_model = "/srv/sapphire/wake-models/saphina-v1.onnx"
+
+# ── Timer / Pomodoro presets ────────────────────────────────────────
+# Single-shot timers ("5分後に教えて") don't need configuration — the
+# `timer_set` tool takes minutes + label directly. Presets are for
+# multi-step routines like Pomodoro so the user can say "ポモドーロ開始"
+# instead of redictating "25分集中 + 5分休憩を3回" every time.
+#
+# Only ONE timer (single-shot or preset) can be active per process;
+# starting a new one cancels the previous. Timers are in-memory and
+# reset on restart. When a timer fires the agent is re-invoked to send
+# a notification on the same channel it was set from — voice → voice,
+# chat → chat, no cross-fallback.
+
+[[timer.preset]]
+name   = "pomodoro"
+cycles = 4
+steps  = [
+  { label = "Focus", minutes = 25 },
+  { label = "Break", minutes = 5 },
+]
+
+# Example: a long-form variant for deep work.
+# [[timer.preset]]
+# name   = "deep_work"
+# cycles = 2
+# steps  = [
+#   { label = "Focus",      minutes = 50 },
+#   { label = "Break",      minutes = 10 },
+# ]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -911,17 +911,24 @@ impl Agent {
                         .config
                         .namespace_for_room(&incoming.room_id)
                         .to_string();
+                    let room_id_for_timer = incoming.room_id.clone();
                     let mut handles = Vec::with_capacity(tool_calls.len());
                     for call in tool_calls {
                         let tools = Arc::clone(&tools);
                         let ns = ns.clone();
+                        let origin = crate::timer::TimerOrigin::Chat {
+                            room_id: room_id_for_timer.clone(),
+                        };
                         handles.push(tokio::spawn(
-                            crate::tools::workspace_tools::scope_memory_namespace(ns, async move {
-                                info!("Executing tool: {} (id={})", call.name, call.id);
-                                let result = tools.execute(&call).await;
-                                info!("Tool {} result: {}", call.name, result);
-                                (call.id, result)
-                            }),
+                            crate::tools::workspace_tools::scope_memory_namespace(
+                                ns,
+                                crate::timer::scope_timer_origin(origin, async move {
+                                    info!("Executing tool: {} (id={})", call.name, call.id);
+                                    let result = tools.execute(&call).await;
+                                    info!("Tool {} result: {}", call.name, result);
+                                    (call.id, result)
+                                }),
+                            ),
                         ));
                     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,12 @@ pub struct Config {
     /// satellite regardless of which room_profile they connect to.
     #[serde(default)]
     pub voice: VoiceConfig,
+    /// Timer / Pomodoro presets. Single-slot in-memory timers fired from
+    /// the `timer_*` tools — Pomodoro cycles drop into [[timer.preset]]
+    /// blocks so the user can say "ポモドーロ開始" instead of redeclaring
+    /// "25分集中 + 5分休憩を3回" every time.
+    #[serde(default)]
+    pub timer: TimerConfig,
 }
 
 fn default_true() -> bool {
@@ -797,6 +803,41 @@ fn default_preserve_recent() -> usize {
 // ---------------------------------------------------------------------------
 // Digest config
 // ---------------------------------------------------------------------------
+
+/// Timer presets (Pomodoro etc.). Each preset names a sequence of
+/// `[label, minutes]` steps and a repeat count. Single-shot timers
+/// don't need a preset — they take `minutes` + `message` directly via
+/// the `timer_set` tool.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TimerConfig {
+    /// Named presets referenced by the `timer_preset` tool.
+    #[serde(default, rename = "preset")]
+    pub presets: Vec<TimerPreset>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TimerPreset {
+    /// Unique preset name (matched case-insensitively against the
+    /// `name` argument of `timer_preset`).
+    pub name: String,
+    /// How many times to repeat the `steps` sequence. Default 1.
+    #[serde(default = "default_timer_cycles")]
+    pub cycles: u32,
+    /// Ordered steps fired once per cycle.
+    pub steps: Vec<TimerStep>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TimerStep {
+    /// Short label surfaced in the fire prompt (e.g. "Focus", "Break").
+    pub label: String,
+    /// Step duration in minutes. Fractional minutes are allowed.
+    pub minutes: f64,
+}
+
+fn default_timer_cycles() -> u32 {
+    1
+}
 
 /// Frontmatter-digest injection & generation config.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod periodic_log;
 mod provider;
 mod serve;
 mod session;
+mod timer;
 mod tools;
 mod voice;
 mod workspace;
@@ -290,11 +291,19 @@ async fn main() -> Result<()> {
                 });
             }
 
+            // ── Timer manager (single-slot, in-memory) ──────────────────────
+            // Built before the tool set so the timer_* tools can hold an
+            // `Arc<TimerManager>`. The agent / serve_state refs are
+            // installed below once those are constructed (Weak both ways).
+            let timer_manager = timer::TimerManager::new();
+
             // ── Tools ───────────────────────────────────────────────────────
             let tool_set = tools::default_tool_set(
                 Arc::clone(&ws_state),
                 config.tools.tavily_api_key.clone(),
                 &config.tools.mcp_servers,
+                Arc::clone(&timer_manager),
+                config.timer.presets.clone(),
             )
             .await;
 
@@ -395,6 +404,9 @@ async fn main() -> Result<()> {
                 voice_providers,
                 image_cache.clone(),
             ));
+            // Wire serve_state into the timer manager so voice-origin
+            // timers can push fire messages back to their satellite.
+            timer_manager.set_serve_state(Arc::downgrade(&serve_state));
 
             if config.standby_mode {
                 tracing::info!(
@@ -517,6 +529,9 @@ async fn main() -> Result<()> {
                     image_cache.clone(),
                 ));
                 agent.bootstrap().await;
+                // Wire the agent into the timer manager so chat-origin
+                // timers fire through `Agent::trigger`.
+                timer_manager.set_agent(Arc::downgrade(&agent));
 
                 // ── Periodic workspace sync + today-digest rebuild ──────
                 // Same cadence drives both: when `periodic_sync` pulls

--- a/src/serve/a2a.rs
+++ b/src/serve/a2a.rs
@@ -296,6 +296,7 @@ async fn handle_send_message(
         user_msg,
         req_id.clone(),
         tx,
+        None,
     )
     .await;
     drop(drain); // sender dropped at end of run_llm_turn, drain returns

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -852,8 +852,18 @@ async fn handle_voice_pipeline_run(
 
     let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(64);
 
+    let device_id_for_timer = device_id.clone();
     tokio::spawn(async move {
-        run_voice_turn(state, session_id, audio_b64, language, req_id, tx).await;
+        run_voice_turn(
+            state,
+            session_id,
+            audio_b64,
+            language,
+            req_id,
+            tx,
+            Some(device_id_for_timer),
+        )
+        .await;
     });
 
     let stream = ReceiverStream::new(rx);
@@ -1007,6 +1017,7 @@ async fn run_voice_turn(
     language: Option<String>,
     req_id: Value,
     tx: mpsc::Sender<Result<Event, Infallible>>,
+    device_id: Option<String>,
 ) {
     use base64::Engine;
 
@@ -1113,7 +1124,7 @@ async fn run_voice_turn(
     .await;
 
     // Hand off to the from-text path for everything past STT.
-    run_voice_turn_from_text_sse(state, session_id, transcript, req_id, tx).await;
+    run_voice_turn_from_text_sse(state, session_id, transcript, req_id, tx, device_id).await;
 }
 
 /// Voice pipeline failure when looking up the per-session config.
@@ -1151,6 +1162,7 @@ async fn run_voice_turn_from_text_sse(
     user_text: String,
     req_id: Value,
     tx: mpsc::Sender<Result<Event, Infallible>>,
+    device_id: Option<String>,
 ) {
     use base64::Engine;
 
@@ -1208,6 +1220,9 @@ async fn run_voice_turn_from_text_sse(
         ChatMessage::user(&user_text),
         req_id.clone(),
         tx.clone(),
+        device_id
+            .clone()
+            .map(|d| crate::timer::TimerOrigin::Voice { device_id: d }),
     )
     .await;
     send(notification_event(
@@ -1418,6 +1433,9 @@ pub(crate) async fn push_voice_text_to_subscriber(
         ChatMessage::user(&user_text),
         Value::Null,
         sink_tx,
+        Some(crate::timer::TimerOrigin::Voice {
+            device_id: device_id.clone(),
+        }),
     )
     .await;
     drain_handle.abort();
@@ -1517,6 +1535,7 @@ async fn run_llm_turn(
     user_msg: ChatMessage,
     req_id: Value,
     tx: mpsc::Sender<Result<Event, Infallible>>,
+    timer_origin: Option<crate::timer::TimerOrigin>,
 ) -> LlmTurnOutcome {
     let send = |evt: Event| {
         let tx = tx.clone();
@@ -1687,17 +1706,28 @@ async fn run_llm_turn(
                 // memory tool writes under `memory/<namespace>/...`.
                 let tools = Arc::clone(&state.tools);
                 let ns = namespace.clone();
+                let timer_origin = timer_origin.clone();
                 let results: Vec<(String, String)> =
                     futures_util::future::join_all(tool_calls.iter().map(|c| {
                         let tools = Arc::clone(&tools);
                         let c = c.clone();
                         let ns = ns.clone();
-                        crate::tools::workspace_tools::scope_memory_namespace(ns, async move {
-                            info!("Executing tool: {} (id={})", c.name, c.id);
-                            let result = tools.execute(&c).await;
-                            info!("Tool {} done", c.name);
-                            (c.id, result)
-                        })
+                        let origin = timer_origin.clone();
+                        async move {
+                            let fut = crate::tools::workspace_tools::scope_memory_namespace(
+                                ns,
+                                async move {
+                                    info!("Executing tool: {} (id={})", c.name, c.id);
+                                    let result = tools.execute(&c).await;
+                                    info!("Tool {} done", c.name);
+                                    (c.id, result)
+                                },
+                            );
+                            match origin {
+                                Some(o) => crate::timer::scope_timer_origin(o, fut).await,
+                                None => fut.await,
+                            }
+                        }
                     }))
                     .await;
 
@@ -1757,6 +1787,7 @@ async fn run_turn(
         ChatMessage::user(&user_message),
         req_id.clone(),
         tx.clone(),
+        None,
     )
     .await;
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,385 @@
+//! Single-slot, in-memory timer & Pomodoro manager.
+//!
+//! The agent supports exactly one active timer per process. Setting a new
+//! timer aborts the previous one (intentional — voice/chat UX makes
+//! multiple parallel timers identified by an ID impractical to manage by
+//! voice). When a timer fires, dispatch routes back to where it was
+//! originally set: chat timer → `Agent::trigger`, voice timer →
+//! `serve::push_voice_text_to_subscriber`. No cross-channel fallback.
+//!
+//! Origin (`TimerOrigin`) is captured at tool-call time via a
+//! `tokio::task_local`. The agent and serve tool loops both wrap each
+//! `tools.execute(...)` invocation with `scope_timer_origin(...)` so the
+//! timer tool reads the originating room or voice device at the moment
+//! it is invoked.
+
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Local};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::config::TimerPreset;
+
+/// Where the timer was set from. Single dispatch target, no fallback.
+#[derive(Debug, Clone)]
+pub enum TimerOrigin {
+    /// Chat channel (Matrix / Discord). Fire path:
+    /// `Agent::trigger(name, prompt, room_id)`.
+    Chat { room_id: String },
+    /// Voice satellite subscribed via `voice/subscribe`. Fire path:
+    /// `serve::push_voice_text_to_subscriber(state, device_id, ...)`.
+    Voice { device_id: String },
+}
+
+tokio::task_local! {
+    static TIMER_ORIGIN_TL: TimerOrigin;
+}
+
+/// Run `fut` with `TIMER_ORIGIN_TL` set to `origin`. Called by the
+/// agent / serve tool-execution loops per turn so the timer tool can
+/// read where the originating message came from.
+pub fn scope_timer_origin<F: std::future::Future>(
+    origin: TimerOrigin,
+    fut: F,
+) -> impl std::future::Future<Output = F::Output> {
+    TIMER_ORIGIN_TL.scope(origin, fut)
+}
+
+/// Read the active origin, when called inside `scope_timer_origin`.
+/// Returns `None` from a turn that wasn't scoped (e.g. background catch-up).
+pub fn current_origin() -> Option<TimerOrigin> {
+    TIMER_ORIGIN_TL.try_with(|o| o.clone()).ok()
+}
+
+/// Snapshot returned by `timer_status` and `timer_cancel`. Describes
+/// the in-flight timer enough for the LLM to phrase a status reply.
+#[derive(Debug, Clone)]
+pub struct TimerSnapshot {
+    pub label: String,
+    pub fires_at: DateTime<Local>,
+    pub kind: TimerKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum TimerKind {
+    Single,
+    Preset {
+        name: String,
+        step_index: usize,
+        total_steps: usize,
+        cycle: u32,
+        total_cycles: u32,
+    },
+}
+
+struct ActiveTimer {
+    handle: JoinHandle<()>,
+    snapshot: TimerSnapshot,
+}
+
+/// Single-slot timer manager. Setting a new timer aborts the previous
+/// one. Lives behind an `Arc` so the tools and the spawned fire tasks
+/// can both reach it.
+pub struct TimerManager {
+    inner: Mutex<Option<ActiveTimer>>,
+    agent: tokio::sync::OnceCell<Weak<crate::agent::Agent>>,
+    serve_state: tokio::sync::OnceCell<Weak<crate::serve::ServeState>>,
+}
+
+impl TimerManager {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(None),
+            agent: tokio::sync::OnceCell::new(),
+            serve_state: tokio::sync::OnceCell::new(),
+        })
+    }
+
+    /// Install the agent ref. Called from `main` after the agent is
+    /// built. Weak to keep the timer/tools graph acyclic.
+    pub fn set_agent(&self, agent: Weak<crate::agent::Agent>) {
+        let _ = self.agent.set(agent);
+    }
+
+    /// Install the serve-state ref. Called from `main` after
+    /// `ServeState` is built.
+    pub fn set_serve_state(&self, state: Weak<crate::serve::ServeState>) {
+        let _ = self.serve_state.set(state);
+    }
+
+    /// Replace the active timer (if any) with a single-shot timer.
+    /// Returns the new snapshot. Origin determines fire dispatch.
+    pub async fn set_single(
+        self: &Arc<Self>,
+        minutes: f64,
+        label: String,
+        origin: TimerOrigin,
+    ) -> Result<TimerSnapshot> {
+        if !minutes.is_finite() || minutes <= 0.0 {
+            anyhow::bail!("minutes must be a positive finite number (got {minutes})");
+        }
+        let duration = Duration::from_secs_f64(minutes * 60.0);
+        let fires_at = Local::now()
+            + chrono::Duration::from_std(duration).context("timer duration overflow")?;
+        let snapshot = TimerSnapshot {
+            label: label.clone(),
+            fires_at,
+            kind: TimerKind::Single,
+        };
+        let me = Arc::clone(self);
+        let origin_for_fire = origin.clone();
+        let label_for_fire = label.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            let prompt = format!(
+                "[Timer] '{label}' ({minutes:.1} min) elapsed. Tell the user the timer is up. Keep it short.",
+                label = label_for_fire,
+                minutes = minutes,
+            );
+            me.dispatch_fire(&label_for_fire, &prompt, &origin_for_fire)
+                .await;
+            // Clear our own slot if we're still the active timer.
+            let mut slot = me.inner.lock().await;
+            if let Some(active) = slot.as_ref()
+                && matches!(active.snapshot.kind, TimerKind::Single)
+                && active.snapshot.label == label_for_fire
+            {
+                *slot = None;
+            }
+        });
+        self.replace_active(ActiveTimer {
+            handle,
+            snapshot: snapshot.clone(),
+        })
+        .await;
+        Ok(snapshot)
+    }
+
+    /// Replace the active timer with a preset run (e.g. Pomodoro).
+    /// Each step fires its own message; on the final step a wrap-up
+    /// message is sent.
+    pub async fn set_preset(
+        self: &Arc<Self>,
+        preset: TimerPreset,
+        cycles_override: Option<u32>,
+        origin: TimerOrigin,
+    ) -> Result<TimerSnapshot> {
+        let cycles = cycles_override.unwrap_or(preset.cycles).max(1);
+        if preset.steps.is_empty() {
+            anyhow::bail!("preset '{}' has no steps", preset.name);
+        }
+        for step in &preset.steps {
+            if !step.minutes.is_finite() || step.minutes <= 0.0 {
+                anyhow::bail!(
+                    "preset '{}' step '{}' has invalid minutes: {}",
+                    preset.name,
+                    step.label,
+                    step.minutes
+                );
+            }
+        }
+        let total_steps = preset.steps.len();
+        let first = &preset.steps[0];
+        let first_dur = Duration::from_secs_f64(first.minutes * 60.0);
+        let fires_at = Local::now()
+            + chrono::Duration::from_std(first_dur).context("preset duration overflow")?;
+        let snapshot = TimerSnapshot {
+            label: first.label.clone(),
+            fires_at,
+            kind: TimerKind::Preset {
+                name: preset.name.clone(),
+                step_index: 0,
+                total_steps,
+                cycle: 1,
+                total_cycles: cycles,
+            },
+        };
+
+        let me = Arc::clone(self);
+        let preset_for_task = preset.clone();
+        let origin_for_task = origin.clone();
+        let handle = tokio::spawn(async move {
+            me.run_preset_loop(preset_for_task, cycles, origin_for_task)
+                .await;
+        });
+        self.replace_active(ActiveTimer {
+            handle,
+            snapshot: snapshot.clone(),
+        })
+        .await;
+        Ok(snapshot)
+    }
+
+    /// Drive the preset state machine. Sleeps for each step, fires
+    /// the per-step message, advances `snapshot`. On final completion
+    /// clears the slot.
+    async fn run_preset_loop(
+        self: Arc<Self>,
+        preset: TimerPreset,
+        cycles: u32,
+        origin: TimerOrigin,
+    ) {
+        let total_steps = preset.steps.len();
+        for cycle in 1..=cycles {
+            for (i, step) in preset.steps.iter().enumerate() {
+                let duration = Duration::from_secs_f64(step.minutes * 60.0);
+                // Update snapshot to reflect what we're currently waiting on.
+                {
+                    let mut slot = self.inner.lock().await;
+                    if let Some(active) = slot.as_mut() {
+                        active.snapshot.label = step.label.clone();
+                        active.snapshot.fires_at = Local::now()
+                            + chrono::Duration::from_std(duration)
+                                .unwrap_or(chrono::Duration::zero());
+                        if let TimerKind::Preset {
+                            step_index,
+                            cycle: c,
+                            ..
+                        } = &mut active.snapshot.kind
+                        {
+                            *step_index = i;
+                            *c = cycle;
+                        }
+                    } else {
+                        // Slot was cleared (cancelled); abort the loop.
+                        return;
+                    }
+                }
+
+                tokio::time::sleep(duration).await;
+
+                let is_last_step =
+                    cycle == cycles && i + 1 == total_steps;
+                let next_label = if is_last_step {
+                    None
+                } else if i + 1 < total_steps {
+                    Some(preset.steps[i + 1].label.clone())
+                } else {
+                    Some(preset.steps[0].label.clone())
+                };
+
+                let prompt = if is_last_step {
+                    format!(
+                        "[Timer: {preset_name}] All {cycles} cycle(s) complete. The final '{label}' step ({minutes:.1} min) just ended. Tell the user the full Pomodoro is finished. Keep it short.",
+                        preset_name = preset.name,
+                        cycles = cycles,
+                        label = step.label,
+                        minutes = step.minutes,
+                    )
+                } else {
+                    format!(
+                        "[Timer: {preset_name}] Step {cur}/{total} of cycle {cycle}/{cycles}: '{label}' ({minutes:.1} min) ended. Next: '{next}'. Tell the user to switch. Keep it short.",
+                        preset_name = preset.name,
+                        cur = i + 1,
+                        total = total_steps,
+                        cycle = cycle,
+                        cycles = cycles,
+                        label = step.label,
+                        minutes = step.minutes,
+                        next = next_label.as_deref().unwrap_or(""),
+                    )
+                };
+                self.dispatch_fire(&step.label, &prompt, &origin).await;
+            }
+        }
+        // Clear slot at the end if still ours.
+        let mut slot = self.inner.lock().await;
+        if let Some(active) = slot.as_ref()
+            && matches!(active.snapshot.kind, TimerKind::Preset { ref name, .. } if name == &preset.name)
+        {
+            *slot = None;
+        }
+    }
+
+    /// Send the fire message to the right channel. Logs and drops on
+    /// failure — no fallback to the other channel.
+    async fn dispatch_fire(&self, task_name: &str, prompt: &str, origin: &TimerOrigin) {
+        match origin {
+            TimerOrigin::Chat { room_id } => match self.agent.get().and_then(Weak::upgrade) {
+                Some(agent) => {
+                    if let Err(e) = agent.trigger(task_name, prompt, room_id).await {
+                        warn!("Timer fire (chat) failed for {task_name} -> {room_id}: {e:#}");
+                    }
+                }
+                None => warn!(
+                    "Timer fire (chat) skipped for {task_name}: agent not wired into TimerManager"
+                ),
+            },
+            TimerOrigin::Voice { device_id } => match self
+                .serve_state
+                .get()
+                .and_then(Weak::upgrade)
+            {
+                Some(state) => {
+                    match crate::serve::push_voice_text_to_subscriber(
+                        state,
+                        device_id.clone(),
+                        Some(task_name.to_string()),
+                        prompt.to_string(),
+                    )
+                    .await
+                    {
+                        Ok(()) => {}
+                        Err(e) => {
+                            let reason = match e {
+                                crate::serve::VoicePushError::Offline => "offline".to_string(),
+                                crate::serve::VoicePushError::NoVoice => "no voice providers".to_string(),
+                                crate::serve::VoicePushError::NotConfigured => {
+                                    "voice_pipeline not configured for room_profile".to_string()
+                                }
+                                crate::serve::VoicePushError::Other(msg) => msg,
+                            };
+                            warn!(
+                                "Timer fire (voice) failed for {task_name} -> device={device_id}: {reason}"
+                            );
+                        }
+                    }
+                }
+                None => warn!(
+                    "Timer fire (voice) skipped for {task_name}: serve_state not wired into TimerManager"
+                ),
+            },
+        }
+    }
+
+    /// Atomically swap in a new active timer; abort the prior one if any.
+    async fn replace_active(&self, new: ActiveTimer) {
+        let mut slot = self.inner.lock().await;
+        if let Some(prev) = slot.take() {
+            info!("Timer: replacing previous timer '{}'", prev.snapshot.label);
+            prev.handle.abort();
+        }
+        *slot = Some(new);
+    }
+
+    /// Cancel the active timer (if any) and return its snapshot.
+    pub async fn cancel(&self) -> Option<TimerSnapshot> {
+        let mut slot = self.inner.lock().await;
+        slot.take().map(|t| {
+            t.handle.abort();
+            t.snapshot
+        })
+    }
+
+    /// Read-only snapshot of the active timer.
+    pub async fn current(&self) -> Option<TimerSnapshot> {
+        self.inner.lock().await.as_ref().map(|t| t.snapshot.clone())
+    }
+}
+
+/// Look up a preset by case-insensitive name match.
+pub fn find_preset<'a>(presets: &'a [TimerPreset], name: &str) -> Result<&'a TimerPreset> {
+    presets
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case(name))
+        .ok_or_else(|| {
+            let known: Vec<&str> = presets.iter().map(|p| p.name.as_str()).collect();
+            anyhow!(
+                "unknown timer preset '{name}'. Known presets: {known:?}"
+            )
+        })
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod builtin_tools;
+pub mod timer_tools;
 pub mod workspace_tools;
 
 use crate::config::McpServerConfig;
@@ -135,12 +136,18 @@ impl ToolSet {
 /// `tavily_api_key`: if provided, the `web_search` tool is included.
 /// `mcp_servers`: external MCP servers whose tools are registered with the
 /// naming convention `mcp__<name>__<tool_name>`.
+/// `timer_manager` + `timer_presets`: drive the `timer_*` tools. Manager
+/// is shared with `main` so the agent/serve fire dispatchers can be
+/// wired in after construction.
 pub async fn default_tool_set(
     state: Arc<Mutex<sapphire_workspace::WorkspaceState>>,
     tavily_api_key: Option<String>,
     mcp_servers: &[McpServerConfig],
+    timer_manager: Arc<crate::timer::TimerManager>,
+    timer_presets: Vec<crate::config::TimerPreset>,
 ) -> Arc<ToolSet> {
     use builtin_tools::*;
+    use timer_tools::*;
     use workspace_tools::*;
 
     let workspace_root = state
@@ -166,6 +173,13 @@ pub async fn default_tool_set(
         Box::new(DirWalkTool::new(Arc::clone(&state))),
         Box::new(ShellTool::new(workspace_root.clone())),
         Box::new(WeatherTool::new()),
+        Box::new(TimerSetTool::new(Arc::clone(&timer_manager))),
+        Box::new(TimerPresetTool::new(
+            Arc::clone(&timer_manager),
+            timer_presets,
+        )),
+        Box::new(TimerCancelTool::new(Arc::clone(&timer_manager))),
+        Box::new(TimerStatusTool::new(Arc::clone(&timer_manager))),
     ];
 
     if let Some(key) = tavily_api_key {

--- a/src/tools/timer_tools.rs
+++ b/src/tools/timer_tools.rs
@@ -1,0 +1,282 @@
+//! Timer & Pomodoro tools.
+//!
+//! Single-slot, in-memory. Setting any new timer cancels the previous
+//! one. Origin (chat room / voice device) is captured from the
+//! `crate::timer::TIMER_ORIGIN_TL` task_local set by the agent/serve
+//! tool-execution loops; tools called outside a scoped turn return an
+//! error rather than guessing.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::config::TimerPreset;
+use crate::provider::ToolSpec;
+use crate::timer::{TimerKind, TimerManager, TimerSnapshot, current_origin, find_preset};
+use crate::tools::Tool;
+
+/// Format a snapshot as a single-line human-readable string for the LLM.
+fn format_snapshot(s: &TimerSnapshot) -> String {
+    let remaining = (s.fires_at - chrono::Local::now()).num_seconds().max(0);
+    let mins = remaining / 60;
+    let secs = remaining % 60;
+    match &s.kind {
+        TimerKind::Single => format!(
+            "Active timer '{}' fires at {} (~{}m{:02}s remaining).",
+            s.label,
+            s.fires_at.format("%H:%M:%S"),
+            mins,
+            secs
+        ),
+        TimerKind::Preset {
+            name,
+            step_index,
+            total_steps,
+            cycle,
+            total_cycles,
+        } => format!(
+            "Active preset '{}' (cycle {}/{}, step {}/{}): waiting on '{}', fires at {} (~{}m{:02}s remaining).",
+            name,
+            cycle,
+            total_cycles,
+            step_index + 1,
+            total_steps,
+            s.label,
+            s.fires_at.format("%H:%M:%S"),
+            mins,
+            secs
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// timer_set
+// ---------------------------------------------------------------------------
+
+pub struct TimerSetTool {
+    manager: Arc<TimerManager>,
+    spec: ToolSpec,
+}
+
+impl TimerSetTool {
+    pub fn new(manager: Arc<TimerManager>) -> Self {
+        Self {
+            manager,
+            spec: ToolSpec {
+                name: "timer_set".into(),
+                description: "Set a single-shot in-memory timer. When it fires, the agent is \
+                    re-invoked to deliver a short notification on the same channel (chat or voice) \
+                    where this tool was called. The process supports ONE active timer at a time — \
+                    calling this with another timer already active cancels the previous one. Use \
+                    'timer_preset' for Pomodoro-style multi-step routines."
+                    .into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "minutes": {
+                            "type": "number",
+                            "description": "Duration in minutes (fractional allowed, e.g. 0.5 = 30 seconds).",
+                            "exclusiveMinimum": 0
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Short label describing what this timer is for (e.g. 'tea steep', 'meeting in 5'). Surfaced in the fire message.",
+                            "default": "timer"
+                        }
+                    },
+                    "required": ["minutes"]
+                }),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for TimerSetTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, input: &serde_json::Value) -> Result<String> {
+        let minutes = input["minutes"]
+            .as_f64()
+            .context("'minutes' must be a number")?;
+        let label = input["label"]
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| "timer".to_string());
+        let origin = current_origin().ok_or_else(|| {
+            anyhow!("timer_set can only be called from a chat or voice turn")
+        })?;
+        let snap = self
+            .manager
+            .set_single(minutes, label.clone(), origin)
+            .await?;
+        Ok(format!(
+            "Timer set: '{}' will fire at {} (in {:.1} min).",
+            label,
+            snap.fires_at.format("%H:%M:%S"),
+            minutes
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// timer_preset
+// ---------------------------------------------------------------------------
+
+pub struct TimerPresetTool {
+    manager: Arc<TimerManager>,
+    presets: Vec<TimerPreset>,
+    spec: ToolSpec,
+}
+
+impl TimerPresetTool {
+    pub fn new(manager: Arc<TimerManager>, presets: Vec<TimerPreset>) -> Self {
+        let names: Vec<&str> = presets.iter().map(|p| p.name.as_str()).collect();
+        let description = format!(
+            "Start a configured timer preset (Pomodoro-style work/break cycles). The preset's \
+             ordered steps fire one by one and the cycle repeats `cycles` times. Cancels any \
+             active timer. Configured presets: {names:?}. Use 'timer_set' for simple one-shot timers."
+        );
+        Self {
+            manager,
+            presets,
+            spec: ToolSpec {
+                name: "timer_preset".into(),
+                description: description.into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Preset name (case-insensitive). Must match one of the configured [[timer.preset]] entries."
+                        },
+                        "cycles": {
+                            "type": "integer",
+                            "description": "Override the preset's default cycle count. Optional.",
+                            "minimum": 1
+                        }
+                    },
+                    "required": ["name"]
+                }),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for TimerPresetTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, input: &serde_json::Value) -> Result<String> {
+        let name = input["name"].as_str().context("missing 'name'")?;
+        let cycles_override = input["cycles"].as_u64().map(|n| n as u32);
+        let preset = find_preset(&self.presets, name)?.clone();
+        let origin = current_origin().ok_or_else(|| {
+            anyhow!("timer_preset can only be called from a chat or voice turn")
+        })?;
+        let snap = self
+            .manager
+            .set_preset(preset.clone(), cycles_override, origin)
+            .await?;
+        let total_cycles = cycles_override.unwrap_or(preset.cycles).max(1);
+        let total_min: f64 = preset.steps.iter().map(|s| s.minutes).sum::<f64>()
+            * total_cycles as f64;
+        Ok(format!(
+            "Preset '{}' started: {} cycle(s) of {} step(s) (~{:.1} min total). First step '{}' fires at {}.",
+            preset.name,
+            total_cycles,
+            preset.steps.len(),
+            total_min,
+            snap.label,
+            snap.fires_at.format("%H:%M:%S")
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// timer_cancel
+// ---------------------------------------------------------------------------
+
+pub struct TimerCancelTool {
+    manager: Arc<TimerManager>,
+    spec: ToolSpec,
+}
+
+impl TimerCancelTool {
+    pub fn new(manager: Arc<TimerManager>) -> Self {
+        Self {
+            manager,
+            spec: ToolSpec {
+                name: "timer_cancel".into(),
+                description: "Cancel the active timer (single-shot or preset). No-op if no timer \
+                    is running."
+                    .into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for TimerCancelTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, _input: &serde_json::Value) -> Result<String> {
+        match self.manager.cancel().await {
+            Some(snap) => Ok(format!("Cancelled timer: '{}'.", snap.label)),
+            None => Ok("No timer was active.".to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// timer_status
+// ---------------------------------------------------------------------------
+
+pub struct TimerStatusTool {
+    manager: Arc<TimerManager>,
+    spec: ToolSpec,
+}
+
+impl TimerStatusTool {
+    pub fn new(manager: Arc<TimerManager>) -> Self {
+        Self {
+            manager,
+            spec: ToolSpec {
+                name: "timer_status".into(),
+                description: "Report the currently active timer (label, kind, time remaining), \
+                    or that none is set."
+                    .into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for TimerStatusTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, _input: &serde_json::Value) -> Result<String> {
+        match self.manager.current().await {
+            Some(snap) => Ok(format_snapshot(&snap)),
+            None => Ok("No timer is currently set.".to_string()),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `timer_set` / `timer_preset` / `timer_cancel` / `timer_status` tools backed by an in-memory single-slot `TimerManager` — new timer cancels the previous one (intentional; voice UX makes ID-based parallel timers impractical).
- Fire dispatch routes to the originating channel: chat-set → `Agent::trigger`, voice-set → `serve::push_voice_text_to_subscriber`. No cross-channel fallback. Origin captured via `tokio::task_local` per turn.
- `[[timer.preset]]` config defines named multi-step routines (Pomodoro etc.); the configured names are surfaced in the tool description so the LLM can fuzzy-match utterances like 「ポモドーロ開始」.

## Design notes
- **Single slot, not a list**: setting a new timer aborts the previous. Cancellation needs no ID (`timer_cancel` just clears the slot).
- **Origin separation**: `TimerOrigin::Chat { room_id }` vs `TimerOrigin::Voice { device_id }` — captured at tool-call time, used only at fire time to pick the dispatch path. No fallback because the only "fallback target" config (`heartbeat`-style `room_id`) doesn't make sense for ad-hoc user-initiated timers.
- **Presets are named**: case-insensitive match; the LLM sees the list of configured names in the tool spec and fuzzy-matches user phrasing. Cycles can be overridden per call (`cycles_override`).
- **Tools require an origin**: api/chat (pull-based session) returns an error if asked to set a timer — there's nowhere to push the fire to.

## Test plan
- [x] `cargo check`
- [x] `cargo build --all-targets`
- [x] `cargo test --bin sapphire-agent` (137/137 pass)
- [ ] Manual: set a 30-second timer in a Matrix room, confirm fire arrives
- [ ] Manual: set a Pomodoro preset via voice satellite, confirm each step fires via voice
- [ ] Manual: set chat timer, then set voice timer — confirm chat timer is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)