### PR TITLE
feat(call): bearer-token auth for /rpc, drop room_profile knob

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/sapphire-agent-api", "crates/sapphire-call"]
 
 [workspace.dependencies]
 anyhow = "1.0"
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.6", features = ["derive", "env"] }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,7 +46,7 @@ cargo run --bin sapphire-agent -- \
 Terminal B (satellite, microphone + speaker required):
 
 ```sh
-cargo run --bin sapphire-call -- voice --room-profile voice_test
+cargo run --bin sapphire-call -- voice --token "<voice_test api_key>"
 ```
 
 The first satellite run downloads the Silero VAD ONNX (~2 MB) to
@@ -132,7 +132,7 @@ Terminal B (satellite):
 
 ```sh
 cargo run --release --bin sapphire-call -- voice \
-    --room-profile voice_irodori --language ja
+    --token "<voice_irodori api_key>" --language ja
 ```
 
 First boot auto-downloads Silero VAD (~2 MB) to
@@ -190,7 +190,7 @@ release to `~/.local/share/sapphire-call/voice-models/oww/`):
 
 ```sh
 cargo run --release --bin sapphire-call -- voice \
-    --room-profile voice_irodori
+    --token "<voice_irodori api_key>"
 ```
 
 The display label printed on wake-fire is derived from the ONNX
@@ -234,13 +234,13 @@ override with `--config <path>`). See
 
 ```toml
 [server]
-url          = "https://agent.example.com"
-room_profile = "home_voice"
+url   = "https://agent.example.com"
+token = "sa-call-<long random>"  # must match an api_keys entry on the agent
 ```
 
-CLI flags override config-file values. Wake-word fields are
-deliberately rejected here — server side is the source of truth
-(see §3).
+CLI flags override config-file values; `SAPPHIRE_AGENT_TOKEN` works
+too. Wake-word fields are deliberately rejected here — server side is
+the source of truth (see §3).
 
 ---
 
@@ -265,7 +265,7 @@ them verbatim into the selection flags.
 sapphire-call voice \
     --input-device  "Jabra SPEAK 510 USB"  \
     --output-device "Jabra SPEAK 510 USB"  \
-    --language ja --room-profile voice_irodori
+    --language ja --token "<voice_irodori api_key>"
 ```
 
 The system "default" rarely points at a USB speakerphone — it

--- a/config.example.toml
+++ b/config.example.toml
@@ -143,8 +143,11 @@ system_prompt = "You are a helpful personal assistant."
 # if defined, otherwise the built-in defaults (Anthropic provider,
 # `default` namespace, global session_policy).
 #
-# API sessions pin a room profile at `initialize` time via the
-# `room_profile` parameter (sapphire-call: `--room-profile <name>`).
+# API sessions pin a room profile via the bearer token sent in
+# `Authorization: Bearer <token>` on every `/rpc` request — the token
+# must appear in some `[room_profile.<n>].api_keys` below, same
+# mechanism MCP and A2A use (sapphire-call: `[server].token` or
+# `--token <TOKEN>`).
 #
 # [room_profile.everyday]
 # profile          = "default"
@@ -163,13 +166,13 @@ system_prompt = "You are a helpful personal assistant."
 # session_policy   = "compact"
 # rooms            = ["!nsfw:example.com"]
 #
-# A2A (Agent2Agent Protocol) and MCP clients reach a room_profile
-# through bearer tokens declared here. Each token must be unique across
-# all room profiles — startup fails if two profiles share one — and an
-# incoming `Authorization: Bearer <token>` resolves implicitly to the
-# owning profile, so external clients never name room_profile
-# themselves. Leave `api_keys = []` (or omit) to deny external access
-# to a profile.
+# /rpc (sapphire-call), A2A (Agent2Agent Protocol), and MCP clients all
+# reach a room_profile through bearer tokens declared here. Each token
+# must be unique across all room profiles — startup fails if two
+# profiles share one — and an incoming `Authorization: Bearer <token>`
+# resolves implicitly to the owning profile, so external clients never
+# name room_profile themselves. Leave `api_keys = []` (or omit) to
+# deny external access to a profile.
 #
 # [room_profile.sapphire_world]
 # profile          = "default"

--- a/crates/sapphire-agent-api/src/lib.rs
+++ b/crates/sapphire-agent-api/src/lib.rs
@@ -57,14 +57,19 @@ impl DeviceMetadata {
 /// `Session-Id` header), the human-readable display id, and whether
 /// the session is brand-new. Exposed so out-of-tree clients (e.g. the
 /// voice satellite) can reuse the same session-setup flow as the REPL.
+///
+/// `token` is sent as `Authorization: Bearer <token>` and selects the
+/// room_profile server-side (the token must match an `api_keys` entry
+/// on some `[room_profile.<n>]`). The control API requires this on
+/// every `/rpc` call — there is no anonymous mode.
 pub async fn initialize(
     client: &reqwest::Client,
     base: &str,
     session: Option<String>,
-    room_profile: Option<&str>,
+    token: &str,
     device: Option<&DeviceMetadata>,
 ) -> Result<(String, String, bool)> {
-    initialize_session(client, base, session, room_profile, device).await
+    initialize_session(client, base, session, token, device).await
 }
 
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -107,7 +112,10 @@ fn next_id() -> u64 {
 /// Run the interactive call client.
 ///
 /// This is the shared entry point used by both `sapphire-agent call` and
-/// the standalone `sapphire-call` binary.
+/// the standalone `sapphire-call` binary. `token` is forwarded as
+/// `Authorization: Bearer <token>` on every `/rpc` call — its match
+/// against `[room_profile.<n>].api_keys` server-side is what pins the
+/// session to a profile (no more `--room-profile`).
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     server: String,
@@ -116,7 +124,7 @@ pub async fn run(
     message: Option<String>,
     history: bool,
     json: bool,
-    room_profile: Option<String>,
+    token: String,
     device: Option<DeviceMetadata>,
 ) -> Result<()> {
     let base = server.trim_end_matches('/').to_string();
@@ -125,24 +133,18 @@ pub async fn run(
     // -- --list mode ----------------------------------------------------------
     if list {
         let (session_id, _, _) =
-            initialize_session(&client, &base, session, None, device.as_ref()).await?;
-        list_sessions(&client, &base, &session_id, json).await?;
+            initialize_session(&client, &base, session, &token, device.as_ref()).await?;
+        list_sessions(&client, &base, &token, &session_id, json).await?;
         return Ok(());
     }
 
     // -- Initialize session ---------------------------------------------------
-    let (mut session_id, display_id, is_new) = initialize_session(
-        &client,
-        &base,
-        session,
-        room_profile.as_deref(),
-        device.as_ref(),
-    )
-    .await?;
+    let (mut session_id, display_id, is_new) =
+        initialize_session(&client, &base, session, &token, device.as_ref()).await?;
 
     // -- --history dump-only mode ---------------------------------------------
     if history {
-        dump_history(&client, &base, &session_id, json, true).await?;
+        dump_history(&client, &base, &token, &session_id, json, true).await?;
         return Ok(());
     }
 
@@ -152,7 +154,7 @@ pub async fn run(
         if trimmed.is_empty() {
             anyhow::bail!("--message requires non-empty text");
         }
-        send_chat(&client, &base, &session_id, trimmed, json).await?;
+        send_chat(&client, &base, &token, &session_id, trimmed, json).await?;
         if !json {
             println!();
         }
@@ -165,7 +167,7 @@ pub async fn run(
     println!("sapphire-agent call  (session: {display_id})");
     if !is_new {
         println!("[resumed existing session]\n");
-        if let Err(e) = dump_history(&client, &base, &session_id, false, false).await {
+        if let Err(e) = dump_history(&client, &base, &token, &session_id, false, false).await {
             eprintln!("[warning: failed to load history: {e:#}]");
         }
     }
@@ -194,15 +196,7 @@ pub async fn run(
                 continue;
             }
             "/clear" => {
-                match initialize_session(
-                    &client,
-                    &base,
-                    None,
-                    room_profile.as_deref(),
-                    device.as_ref(),
-                )
-                .await
-                {
+                match initialize_session(&client, &base, None, &token, device.as_ref()).await {
                     Ok((new_sid, new_display_id, _)) => {
                         session_id = new_sid;
                         println!("[new session: {new_display_id}]");
@@ -215,7 +209,7 @@ pub async fn run(
             _ => {}
         }
 
-        if let Err(e) = send_chat(&client, &base, &session_id, trimmed, false).await {
+        if let Err(e) = send_chat(&client, &base, &token, &session_id, trimmed, false).await {
             eprintln!("[error: {e:#}]");
         }
         println!();
@@ -232,14 +226,11 @@ async fn initialize_session(
     client: &reqwest::Client,
     base: &str,
     session: Option<String>,
-    room_profile: Option<&str>,
+    token: &str,
     device: Option<&DeviceMetadata>,
 ) -> Result<(String, String, bool)> {
     let session_id_req = session.as_deref().unwrap_or("new");
     let mut params = json!({ "session_id": session_id_req });
-    if let Some(p) = room_profile {
-        params["room_profile"] = json!(p);
-    }
     if let Some(d) = device.and_then(DeviceMetadata::to_params) {
         params["device"] = d;
     }
@@ -252,6 +243,7 @@ async fn initialize_session(
 
     let resp = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .json(&body)
         .send()
         .await
@@ -289,6 +281,7 @@ async fn initialize_session(
 async fn dump_history(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     session_id: &str,
     json_mode: bool,
     standalone: bool,
@@ -302,6 +295,7 @@ async fn dump_history(
 
     let val: Value = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .header("session-id", session_id)
         .json(&body)
         .send()
@@ -373,6 +367,7 @@ async fn dump_history(
 async fn list_sessions(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     session_id: &str,
     json_mode: bool,
 ) -> Result<()> {
@@ -385,6 +380,7 @@ async fn list_sessions(
 
     let val: Value = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .header("session-id", session_id)
         .json(&body)
         .send()
@@ -427,6 +423,7 @@ async fn list_sessions(
 async fn send_chat(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     session_id: &str,
     content: &str,
     json_mode: bool,
@@ -441,6 +438,7 @@ async fn send_chat(
 
     let resp = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .header("session-id", session_id)
         .header("accept", "text/event-stream")
         .json(&body)

--- a/crates/sapphire-agent-api/src/voice.rs
+++ b/crates/sapphire-agent-api/src/voice.rs
@@ -55,10 +55,14 @@ pub struct WakeWordModel {
 /// Fetch the server's global wake-word configuration. Returns an
 /// empty `WakeWordConfig` when `[voice].wake_word_model` is unset.
 ///
-/// No session token needed — wake-word config is the same for every
-/// satellite regardless of room_profile, so this is a stateless
-/// GET-like call.
-pub async fn voice_config(client: &reqwest::Client, base: &str) -> Result<WakeWordConfig> {
+/// `token` is sent as `Authorization: Bearer <token>` — the `/rpc`
+/// endpoint is uniformly authenticated, so even this stateless lookup
+/// requires the satellite's bearer.
+pub async fn voice_config(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+) -> Result<WakeWordConfig> {
     let base = base.trim_end_matches('/');
     let body = json!({
         "jsonrpc": "2.0",
@@ -68,6 +72,7 @@ pub async fn voice_config(client: &reqwest::Client, base: &str) -> Result<WakeWo
     });
     let val: Value = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .json(&body)
         .send()
         .await?
@@ -178,16 +183,17 @@ pub enum VoicePushEvent {
 /// returned future is dropped, but explicit closure helps the
 /// playback consumer exit.
 ///
-/// `device_id` + `room_profile` are the conversation-routing key. The
-/// server derives a deterministic session id from this pair so the
-/// satellite can resume the same conversation across restarts /
-/// network blips without juggling explicit session tokens.
+/// `device_id` + the room_profile resolved from `token` are the
+/// conversation-routing key. The server derives a deterministic
+/// session id from this pair so the satellite can resume the same
+/// conversation across restarts / network blips without juggling
+/// explicit session tokens.
 #[allow(clippy::too_many_arguments)]
 pub async fn voice_pipeline_run(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     device_id: &str,
-    room_profile: &str,
     pcm: &[i16],
     language: Option<&str>,
     device: Option<&crate::DeviceMetadata>,
@@ -205,7 +211,6 @@ pub async fn voice_pipeline_run(
     let mut params = json!({
         "audio": audio_b64,
         "device_id": device_id,
-        "room_profile": room_profile,
     });
     if let Some(l) = language {
         params["language"] = json!(l);
@@ -222,6 +227,7 @@ pub async fn voice_pipeline_run(
 
     let resp = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .header("accept", "text/event-stream")
         .json(&body)
         .send()
@@ -258,14 +264,15 @@ fn parse_sse_data(raw: &str) -> Option<Value> {
 /// returns — the typical flow is "until satellite shuts down."
 ///
 /// Routing is by `(device_id, room_profile)` — the same key
-/// `voice/pipeline_run` uses to derive its session id. A new
-/// subscription supersedes any prior subscription for the same key, so
-/// reconnecting after a network blip just re-binds the channel.
+/// `voice/pipeline_run` uses to derive its session id; `room_profile`
+/// comes from the bearer `token`. A new subscription supersedes any
+/// prior subscription for the same key, so reconnecting after a
+/// network blip just re-binds the channel.
 pub async fn voice_subscribe(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     device_id: &str,
-    room_profile: &str,
     event_tx: mpsc::Sender<VoicePushEvent>,
 ) -> Result<()> {
     let base = base.trim_end_matches('/');
@@ -275,12 +282,12 @@ pub async fn voice_subscribe(
         "method": "voice/subscribe",
         "params": {
             "device_id": device_id,
-            "room_profile": room_profile,
         },
     });
 
     let resp = client
         .post(format!("{base}/rpc"))
+        .bearer_auth(token)
         .header("accept", "text/event-stream")
         .json(&body)
         .send()

--- a/crates/sapphire-call/config.example.toml
+++ b/crates/sapphire-call/config.example.toml
@@ -7,11 +7,16 @@
 # room_profile — see `[room_profile.<n>].wake_word` on the agent.
 # Every satellite for that room_profile fetches the same phrase via
 # `voice/config` at startup.
+#
+# The room_profile binding is selected server-side by the bearer
+# `token` below: the token must appear in some
+# `[room_profile.<n>].api_keys` on the agent, and that profile becomes
+# the session's binding (same mechanism MCP and A2A use).
 
 [server]
-url          = "https://agent.example.com"
-room_profile = "home_voice"
-# session    = "abc1234"   # 7-char grain id to resume an existing session
+url   = "https://agent.example.com"
+token = "sa-call-REPLACE_ME"   # bearer; must match [room_profile.<n>].api_keys on the agent
+# session = "abc1234"          # 7-char grain id to resume an existing session
 
 [audio]
 # Discover names via `sapphire-call voice --list-devices`. Either or

--- a/crates/sapphire-call/src/config.rs
+++ b/crates/sapphire-call/src/config.rs
@@ -1,10 +1,16 @@
 //! Persistent satellite configuration.
 //!
 //! All fields are optional and override-able from the CLI; this file
-//! exists so you don't have to type `--server https://… --room-profile …`
+//! exists so you don't have to type `--server https://… --token …`
 //! every time you start `sapphire-call`. Wake-word configuration is
 //! intentionally **not** here — the server is the source of truth for
 //! the AI's name (see `[room_profile.<n>].wake_word` on the server).
+//!
+//! The room_profile is selected server-side by the bearer token — the
+//! token must appear in some `[room_profile.<n>].api_keys` entry on
+//! the agent, and that profile becomes the session's binding. Mirrors
+//! the existing MCP / A2A authentication model so all three protocol
+//! surfaces use the same `api_keys` table.
 //!
 //! Resolution order at startup:
 //!   1. explicit CLI flag
@@ -54,9 +60,11 @@ pub struct ServerConfig {
     /// Resume an existing session by 7-char grain id. Equivalent to
     /// `--session`.
     pub session: Option<String>,
-    /// Pin the session to a server-side `[room_profile.<n>]`.
-    /// Equivalent to `--room-profile`.
-    pub room_profile: Option<String>,
+    /// Bearer token sent as `Authorization: Bearer <token>` on every
+    /// `/rpc` request. Must match an `api_keys` entry on some
+    /// `[room_profile.<n>]` on the agent — that profile becomes the
+    /// session's binding. Equivalent to `--token`.
+    pub token: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -273,7 +281,7 @@ url = "https://agent.example.com"
 [server]
 url = "https://agent.example.com"
 session = "abc1234"
-room_profile = "home_voice"
+token = "sa-call-abc123"
 
 [audio]
 input_device = "Jabra SPEAK 510 USB"
@@ -300,7 +308,7 @@ vad_min_silence_ms = 350
 vad_min_speech_ms  = 200
 "#;
         let cfg: CallConfig = toml::from_str(raw).unwrap();
-        assert_eq!(cfg.server.room_profile.as_deref(), Some("home_voice"));
+        assert_eq!(cfg.server.token.as_deref(), Some("sa-call-abc123"));
         assert_eq!(
             cfg.audio.input_device.as_deref(),
             Some("Jabra SPEAK 510 USB")

--- a/crates/sapphire-call/src/main.rs
+++ b/crates/sapphire-call/src/main.rs
@@ -27,12 +27,14 @@ struct Cli {
     #[arg(long, global = true)]
     session: Option<String>,
 
-    /// Room profile name to bind to a newly created session. Must match a
-    /// `[room_profile.<name>]` entry on the server side. Ignored when
-    /// resuming an existing session via --session. Overrides
-    /// `[server].room_profile` in the config file.
-    #[arg(long, global = true)]
-    room_profile: Option<String>,
+    /// Bearer token sent as `Authorization: Bearer <token>` on every
+    /// `/rpc` request. Must match an `api_keys` entry on a server-side
+    /// `[room_profile.<name>]`; the room_profile resolved from this
+    /// token is the session's binding (mirrors how MCP and A2A
+    /// authenticate). Overrides `[server].token` in the config file
+    /// and the `SAPPHIRE_AGENT_TOKEN` environment variable.
+    #[arg(long, global = true, env = "SAPPHIRE_AGENT_TOKEN")]
+    token: Option<String>,
 
     /// Path to a TOML config file. Defaults to
     /// `~/.config/sapphire-call/config.toml` when present; missing is
@@ -121,7 +123,17 @@ async fn main() -> Result<()> {
         .or(file_cfg.server.url)
         .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string());
     let session = cli.session.clone().or(file_cfg.server.session);
-    let room_profile = cli.room_profile.clone().or(file_cfg.server.room_profile);
+    let token = cli
+        .token
+        .clone()
+        .or(file_cfg.server.token)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "missing bearer token — set [server].token in the config, pass --token <TOKEN>, \
+                 or export SAPPHIRE_AGENT_TOKEN; the agent uses it to look up your room_profile \
+                 (api_keys on [room_profile.<n>])"
+            )
+        })?;
     let device = file_cfg.device.to_api();
 
     if let Some(Command::Voice {
@@ -134,7 +146,7 @@ async fn main() -> Result<()> {
         return voice::run(
             server,
             session,
-            room_profile,
+            token,
             voice::VoiceOptions {
                 language: language.or(file_cfg.language.stt),
                 list_devices,
@@ -155,7 +167,7 @@ async fn main() -> Result<()> {
         cli.message,
         cli.history,
         cli.json,
-        room_profile,
+        token,
         device,
     )
     .await

--- a/crates/sapphire-call/src/voice/mod.rs
+++ b/crates/sapphire-call/src/voice/mod.rs
@@ -278,7 +278,7 @@ fn handle_stream_error(
 pub async fn run(
     server: String,
     _session: Option<String>,
-    room_profile: Option<String>,
+    token: String,
     options: VoiceOptions,
 ) -> Result<()> {
     // `--list-devices` short-circuits before we touch the network /
@@ -291,20 +291,15 @@ pub async fn run(
     let client = reqwest::Client::new();
 
     // Voice conversations are routed by (device_id, room_profile) so
-    // the satellite picks up where it left off across restarts.
+    // the satellite picks up where it left off across restarts. The
+    // room_profile is resolved server-side from the bearer `token`.
     // `session` (legacy chat session id) is ignored in voice mode.
     let device_id = crate::device_id::ensure_device_id()
         .context("failed to load or generate sapphire-call device id")?;
-    let room_profile = room_profile.ok_or_else(|| {
-        anyhow!(
-            "voice mode requires a room_profile — set [server].room_profile in the config \
-             or pass --room-profile <name>"
-        )
-    })?;
-    eprintln!("sapphire-call voice (device: {device_id}, room_profile: {room_profile})",);
+    eprintln!("sapphire-call voice (device: {device_id})");
 
     // ── Wake-word config: fetch the inline ONNX from the server ─────────
-    let server_wake = sapphire_agent_api::voice_config(&client, &base)
+    let server_wake = sapphire_agent_api::voice_config(&client, &base, &token)
         .await
         .unwrap_or_else(|e| {
             eprintln!(
@@ -497,8 +492,8 @@ pub async fn run(
     let subscribe_handle = tokio::spawn(subscribe_loop(
         client.clone(),
         base.clone(),
+        token.clone(),
         device_id.clone(),
-        room_profile.clone(),
         cmd_tx,
         Arc::clone(&shutdown),
     ));
@@ -513,8 +508,8 @@ pub async fn run(
         output_rate,
         client,
         base,
+        token,
         device_id,
-        room_profile,
         language: options.language,
         device: options.device,
         shutdown: Arc::clone(&shutdown),
@@ -558,8 +553,8 @@ struct ListenCtx {
     output_rate: u32,
     client: reqwest::Client,
     base: String,
+    token: String,
     device_id: String,
-    room_profile: String,
     language: Option<String>,
     device: Option<sapphire_agent_api::DeviceMetadata>,
     shutdown: Arc<AtomicBool>,
@@ -760,8 +755,8 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
             if let Err(e) = process_utterance(
                 &ctx.client,
                 &ctx.base,
+                &ctx.token,
                 &ctx.device_id,
-                &ctx.room_profile,
                 &utterance,
                 ctx.language.as_deref(),
                 ctx.device.as_ref(),
@@ -900,15 +895,15 @@ async fn handle_push_command(ctx: &mut ListenCtx, cmd: ListenCommand, window_buf
 async fn subscribe_loop(
     client: reqwest::Client,
     base: String,
+    token: String,
     device_id: String,
-    room_profile: String,
     cmd_tx: mpsc::UnboundedSender<ListenCommand>,
     shutdown: Arc<AtomicBool>,
 ) {
     let mut backoff_secs: u64 = 1;
     while !shutdown.load(Ordering::SeqCst) {
         let (push_tx, mut push_rx) = mpsc::channel::<VoicePushEvent>(32);
-        let conn = voice_subscribe(&client, &base, &device_id, &room_profile, push_tx);
+        let conn = voice_subscribe(&client, &base, &token, &device_id, push_tx);
         // Forward push events as ListenCommands while the subscribe
         // call runs to completion in parallel.
         let forwarder = {
@@ -1537,8 +1532,8 @@ fn open_output_stream(
 async fn process_utterance(
     client: &reqwest::Client,
     base: &str,
+    token: &str,
     device_id: &str,
-    room_profile: &str,
     pcm_16khz: &[i16],
     language: Option<&str>,
     device_meta: Option<&sapphire_agent_api::DeviceMetadata>,
@@ -1554,8 +1549,8 @@ async fn process_utterance(
     let server_call = tokio::spawn({
         let client = client.clone();
         let base = base.to_string();
+        let token = token.to_string();
         let device = device_id.to_string();
-        let room = room_profile.to_string();
         let pcm = pcm_16khz.to_vec();
         let lang = language.map(String::from);
         let device_meta = device_meta.cloned();
@@ -1563,8 +1558,8 @@ async fn process_utterance(
             voice_pipeline_run(
                 &client,
                 &base,
+                &token,
                 &device,
-                &room,
                 &pcm,
                 lang.as_deref(),
                 device_meta.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,11 +119,12 @@ enum Command {
         /// and --message; ignored in REPL mode.
         #[arg(long)]
         json: bool,
-        /// Room profile name to bind to a newly created session. Must match a
-        /// `[room_profile.<name>]` entry on the server side. Ignored when
-        /// resuming an existing session via --session.
-        #[arg(long)]
-        room_profile: Option<String>,
+        /// Bearer token sent as `Authorization: Bearer <token>` on every
+        /// `/rpc` request. Must match an `api_keys` entry on a server-side
+        /// `[room_profile.<name>]`; the room_profile resolved from the
+        /// token is the session's binding (mirrors MCP and A2A auth).
+        #[arg(long, env = "SAPPHIRE_AGENT_TOKEN")]
+        token: Option<String>,
     },
 }
 
@@ -147,23 +148,19 @@ async fn main() -> Result<()> {
         message,
         history,
         json,
-        room_profile,
+        token,
     }) = cli.command
     {
+        let token = token.ok_or_else(|| {
+            anyhow::anyhow!(
+                "missing bearer token — pass --token <TOKEN> or export SAPPHIRE_AGENT_TOKEN; the \
+                 agent looks the token up under `[room_profile.<n>].api_keys` to pin the session"
+            )
+        })?;
         // The in-tree `sapphire-agent call` CLI has no per-device config
         // file, so no DeviceMetadata is forwarded; standalone callers
         // (sapphire-call) plumb their own `[device]` block through.
-        return call::run(
-            server,
-            session,
-            list,
-            message,
-            history,
-            json,
-            room_profile,
-            None,
-        )
-        .await;
+        return call::run(server, session, list, message, history, json, token, None).await;
     }
 
     let config_path = cli.config.unwrap_or_else(Config::default_path);

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -358,6 +358,12 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
 // POST /rpc  — dispatch JSON-RPC methods
 // ---------------------------------------------------------------------------
 
+/// JSON-RPC error code returned when the Authorization header is present
+/// but the bearer token is not registered under any
+/// `[room_profile.<n>].api_keys`. Mirrors `codes::AUTH_REQUIRED` used by
+/// `/a2a` and `/mcp` so the three protocol surfaces stay symmetrical.
+const RPC_AUTH_REQUIRED: i32 = -32001;
+
 async fn rpc_post(
     State(state): State<Arc<ServeState>>,
     headers: HeaderMap,
@@ -370,18 +376,60 @@ async fn rpc_post(
 
     let req_id = req.id.clone().unwrap_or(Value::Null);
 
+    // Bearer auth → room_profile reverse lookup. The token IS the
+    // profile selector; clients no longer pass `room_profile` in
+    // params. Missing/empty bearer → 401 at the HTTP layer (matches
+    // /a2a); unknown token → JSON-RPC AUTH_REQUIRED.
+    let bearer = match extract_bearer(&headers) {
+        Some(b) => b,
+        None => {
+            return (StatusCode::UNAUTHORIZED, "missing bearer token").into_response();
+        }
+    };
+    let profile_name = match state.config.resolve_a2a_token(&bearer) {
+        Some(name) => name.to_string(),
+        None => {
+            let body = error_response(req_id, RPC_AUTH_REQUIRED, "unknown or revoked bearer token");
+            return body.into_response();
+        }
+    };
+
     match req.method.as_str() {
-        "initialize" => handle_initialize(state, req_id, req.params, session_id).await,
+        "initialize" => {
+            handle_initialize(state, req_id, req.params, session_id, profile_name).await
+        }
         "chat" => handle_chat(state, req_id, req.params, session_id).await,
         "list_sessions" => handle_list_sessions(state, req_id).await,
         "get_session" => handle_get_session(state, req_id, session_id).await,
         "voice/config" => handle_voice_config(state, req_id, req.params).await,
-        "voice/pipeline_run" => handle_voice_pipeline_run(state, req_id, req.params).await,
-        "voice/subscribe" => handle_voice_subscribe(state, req_id, req.params).await,
+        "voice/pipeline_run" => {
+            handle_voice_pipeline_run(state, req_id, req.params, profile_name).await
+        }
+        "voice/subscribe" => {
+            handle_voice_subscribe(state, req_id, req.params, profile_name).await
+        }
         _ => {
             let body = error_response(req_id, -32601, "Method not found");
             body.into_response()
         }
+    }
+}
+
+/// Extract a `Bearer <token>` from the `Authorization` header, trimming
+/// whitespace. Empty / malformed → `None`. Shared shape with
+/// `serve::a2a::extract_bearer` — same Authorization parsing rules so
+/// the three protocol endpoints stay symmetrical.
+fn extract_bearer(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(axum::http::header::AUTHORIZATION)?;
+    let s = value.to_str().ok()?;
+    let token = s
+        .strip_prefix("Bearer ")
+        .or_else(|| s.strip_prefix("bearer "))?;
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 
@@ -405,21 +453,12 @@ async fn handle_initialize(
     req_id: Value,
     params: Option<Value>,
     existing_header_session: Option<String>,
+    profile_name: String,
 ) -> axum::response::Response {
-    // Optional `params.room_profile` — must reference a defined
-    // `[room_profile.<n>]` entry. Rejected eagerly so misspellings
-    // surface at session start rather than as a silent fallback to
-    // the background provider.
-    let requested_room_profile: Option<String> = params
-        .as_ref()
-        .and_then(|p| p["room_profile"].as_str())
-        .map(|s| s.to_string());
-    if let Some(name) = &requested_room_profile
-        && state.config.room_profile(name).is_none()
-    {
-        let body = error_response(req_id, -32602, &format!("Unknown room_profile '{name}'"));
-        return body.into_response();
-    }
+    // `room_profile` is no longer accepted as a JSON-RPC param — the
+    // bearer token resolved in `rpc_post` is the sole profile selector
+    // (mirrors A2A / MCP). `resolve_a2a_token` only returns names that
+    // exist in the config, so no extra validation is needed here.
 
     // Resolve to an internal UUID session_id.
     // - Session-Id header: already a UUID (internal), use directly.
@@ -491,13 +530,11 @@ async fn handle_initialize(
             .and_then(|m| m.public_id)
     };
 
-    if let Some(name) = requested_room_profile {
-        state
-            .session_room_profiles
-            .lock()
-            .await
-            .insert(session_id.clone(), name);
-    }
+    state
+        .session_room_profiles
+        .lock()
+        .await
+        .insert(session_id.clone(), profile_name.clone());
 
     // Optional `params.device = { name, description }` from sapphire-call /
     // other voice clients. We treat `name` as the device handle (e.g.
@@ -767,6 +804,7 @@ async fn handle_voice_pipeline_run(
     state: Arc<ServeState>,
     req_id: Value,
     params: Option<Value>,
+    room_profile: String,
 ) -> axum::response::Response {
     if state.voice.is_none() {
         let body = error_response(
@@ -792,24 +830,8 @@ async fn handle_voice_pipeline_run(
             return body.into_response();
         }
     };
-    let room_profile = match params["room_profile"].as_str() {
-        Some(s) => s.to_string(),
-        None => {
-            let body = error_response(req_id, -32602, "Missing params.room_profile");
-            return body.into_response();
-        }
-    };
-    // Validate room_profile up front so typos surface as a clean
-    // JSON-RPC error rather than as a silent fallback to the
-    // background provider.
-    if state.config.room_profile(&room_profile).is_none() {
-        let body = error_response(
-            req_id,
-            -32602,
-            &format!("Unknown room_profile '{room_profile}'"),
-        );
-        return body.into_response();
-    }
+    // `room_profile` comes from the bearer token resolved in
+    // `rpc_post`; clients no longer pass it as a param.
     let language = params["language"].as_str().map(|s| s.to_string());
 
     // Derive a deterministic session id from (device_id, room_profile)
@@ -880,6 +902,7 @@ async fn handle_voice_subscribe(
     state: Arc<ServeState>,
     req_id: Value,
     params: Option<Value>,
+    room_profile: String,
 ) -> axum::response::Response {
     let params = params.unwrap_or(Value::Null);
     let device_id = match params["device_id"].as_str() {
@@ -889,21 +912,8 @@ async fn handle_voice_subscribe(
             return body.into_response();
         }
     };
-    let room_profile = match params["room_profile"].as_str() {
-        Some(s) => s.to_string(),
-        None => {
-            let body = error_response(req_id, -32602, "Missing params.room_profile");
-            return body.into_response();
-        }
-    };
-    if state.config.room_profile(&room_profile).is_none() {
-        let body = error_response(
-            req_id,
-            -32602,
-            &format!("Unknown room_profile '{room_profile}'"),
-        );
-        return body.into_response();
-    }
+    // `room_profile` comes from the bearer token resolved in
+    // `rpc_post`; clients no longer pass it as a param.
 
     // Replace any prior subscription for this device (typical case:
     // the same satellite reconnects after a brief network blip). The


### PR DESCRIPTION
## Summary

- Align sapphire-call's auth with MCP and A2A: bearer token resolves server-side to a `[room_profile.<n>]` via the existing `api_keys` table.
- Remove `[server].room_profile` / `--room-profile` from sapphire-call and the in-tree `sapphire-agent call`; replace with `[server].token` / `--token` (also reads `SAPPHIRE_AGENT_TOKEN`).
- Drop `params.room_profile` from `initialize`, `voice/pipeline_run`, and `voice/subscribe` — server now derives the profile solely from the bearer.

## Wire / config behaviour

- `/rpc` requires `Authorization: Bearer <token>`; missing → `401`, unknown token → JSON-RPC `AUTH_REQUIRED (-32001)`. Mirrors the existing `/a2a` and `/mcp` handling exactly.
- Existing `[room_profile.<n>].api_keys` entries are reused — no new config field, no new lookup. A token that already works for A2A/MCP now also works for `/rpc`.
- Workspace `clap` dep gains the `env` feature so the CLI flag can fall back to `SAPPHIRE_AGENT_TOKEN`.

## Docs / fixtures

- `crates/sapphire-call/config.example.toml`, top-level `config.example.toml`, and `TESTING.md` updated to show the token flow.
- `test-configs/voice-{mock,openai}.toml` gain `api_keys` entries so the documented `--token` invocations work out of the box.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (166 tests passing)
- [ ] Manual smoke against `test-configs/voice-mock.toml` with `--token sa-voice-test-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)