### PR TITLE
refactor(cli): drop `call` subcommand, promote `serve` to default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7616,7 +7616,6 @@ dependencies = [
  "hound",
  "matrix-sdk",
  "reqwest",
- "sapphire-agent-api",
  "sapphire-workspace",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,7 @@ sapphire-workspace = { version = "0.11.0", default-features = false }
 # Human-readable session IDs for API sessions
 grain-id = { version = "0.14", features = ["serde"] }
 
-# Client library (shared with sapphire-call)
-sapphire-agent-api = { path = "crates/sapphire-agent-api", version = "0.5.0" }
-
-# HTTP server (serve command)
+# HTTP server (control API + Matrix/Discord channels)
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 
 # Stream utilities (axum SSE)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ A personal AI assistant agent that lives in a [`sapphire-workspace`](https://cra
 - **Background**: heartbeat cron tasks, periodic memory compaction, periodic workspace sync, daily logs.
 - **External AI integration**: `/mcp` endpoint publishes `write_report` and `recall_memory` tools so Claude Code (and other MCP clients) can share project context with the agent — see [docs/mcp-integration.md](docs/mcp-integration.md).
 - **Commands**:
-  - `call` — interactive REPL (reedline)
-  - `serve` — JSON-RPC over HTTP control API (`/rpc`)
-  - `run` — start the channel listeners
-  - `verify` — validate config and report loaded workspace files
+  - `sapphire-agent` — start the channel listeners + JSON-RPC HTTP control API (`/rpc`)
+  - `sapphire-agent verify` — validate config and report loaded workspace files
+  - `sapphire-call` — interactive REPL / voice satellite client (separate crate; see [crates/sapphire-call](crates/sapphire-call/))
 
 ## Install
 
@@ -43,8 +42,8 @@ Then:
 
 ```sh
 sapphire-agent verify   # sanity-check config and workspace
-sapphire-agent run      # start the channel listeners
-sapphire-agent call     # one-off interactive session
+sapphire-agent          # start the channel listeners + HTTP control API
+sapphire-call           # one-off interactive session (separate crate)
 ```
 
 ## License

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,1 +1,0 @@
-pub use sapphire_agent_api::run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 mod agent;
-mod call;
 mod channel;
 mod config;
 mod context_compression;
@@ -82,50 +81,18 @@ struct Cli {
     #[arg(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
 
+    /// Override bind address (e.g. 127.0.0.1:9000)
+    #[arg(long, value_name = "ADDR")]
+    bind: Option<String>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
 
 #[derive(Subcommand)]
 enum Command {
-    /// Start the agent — Matrix/Discord channels + HTTP API server (default)
-    Serve {
-        /// Override bind address (e.g. 127.0.0.1:9000)
-        #[arg(long, value_name = "ADDR")]
-        bind: Option<String>,
-    },
     /// Validate the config file and exit
     Verify,
-    /// Interactive session with a running serve server
-    Call {
-        /// Server base URL
-        #[arg(long, default_value = "http://localhost:9000")]
-        server: String,
-        /// Grain-id of an existing session to resume (e.g. a3b7k9p)
-        #[arg(long)]
-        session: Option<String>,
-        /// List available API sessions and exit
-        #[arg(long)]
-        list: bool,
-        /// Send a single message and exit instead of entering the REPL.
-        /// Useful as a CJK-safe fallback or for IDE/editor integration.
-        #[arg(short, long, value_name = "TEXT")]
-        message: Option<String>,
-        /// Dump the session history and exit (no message sent, no REPL).
-        /// Intended for IDE integrations restoring a session.
-        #[arg(long)]
-        history: bool,
-        /// Emit machine-readable JSON output. Applies to --list, --history,
-        /// and --message; ignored in REPL mode.
-        #[arg(long)]
-        json: bool,
-        /// Bearer token sent as `Authorization: Bearer <token>` on every
-        /// `/rpc` request. Must match an `api_keys` entry on a server-side
-        /// `[room_profile.<name>]`; the room_profile resolved from the
-        /// token is the session's binding (mirrors MCP and A2A auth).
-        #[arg(long, env = "SAPPHIRE_AGENT_TOKEN")]
-        token: Option<String>,
-    },
 }
 
 #[tokio::main]
@@ -140,35 +107,12 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    // `call` needs no config file — handle before loading config
-    if let Some(Command::Call {
-        server,
-        session,
-        list,
-        message,
-        history,
-        json,
-        token,
-    }) = cli.command
-    {
-        let token = token.ok_or_else(|| {
-            anyhow::anyhow!(
-                "missing bearer token — pass --token <TOKEN> or export SAPPHIRE_AGENT_TOKEN; the \
-                 agent looks the token up under `[room_profile.<n>].api_keys` to pin the session"
-            )
-        })?;
-        // The in-tree `sapphire-agent call` CLI has no per-device config
-        // file, so no DeviceMetadata is forwarded; standalone callers
-        // (sapphire-call) plumb their own `[device]` block through.
-        return call::run(server, session, list, message, history, json, token, None).await;
-    }
-
     let config_path = cli.config.unwrap_or_else(Config::default_path);
     let config = Config::load(&config_path)
         .with_context(|| format!("Failed to load config from {}", config_path.display()))?;
 
-    match cli.command.unwrap_or(Command::Serve { bind: None }) {
-        Command::Verify => {
+    match cli.command {
+        Some(Command::Verify) => {
             let workspace_dir = config.resolved_workspace_dir(&config_path);
             println!("Config OK");
             if let Some(m) = &config.matrix {
@@ -213,7 +157,8 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Command::Serve { bind } => {
+        None => {
+            let bind = cli.bind;
             let workspace_dir = config.resolved_workspace_dir(&config_path);
 
             // ── Migrate pre-namespace memory layout (one-time) ─────────────
@@ -654,7 +599,6 @@ async fn main() -> Result<()> {
                 tracing::warn!("Agent task did not finish cleanly: {e}");
             }
         }
-        Command::Call { .. } => unreachable!(),
     }
 
     Ok(())

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -34,8 +34,8 @@ pub const PIPELINE_SAMPLE_RATE: u32 = 16_000;
 
 /// Server-internal push event delivered to a `voice/subscribe` writer
 /// task, which translates to wire-format SSE notifications. Mirrors the
-/// public `sapphire_agent_api::VoicePushEvent` plus enough metadata to
-/// reconstruct the heartbeat task name on the wire.
+/// public `VoicePushEvent` in `sapphire-agent-api` plus enough metadata
+/// to reconstruct the heartbeat task name on the wire.
 #[derive(Debug, Clone)]
 pub enum VoicePushItem {
     /// Begin a new push (e.g. heartbeat fire).


### PR DESCRIPTION
## Summary
- Removed the in-tree `sapphire-agent call` subcommand; the interactive client now lives only in the standalone `sapphire-call` crate (which has its own config + per-device metadata that the shim never carried).
- Promoted `sapphire-agent serve` to the default (no-subcommand) invocation. `--bind` moves up to a top-level flag; `verify` stays as the only remaining subcommand.
- Dropped the `sapphire-agent-api` dependency from the root crate — the server never imported any types from it; only the removed `call` shim did.

## Notes
- Doc-comment in [src/voice/mod.rs](src/voice/mod.rs) updated to reflect that `sapphire_agent_api::VoicePushEvent` is no longer in scope of `sapphire-agent` itself.
- README updated to drop the `call` / `run` / `serve` subcommand listing and point users at `sapphire-call` for the REPL.
- Follow-up tracked in #112: restore `sapphire-agent-api` to its original role as a shared message-type crate (the in-tree `call` shim was the reason its client-side helpers had grown so large).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (137 + 3 + 26 = 166 tests pass)
- [x] `sapphire-agent --help` shows only `verify` subcommand and `--bind` as top-level flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)