### PR TITLE
fix(release): install ALSA dev libs + retrigger v0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release
 
@@ -103,6 +106,8 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
       - name: Publish workspace crates to crates.io
         run: cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- v0.6.0's first release attempt (PR #114) failed: `cargo publish --workspace` panicked verifying the `sapphire-call` tarball because `libasound2-dev` isn't on the runner, so `alsa-sys`'s build script bailed (`Package 'alsa' not found`). The Linux entries of the build matrix were on track to fail the same way (workspace build pulls `cpal` via `sapphire-call`).
- The `ci.yml` workflow already installs `libasound2-dev`; `release.yml` did not. This PR adds the install step to both the build matrix (gated on `runner.os == 'Linux'`) and the publish job.
- The orphaned `v0.6.0` tag and the previous `release/v0.6.0` branch have been deleted on the remote. No crate was published and no GitHub Release was created, so this PR's merge is the v0.6.0 release: the prepare job will recreate the tag and the rest of the pipeline runs on the fixed YAML.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: release workflow recreates `v0.6.0` tag, all four build matrix entries succeed (Linux x86_64 / aarch64 required; macOS / Windows best-effort), GitHub Release published with binaries, `cargo publish --workspace` uploads `sapphire-agent-api`, `sapphire-agent`, `sapphire-call` v0.6.0 to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)