### PR TITLE
fix(timer): unblock heartbeat reply path + clarify tool guidance

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -506,10 +506,15 @@ impl Agent {
 
     /// Persist `msg` to the session store. No-op if session creation failed.
     ///
-    /// Messages containing `ToolUse` or `ToolResult` parts are intentionally
-    /// skipped: tool payloads can be arbitrarily large (file contents, etc.)
-    /// and we never reload raw history across restarts, so persisting them
-    /// would only bloat the JSONL. Context survives via compaction summaries.
+    /// `ToolUse` / `ToolResult` parts are stripped before write: tool
+    /// payloads can be arbitrarily large (file contents, etc.) and raw
+    /// history is never reloaded across restarts, so persisting them
+    /// would only bloat the JSONL — context survives via compaction
+    /// summaries. The assistant's *text* alongside a tool call is kept,
+    /// however, since that's what the user actually saw and removing it
+    /// makes the session log a misleading record of the conversation.
+    /// A message that becomes empty after stripping is dropped entirely
+    /// (e.g. pure tool-result turns).
     ///
     /// Image scrubbing (raw base64 → `[image: <media_type> sha256=...]` text
     /// marker) happens centrally inside [`SessionStore::append`] so every
@@ -518,16 +523,29 @@ impl Agent {
         if session_id.is_empty() {
             return;
         }
-        let has_tool_parts = msg.parts.iter().any(|p| {
-            matches!(
-                p,
-                ContentPart::ToolUse { .. } | ContentPart::ToolResult { .. }
-            )
+        let kept: Vec<ContentPart> = msg
+            .parts
+            .iter()
+            .filter(|p| {
+                !matches!(
+                    p,
+                    ContentPart::ToolUse { .. } | ContentPart::ToolResult { .. }
+                )
+            })
+            .cloned()
+            .collect();
+        let has_content = kept.iter().any(|p| match p {
+            ContentPart::Text(t) => !t.is_empty(),
+            _ => true,
         });
-        if has_tool_parts {
+        if !has_content {
             return;
         }
-        if let Err(e) = self.session_store.append(session_id, msg) {
+        let filtered = ChatMessage {
+            role: msg.role.clone(),
+            parts: kept,
+        };
+        if let Err(e) = self.session_store.append(session_id, &filtered) {
             warn!("Failed to persist message: {e}");
         }
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -140,8 +140,7 @@ impl TimerManager {
                 label = label_for_fire,
                 minutes = minutes,
             );
-            me.dispatch_fire(&label_for_fire, &prompt, &origin_for_fire)
-                .await;
+            me.dispatch_fire(&label_for_fire, &prompt, &origin_for_fire);
             // Clear our own slot if we're still the active timer.
             let mut slot = me.inner.lock().await;
             if let Some(active) = slot.as_ref()
@@ -272,7 +271,7 @@ impl TimerManager {
                     )
                 } else {
                     format!(
-                        "[Timer: {preset_name}] Step {cur}/{total} of cycle {cycle}/{cycles}: '{label}' ({minutes:.1} min) ended. Next: '{next}'. Tell the user to switch. Keep it short.",
+                        "[Timer: {preset_name}] Step {cur}/{total} of cycle {cycle}/{cycles}: '{label}' ({minutes:.1} min) ended. Next step '{next}' is already auto-scheduled by the preset — do NOT call timer_set / timer_preset. Just tell the user to switch. Keep it short.",
                         preset_name = preset.name,
                         cur = i + 1,
                         total = total_steps,
@@ -283,7 +282,7 @@ impl TimerManager {
                         next = next_label.as_deref().unwrap_or(""),
                     )
                 };
-                self.dispatch_fire(&step.label, &prompt, &origin).await;
+                self.dispatch_fire(&step.label, &prompt, &origin);
             }
         }
         // Clear slot at the end if still ours.
@@ -297,13 +296,27 @@ impl TimerManager {
 
     /// Send the fire message to the right channel. Logs and drops on
     /// failure — no fallback to the other channel.
-    async fn dispatch_fire(&self, task_name: &str, prompt: &str, origin: &TimerOrigin) {
+    ///
+    /// The dispatch is detached via `tokio::spawn` so the trigger does not
+    /// run inside the calling timer task. If we awaited it here, an AI
+    /// `timer_set`/`timer_preset` invocation during the trigger would call
+    /// `replace_active` → `prev.handle.abort()` on the very task we're
+    /// running inside, killing the AI's tool-call loop mid-flight (the
+    /// `tool_use` then has no matching `tool_result` and the next turn
+    /// fails with Anthropic 400 `tool_use ids were found without
+    /// tool_result blocks immediately after`).
+    fn dispatch_fire(&self, task_name: &str, prompt: &str, origin: &TimerOrigin) {
         match origin {
             TimerOrigin::Chat { room_id } => match self.agent.get().and_then(Weak::upgrade) {
                 Some(agent) => {
-                    if let Err(e) = agent.trigger(task_name, prompt, room_id).await {
-                        warn!("Timer fire (chat) failed for {task_name} -> {room_id}: {e:#}");
-                    }
+                    let task_name = task_name.to_string();
+                    let prompt = prompt.to_string();
+                    let room_id = room_id.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = agent.trigger(&task_name, &prompt, &room_id).await {
+                            warn!("Timer fire (chat) failed for {task_name} -> {room_id}: {e:#}");
+                        }
+                    });
                 }
                 None => warn!(
                     "Timer fire (chat) skipped for {task_name}: agent not wired into TimerManager"
@@ -315,29 +328,36 @@ impl TimerManager {
                 .and_then(Weak::upgrade)
             {
                 Some(state) => {
-                    match crate::serve::push_voice_text_to_subscriber(
-                        state,
-                        device_id.clone(),
-                        Some(task_name.to_string()),
-                        prompt.to_string(),
-                    )
-                    .await
-                    {
-                        Ok(()) => {}
-                        Err(e) => {
-                            let reason = match e {
-                                crate::serve::VoicePushError::Offline => "offline".to_string(),
-                                crate::serve::VoicePushError::NoVoice => "no voice providers".to_string(),
-                                crate::serve::VoicePushError::NotConfigured => {
-                                    "voice_pipeline not configured for room_profile".to_string()
-                                }
-                                crate::serve::VoicePushError::Other(msg) => msg,
-                            };
-                            warn!(
-                                "Timer fire (voice) failed for {task_name} -> device={device_id}: {reason}"
-                            );
+                    let task_name = task_name.to_string();
+                    let prompt = prompt.to_string();
+                    let device_id = device_id.clone();
+                    tokio::spawn(async move {
+                        match crate::serve::push_voice_text_to_subscriber(
+                            state,
+                            device_id.clone(),
+                            Some(task_name.clone()),
+                            prompt,
+                        )
+                        .await
+                        {
+                            Ok(()) => {}
+                            Err(e) => {
+                                let reason = match e {
+                                    crate::serve::VoicePushError::Offline => "offline".to_string(),
+                                    crate::serve::VoicePushError::NoVoice => {
+                                        "no voice providers".to_string()
+                                    }
+                                    crate::serve::VoicePushError::NotConfigured => {
+                                        "voice_pipeline not configured for room_profile".to_string()
+                                    }
+                                    crate::serve::VoicePushError::Other(msg) => msg,
+                                };
+                                warn!(
+                                    "Timer fire (voice) failed for {task_name} -> device={device_id}: {reason}"
+                                );
+                            }
                         }
-                    }
+                    });
                 }
                 None => warn!(
                     "Timer fire (voice) skipped for {task_name}: serve_state not wired into TimerManager"

--- a/src/tools/timer_tools.rs
+++ b/src/tools/timer_tools.rs
@@ -66,11 +66,16 @@ impl TimerSetTool {
             manager,
             spec: ToolSpec {
                 name: "timer_set".into(),
-                description: "Set a single-shot in-memory timer. When it fires, the agent is \
-                    re-invoked to deliver a short notification on the same channel (chat or voice) \
-                    where this tool was called. The process supports ONE active timer at a time — \
-                    calling this with another timer already active cancels the previous one. Use \
-                    'timer_preset' for Pomodoro-style multi-step routines."
+                description: "Set a single-shot in-memory timer. The timer lives ONLY in the \
+                    agent process — the user has no visual indicator, no notification, no way to \
+                    see it. When you set, replace, or cancel a timer you MUST tell the user in \
+                    your text reply (label + when it will fire), otherwise they have no idea \
+                    anything happened. When the timer fires, the agent is re-invoked with a \
+                    heartbeat — again, ALWAYS reply with a short text message to actually deliver \
+                    the notification (tool-only replies are silent to the user). The process \
+                    supports ONE active timer at a time; calling this with another timer already \
+                    active cancels the previous one. Use 'timer_preset' for Pomodoro-style \
+                    multi-step routines."
                     .into(),
                 input_schema: json!({
                     "type": "object",
@@ -138,8 +143,13 @@ impl TimerPresetTool {
         let names: Vec<&str> = presets.iter().map(|p| p.name.as_str()).collect();
         let description = format!(
             "Start a configured timer preset (Pomodoro-style work/break cycles). The preset's \
-             ordered steps fire one by one and the cycle repeats `cycles` times. Cancels any \
-             active timer. Configured presets: {names:?}. Use 'timer_set' for simple one-shot timers."
+             ordered steps fire one by one AUTOMATICALLY — once started, do NOT call timer_set or \
+             timer_preset again to advance steps; the next step is already scheduled. Cancels any \
+             active timer. The preset lives ONLY in the agent process — the user has no visible \
+             indicator. Always confirm in your text reply (which preset, how many cycles, when \
+             the first step fires); and when each step fires you'll be re-invoked via heartbeat, \
+             so ALWAYS reply with a short text message to actually notify the user. Configured \
+             presets: {names:?}. Use 'timer_set' for simple one-shot timers."
         );
         Self {
             manager,
@@ -214,8 +224,9 @@ impl TimerCancelTool {
             manager,
             spec: ToolSpec {
                 name: "timer_cancel".into(),
-                description: "Cancel the active timer (single-shot or preset). No-op if no timer \
-                    is running."
+                description: "Cancel the active timer (single-shot or preset). No-op if no \
+                    timer is running. The user can't see the timer state, so confirm the \
+                    cancellation in your text reply."
                     .into(),
                 input_schema: json!({
                     "type": "object",
@@ -256,7 +267,8 @@ impl TimerStatusTool {
             spec: ToolSpec {
                 name: "timer_status".into(),
                 description: "Report the currently active timer (label, kind, time remaining), \
-                    or that none is set."
+                    or that none is set. The tool result is for your eyes only — relay it to the \
+                    user in your text reply, since they have no other way to see timer state."
                     .into(),
                 input_schema: json!({
                     "type": "object",


### PR DESCRIPTION
## Summary

- Timer fire path no longer self-cancels: `dispatch_fire` now spawns `agent.trigger` / `push_voice_text_to_subscriber` detached instead of awaiting in the timer task. Previously, an AI `timer_set` call during a preset-step heartbeat would `replace_active` → `abort` the same task driving the chat loop, dropping the in-progress tool round; the next turn then failed with Anthropic `400: tool_use ids were found without tool_result blocks immediately after`. The notification for the fired step never reached the channel.
- Preset intermediate-step prompt now states the next step is auto-scheduled and forbids `timer_set` / `timer_preset` re-invocation, so the AI stops racing the state machine.
- All four `timer_*` tool descriptions now make explicit that the timer is agent-private (no user-visible indicator) and the AI must always notify the user in text on set / cancel / fire — tool-only replies are silent.
- `Agent::persist` strips `ToolUse` / `ToolResult` parts in place rather than dropping the whole message, so the assistant text that accompanies a tool call survives in the session log. Pure tool-result turns still drop entirely.

## Test plan

- [ ] `cargo build --bin sapphire-agent` clean ✓ (verified locally)
- [ ] `cargo clippy --bin sapphire-agent -- -D warnings` clean ✓ (verified locally)
- [ ] Restart agent and run `ポモドーロタイマーを3セットセットして`; confirm a text notification arrives at each step boundary and the preset chains to completion without 400 errors in the journal.
- [ ] Confirm session JSONL now contains an assistant entry alongside each timer-related tool call (text portion preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)