### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-18
+
+### Fixed
+
+- **Timer fire heartbeat now reliably delivers a notification.** When a
+  preset step (or single timer) fired, the timer task awaited
+  `agent.trigger` inline; an AI `timer_set` call during that reply
+  caused `replace_active` → `abort` on the very task driving the
+  heartbeat, dropping the chat loop mid tool-round so the matching
+  `tool_result` never landed in history. The next turn then hit
+  Anthropic `400: tool_use ids were found without tool_result blocks
+  immediately after` and the notification never reached the channel.
+  `TimerManager::dispatch_fire` is now sync-spawning detached so the
+  trigger runs outside the timer task. (#116)
+- **Preset auto-chain prompt** — the intermediate-step heartbeat now
+  states the next step is already scheduled and forbids
+  `timer_set` / `timer_preset` re-invocation, to keep the AI from
+  racing the state machine. (#116)
+- **`timer_*` tool descriptions** — all four tools now make explicit
+  that the timer state is agent-private and the AI must always notify
+  the user via text on set / cancel / fire; tool-only replies are
+  silent to the user. (#116)
+- **`Agent::persist`** strips `ToolUse` / `ToolResult` parts in place
+  instead of dropping the whole message, so the assistant text that
+  accompanies a tool call is preserved in the session log. (#116)
+- **Release workflow** installs `libasound2-dev` on Linux so
+  `sapphire-call`'s `cpal` dependency builds cleanly during the
+  workspace publish step. (#115)
+
 ## [0.6.0] - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7597,7 +7597,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "a2a-lf",
  "anyhow",
@@ -7637,7 +7637,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-agent-api"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bzip2 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.6.0" }
+sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.6.1" }
 
 # Async runtime — voice subcommand needs sync, time, and rt features.
 tokio = { workspace = true, features = ["sync", "time", "rt-multi-thread", "macros", "signal"] }


### PR DESCRIPTION
## Summary

Patch release. Workspace version `0.6.0` → `0.6.1`, CHANGELOG updated.

### Fixed

- Timer fire heartbeat now reliably delivers a notification — `dispatch_fire` no longer awaits inside the timer task it might end up cancelling. (#116)
- Preset intermediate-step prompt forbids `timer_set` / `timer_preset` re-invocation so the AI stops racing the auto-chain. (#116)
- `timer_*` tool descriptions now make explicit that timer state is agent-private; the AI must always reply with text on set / cancel / fire. (#116)
- `Agent::persist` preserves the assistant's text when it accompanies a tool call, so session JSONL stays an accurate record of what the user saw. (#116)
- Release workflow installs `libasound2-dev` on Linux so the workspace publish step builds `cpal` cleanly. (#115)

## Test plan

- [ ] CI green
- [ ] Tag `v0.6.1` after merge and let the release workflow publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)