### PR TITLE
fix(channel): sniff image MIME from bytes to avoid Anthropic 400

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -253,14 +253,18 @@ impl Channel for DiscordChannel {
 /// Download every `image/*` attachment on `msg`. Oversized attachments
 /// (>5 MB) and non-image attachments are skipped with a warning so the
 /// conversation continues without them.
+///
+/// After download, the MIME type is derived from the actual bytes rather
+/// than Discord's declared `content_type`. Discord occasionally labels a
+/// transcoded image with a stale MIME (e.g. claims `image/webp` for what
+/// is in fact PNG bytes), which Anthropic's API rejects with a 400.
 async fn download_image_attachments(msg: &Message) -> Vec<Attachment> {
     let mut out = Vec::new();
     for att in &msg.attachments {
         let Some(ct) = att.content_type.as_deref() else {
             continue;
         };
-        const SUPPORTED: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
-        if !SUPPORTED.contains(&ct) {
+        if !super::SUPPORTED_IMAGE_MIME.contains(&ct) {
             warn!(
                 "Discord image '{}' has unsupported MIME type '{}'; skipping",
                 att.filename, ct
@@ -276,10 +280,25 @@ async fn download_image_attachments(msg: &Message) -> Vec<Attachment> {
         }
         match att.download().await {
             Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => {
-                out.push(Attachment {
-                    media_type: ct.to_string(),
-                    data: bytes,
-                });
+                match super::sniff_image_mime(&bytes) {
+                    Some(t) => {
+                        if t != ct {
+                            warn!(
+                                "Discord image '{}' declared MIME '{}' differs from \
+                                 detected '{}'; using detected",
+                                att.filename, ct, t
+                            );
+                        }
+                        out.push(Attachment {
+                            media_type: t.to_string(),
+                            data: bytes,
+                        });
+                    }
+                    None => warn!(
+                        "Discord image '{}' has unrecognised format (declared: '{}'); skipping",
+                        att.filename, ct
+                    ),
+                }
             }
             Ok(bytes) => warn!(
                 "Discord image '{}' decoded to {} bytes (>5MB); skipping",

--- a/src/channel/matrix.rs
+++ b/src/channel/matrix.rs
@@ -117,23 +117,6 @@ impl MatrixChannel {
     }
 }
 
-/// Detect the MIME type of an image from its magic bytes.
-/// Returns `None` if the format is not one of the four types supported by
-/// the Anthropic API (jpeg, png, gif, webp).
-fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
-    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
-        Some("image/jpeg")
-    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
-        Some("image/png")
-    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
-        Some("image/gif")
-    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
-        Some("image/webp")
-    } else {
-        None
-    }
-}
-
 /// Result of attempting to download a Matrix image attachment.
 enum ImageDownload {
     /// Successfully downloaded and format is supported.
@@ -166,36 +149,33 @@ async fn download_matrix_image(client: &Client, image: &ImageMessageEventContent
 
     match client.media().get_media_content(&request, true).await {
         Ok(bytes) if bytes.len() <= MAX_ATTACHMENT_BYTES => {
-            // Determine MIME type: trust the event metadata only if it names one
-            // of the four types the Anthropic API accepts. Otherwise fall back to
-            // sniffing the magic bytes — Matrix clients sometimes omit `mimetype`
-            // or send a generic type even for standard formats.
-            const SUPPORTED: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+            // Always derive the MIME from the actual bytes. Anthropic rejects
+            // requests whose declared `media_type` doesn't match the bytes
+            // (400 invalid_request_error), so the declared MIME is only used
+            // for diagnostic warnings on mismatch.
             let declared = image
                 .info
                 .as_ref()
                 .and_then(|info| info.mimetype.as_deref());
-            let media_type = if declared.is_some_and(|m| SUPPORTED.contains(&m)) {
-                declared.unwrap().to_string()
-            } else {
-                match sniff_image_mime(&bytes) {
-                    Some(t) => {
-                        if let Some(d) = declared {
-                            warn!(
-                                "Matrix image '{}' declared MIME '{}' is unsupported; \
-                                 detected '{}' from bytes",
-                                image.body, d, t
-                            );
-                        }
-                        t.to_string()
-                    }
-                    None => {
+            let media_type = match super::sniff_image_mime(&bytes) {
+                Some(t) => {
+                    if let Some(d) = declared
+                        && d != t
+                    {
                         warn!(
-                            "Matrix image '{}' has unrecognised format (declared: {:?})",
-                            image.body, declared
+                            "Matrix image '{}' declared MIME '{}' differs from \
+                             detected '{}'; using detected",
+                            image.body, d, t
                         );
-                        return ImageDownload::UnsupportedFormat;
                     }
+                    t.to_string()
+                }
+                None => {
+                    warn!(
+                        "Matrix image '{}' has unrecognised format (declared: {:?})",
+                        image.body, declared
+                    );
+                    return ImageDownload::UnsupportedFormat;
                 }
             };
             ImageDownload::Ok(Attachment {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -13,6 +13,32 @@ use tracing::{error, warn};
 /// dropped with a warning (the conversation continues without them).
 pub const MAX_ATTACHMENT_BYTES: usize = 5 * 1024 * 1024;
 
+/// MIME types of images forwarded to the LLM. Anthropic accepts these four;
+/// anything else is dropped at the channel layer.
+pub(crate) const SUPPORTED_IMAGE_MIME: &[&str] =
+    &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Detect the MIME type of an image from its magic bytes. Returns `None`
+/// when the bytes don't match one of the four types Anthropic accepts.
+///
+/// Used in preference to the platform-declared content type because
+/// Discord (and some Matrix clients) sometimes label, say, a PNG as
+/// `image/webp`. Anthropic strictly validates that the declared
+/// `media_type` matches the actual bytes and 400s on mismatch.
+pub(crate) fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
 /// A binary attachment fetched from a channel (currently images only).
 #[derive(Debug, Clone)]
 pub struct Attachment {
@@ -260,4 +286,48 @@ pub fn seed_routing_from_config(config: &crate::config::Config) -> HashMap<Strin
         }
     }
     seed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sniff_image_mime;
+
+    #[test]
+    fn sniffs_jpeg() {
+        assert_eq!(sniff_image_mime(&[0xFF, 0xD8, 0xFF, 0xE0, 0, 0]), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn sniffs_png() {
+        let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+        assert_eq!(sniff_image_mime(&png), Some("image/png"));
+    }
+
+    #[test]
+    fn sniffs_gif() {
+        assert_eq!(sniff_image_mime(b"GIF87a..."), Some("image/gif"));
+        assert_eq!(sniff_image_mime(b"GIF89a..."), Some("image/gif"));
+    }
+
+    #[test]
+    fn sniffs_webp() {
+        let mut webp = Vec::new();
+        webp.extend_from_slice(b"RIFF");
+        webp.extend_from_slice(&[0; 4]);
+        webp.extend_from_slice(b"WEBP");
+        webp.extend_from_slice(b"VP8 ");
+        assert_eq!(sniff_image_mime(&webp), Some("image/webp"));
+    }
+
+    #[test]
+    fn returns_none_for_unknown() {
+        assert_eq!(sniff_image_mime(&[0, 0, 0, 0]), None);
+        assert_eq!(sniff_image_mime(b""), None);
+        // RIFF prefix without WEBP marker (e.g. WAV) is not an image.
+        let mut wav = Vec::new();
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&[0; 4]);
+        wav.extend_from_slice(b"WAVE");
+        assert_eq!(sniff_image_mime(&wav), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Discord/Matrix のチャネルは添付の `content_type` をそのまま `media_type` として Anthropic に渡していたが、Discord が `image/webp` と申告した PNG バイトのように **申告 MIME と実バイトが食い違うケース** で Anthropic API が 400 `invalid_request_error` を返す。fallback の OpenAI 互換プロバイダも非マルチモーダル設定だと 500 で死に、ユーザには `image input is not supported` という不可解なエラーだけが見える。
- ダウンロード後に **magic bytes から MIME を判定** し、その結果を `media_type` として採用する。申告された MIME はダウンロード前のフィルタと、不一致時の warn ログ用途に限定。
- Discord と Matrix で重複していた sniff ロジックを `src/channel/mod.rs` に集約。

## Root cause (from journald)
```
WARN sapphire_agent::provider::fallback: Primary provider 'anthropic' errored
(Anthropic API error 400 Bad Request: ... "The image was specified using the
image/webp media type, but the image appears to be a image/png image" ...);
retrying via fallback 'local'
ERROR sapphire_agent::agent: Provider error: OpenAI-compatible API error 500
Internal Server Error: ... "image input is not supported ..."
```

## Test plan
- [x] `cargo build --bin sapphire-agent`
- [x] `cargo test channel::` — 新規ユニットテスト 5 件 (JPEG / PNG / GIF / WebP / 不明形式) を含めて全通過
- [x] `cargo clippy --bin sapphire-agent -- -D warnings`
- [ ] Discord で PNG 画像送信、Anthropic 経由でレスポンスが返ることを確認
- [ ] Discord で実際に webp フォーマットの画像を送ったケースの確認
- [ ] Matrix 経由でも画像が引き続き処理できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)