### PR TITLE
feat(image-cache): drop historical images + add recall_image tool

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -867,7 +867,7 @@ impl Agent {
             // Hydrate `ImageRef` parts back to `Image` so the provider
             // sees the actual bytes. Cache misses degrade to a text
             // marker that preserves the hash for context references.
-            let messages_for_provider = hydrate_history(&messages, self.image_cache.as_deref());
+            let messages_for_provider = hydrate_history(&messages);
             let response = provider
                 .chat(
                     system_with_context.as_deref(),
@@ -942,9 +942,14 @@ impl Agent {
                                 ns,
                                 crate::timer::scope_timer_origin(origin, async move {
                                     info!("Executing tool: {} (id={})", call.name, call.id);
-                                    let result = tools.execute(&call).await;
-                                    info!("Tool {} result: {}", call.name, result);
-                                    (call.id, result)
+                                    let output = tools.execute(&call).await;
+                                    info!(
+                                        "Tool {} result ({} image(s) attached): {}",
+                                        call.name,
+                                        output.images.len(),
+                                        output.text
+                                    );
+                                    (call.id, output)
                                 }),
                             ),
                         ));
@@ -958,7 +963,16 @@ impl Agent {
                         }
                     }
 
-                    let msg = ChatMessage::tool_results(results);
+                    // Split each ToolOutput into the text body (becomes a
+                    // tool_result block) and any images (sibling Image
+                    // blocks on the same user message).
+                    let mut text_results = Vec::with_capacity(results.len());
+                    let mut images = Vec::new();
+                    for (id, output) in results {
+                        text_results.push((id, output.text));
+                        images.extend(output.images);
+                    }
+                    let msg = ChatMessage::tool_results_with_images(text_results, images);
                     self.history
                         .lock()
                         .await
@@ -1013,7 +1027,11 @@ impl Agent {
                             input,
                         })
                         .await;
-                    agent.prefetch_cache.lock().await.insert(key_clone, result);
+                    agent
+                        .prefetch_cache
+                        .lock()
+                        .await
+                        .insert(key_clone, result.text);
                 });
             }
         }

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -316,7 +316,10 @@ mod tests {
                     input: json!({}),
                 }],
             ),
-            ChatMessage::tool_results(vec![("t1".into(), "result".into())]),
+            ChatMessage::tool_results_with_images(
+                vec![("t1".into(), "result".into())],
+                vec![],
+            ),
             ChatMessage::assistant("final answer"),
         ];
 

--- a/src/image_cache.rs
+++ b/src/image_cache.rs
@@ -136,18 +136,21 @@ pub fn scrub_history_inplace(history: &mut [ChatMessage], cache: Option<&ImageCa
     }
 }
 
-/// Build a hydrated copy of `history`: every `ImageRef` whose bytes
-/// live in `cache` becomes an `Image` again so the provider call sees
-/// the actual pixels. A cache miss is replaced with a `Text` marker
-/// (`[image: <media_type> sha256=<hex> (cache miss)]`) so the model
-/// retains a stable reference to the image even when the bytes are
-/// gone.
+/// Build a provider-ready copy of `history`: `ImageRef` parts are
+/// degraded to a `Text` marker (`[image: <media_type> sha256=<hex>]`)
+/// so that historical images are NOT re-sent to the model every turn.
+/// `Image` parts pass through unchanged — an image that arrived this
+/// turn hasn't been scrubbed to `ImageRef` yet, and is the only thing
+/// that should reach the model.
 ///
-/// `Image` parts pass through unchanged (an image that arrived this
-/// turn hasn't been scrubbed yet but is already inline). When `cache`
-/// is `None`, every `ImageRef` falls back to the text marker — same
-/// degradation path as a cache miss.
-pub fn hydrate_history(history: &[ChatMessage], cache: Option<&ImageCache>) -> Vec<ChatMessage> {
+/// Rationale: re-sending every past image as input bytes every turn
+/// re-bills the entire image-token cost per turn for the whole
+/// session. The cache still retains the raw bytes by sha256, so a
+/// dedicated `recall_image` tool can fetch a specific past image on
+/// demand when the user actually asks about one — but day-to-day
+/// "react to this image" interactions don't pay for the entire
+/// historical gallery.
+pub fn hydrate_history(history: &[ChatMessage]) -> Vec<ChatMessage> {
     history
         .iter()
         .map(|msg| ChatMessage {
@@ -156,17 +159,9 @@ pub fn hydrate_history(history: &[ChatMessage], cache: Option<&ImageCache>) -> V
                 .parts
                 .iter()
                 .map(|p| match p {
-                    ContentPart::ImageRef { media_type, sha256 } => {
-                        match cache.and_then(|c| c.get(sha256)) {
-                            Some(bytes) => ContentPart::Image {
-                                media_type: media_type.clone(),
-                                data_base64: BASE64_STANDARD.encode(&bytes),
-                            },
-                            None => ContentPart::Text(format!(
-                                "[image: {media_type} sha256={sha256} (cache miss)]"
-                            )),
-                        }
-                    }
+                    ContentPart::ImageRef { media_type, sha256 } => ContentPart::Text(
+                        format!("[image: {media_type} sha256={sha256}]"),
+                    ),
                     other => other.clone(),
                 })
                 .collect(),
@@ -260,54 +255,21 @@ mod tests {
     }
 
     #[test]
-    fn hydrate_revives_imageref_when_cache_hit() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
-        let bytes = fake_image();
-        let sha = sha256_hex(&bytes);
-        cache.put(&sha, &bytes).unwrap();
-
+    fn hydrate_degrades_imageref_to_text_marker() {
         let history = vec![ChatMessage {
             role: Role::User,
             parts: vec![ContentPart::ImageRef {
                 media_type: "image/jpeg".to_string(),
-                sha256: sha.clone(),
+                sha256: "abc123".to_string(),
             }],
         }];
-        let hydrated = hydrate_history(&history, Some(&cache));
-        match &hydrated[0].parts[0] {
-            ContentPart::Image {
-                media_type,
-                data_base64,
-            } => {
-                assert_eq!(media_type, "image/jpeg");
-                assert_eq!(BASE64_STANDARD.decode(data_base64).unwrap(), bytes);
-            }
-            other => panic!("expected Image, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn hydrate_degrades_to_text_on_cache_miss() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
-        // Note: cache is empty.
-
-        let history = vec![ChatMessage {
-            role: Role::User,
-            parts: vec![ContentPart::ImageRef {
-                media_type: "image/jpeg".to_string(),
-                sha256: "missing".to_string(),
-            }],
-        }];
-        let hydrated = hydrate_history(&history, Some(&cache));
+        let hydrated = hydrate_history(&history);
         match &hydrated[0].parts[0] {
             ContentPart::Text(s) => {
-                assert!(s.contains("cache miss"));
                 assert!(s.contains("image/jpeg"));
-                assert!(s.contains("sha256=missing"));
+                assert!(s.contains("sha256=abc123"));
             }
-            other => panic!("expected Text marker on miss, got {other:?}"),
+            other => panic!("expected Text marker, got {other:?}"),
         }
     }
 
@@ -319,7 +281,7 @@ mod tests {
             "now",
             std::iter::once(("image/png".to_string(), b64.clone())),
         )];
-        let hydrated = hydrate_history(&history, None);
+        let hydrated = hydrate_history(&history);
         match &hydrated[0].parts[0] {
             ContentPart::Image {
                 media_type,

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,15 @@ async fn main() -> Result<()> {
                 None
             };
 
+            // Register `recall_image` once the image cache is resolved.
+            // Without a cache there's nothing to recall, so skip the
+            // tool entirely — the model never sees it advertised.
+            if let Some(cache) = image_cache.clone() {
+                tool_set
+                    .register_tool(Box::new(tools::builtin_tools::RecallImageTool::new(cache)))
+                    .await;
+            }
+
             let serve_state = Arc::new(serve::ServeState::new(
                 config.clone(),
                 Arc::clone(&registry),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -137,15 +137,34 @@ impl ChatMessage {
         }
     }
 
-    /// User message containing tool execution results.
-    pub fn tool_results(results: Vec<(String, String)>) -> Self {
-        let parts = results
+    /// User message containing tool execution results plus optional
+    /// image attachments. Images are appended after all tool_result
+    /// parts; they're carried as siblings to the tool_result blocks on
+    /// the same user message — the wire format both Anthropic and (in
+    /// degraded form) OpenAI-compatible accept.
+    ///
+    /// Used by tools like `recall_image` to deliver image bytes back to
+    /// the model alongside their textual tool_result. Pass an empty
+    /// `images` vec for the common text-only case.
+    pub fn tool_results_with_images(
+        results: Vec<(String, String)>,
+        images: Vec<(String, String)>,
+    ) -> Self {
+        let mut parts: Vec<ContentPart> = results
             .into_iter()
             .map(|(id, content)| ContentPart::ToolResult {
                 tool_use_id: id,
                 content,
             })
             .collect();
+        parts.extend(
+            images
+                .into_iter()
+                .map(|(media_type, data_base64)| ContentPart::Image {
+                    media_type,
+                    data_base64,
+                }),
+        );
         Self {
             role: Role::User,
             parts,

--- a/src/provider/openai_compatible.rs
+++ b/src/provider/openai_compatible.rs
@@ -529,10 +529,13 @@ mod tests {
 
     #[test]
     fn tool_results_split_into_separate_tool_messages() {
-        let msg = ChatMessage::tool_results(vec![
-            ("call_a".to_string(), "result_a".to_string()),
-            ("call_b".to_string(), "result_b".to_string()),
-        ]);
+        let msg = ChatMessage::tool_results_with_images(
+            vec![
+                ("call_a".to_string(), "result_a".to_string()),
+                ("call_b".to_string(), "result_b".to_string()),
+            ],
+            vec![],
+        );
         let api = chat_message_to_api(&msg);
         assert_eq!(api.len(), 2);
         assert_eq!(api[0].role, "tool");

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -1663,11 +1663,11 @@ async fn run_llm_turn(
 
         // Hydrate `ImageRef` parts from the image cache into full
         // `Image` parts for the provider call. `Image` parts (just
-        // arrived this turn) and Text/Tool parts pass through. Cache
-        // misses degrade to text markers carrying the hash so the
-        // model still has a stable reference to the image.
-        let history_for_provider =
-            crate::image_cache::hydrate_history(&history, state.image_cache.as_deref());
+        // arrived this turn) and Text/Tool parts pass through;
+        // `ImageRef` parts are intentionally degraded to text markers
+        // so historical images aren't re-billed every turn (the cache
+        // still retains the bytes for an on-demand recall tool).
+        let history_for_provider = crate::image_cache::hydrate_history(&history);
         let response = provider
             .chat(system.as_deref(), &history_for_provider, Some(&tool_specs))
             .await;
@@ -1717,7 +1717,7 @@ async fn run_llm_turn(
                 let tools = Arc::clone(&state.tools);
                 let ns = namespace.clone();
                 let timer_origin = timer_origin.clone();
-                let results: Vec<(String, String)> =
+                let results: Vec<(String, crate::tools::ToolOutput)> =
                     futures_util::future::join_all(tool_calls.iter().map(|c| {
                         let tools = Arc::clone(&tools);
                         let c = c.clone();
@@ -1728,9 +1728,9 @@ async fn run_llm_turn(
                                 ns,
                                 async move {
                                     info!("Executing tool: {} (id={})", c.name, c.id);
-                                    let result = tools.execute(&c).await;
+                                    let output = tools.execute(&c).await;
                                     info!("Tool {} done", c.name);
-                                    (c.id, result)
+                                    (c.id, output)
                                 },
                             );
                             match origin {
@@ -1750,7 +1750,13 @@ async fn run_llm_turn(
                     .await;
                 }
 
-                let result_msg = ChatMessage::tool_results(results);
+                let mut text_results = Vec::with_capacity(results.len());
+                let mut images = Vec::new();
+                for (id, output) in results {
+                    text_results.push((id, output.text));
+                    images.extend(output.images);
+                }
+                let result_msg = ChatMessage::tool_results_with_images(text_results, images);
                 history.push(result_msg.clone());
                 // Tool_result payloads are not persisted — see the matching
                 // tool_use branch above for rationale.

--- a/src/tools/builtin_tools.rs
+++ b/src/tools/builtin_tools.rs
@@ -1,7 +1,9 @@
+use crate::image_cache::ImageCache;
 use crate::provider::ToolSpec;
-use crate::tools::{Tool, ToolSet};
+use crate::tools::{Tool, ToolOutput, ToolSet};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use sapphire_workspace::WorkspaceState;
 use serde_json::json;
 use std::path::PathBuf;
@@ -1135,5 +1137,161 @@ impl Tool for McpReconnectTool {
         }
 
         tool_set.reconnect_mcp_server(server).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// recall_image
+// ---------------------------------------------------------------------------
+
+/// Re-fetch a past image from the workspace-external image cache and
+/// attach it to the tool_result so the model can look at it again.
+///
+/// Older turns in conversation history appear to the model as text
+/// markers like `[image: image/png sha256=<hex>]` — the raw bytes
+/// aren't re-sent every turn to keep input-token cost down. When the
+/// user asks the model to look at a past image, the model is expected
+/// to call this tool with the marker's sha256 + media_type; the cache
+/// is then queried and the actual bytes get appended to the user
+/// message carrying this tool's result.
+pub struct RecallImageTool {
+    cache: Arc<ImageCache>,
+    spec: ToolSpec,
+}
+
+impl RecallImageTool {
+    pub fn new(cache: Arc<ImageCache>) -> Self {
+        let spec = ToolSpec {
+            name: "recall_image".into(),
+            description: "Re-fetch a past image from the conversation by its sha256 hash. \
+                Use this when the user references an image that now appears in history as a \
+                `[image: <media_type> sha256=<hex>]` text marker (only images attached in the \
+                CURRENT turn are visible inline; older ones are shown as markers to save \
+                tokens). Pass the marker's `sha256` and `media_type` verbatim; the actual \
+                image bytes will be returned as an attachment for you to view."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "sha256": {
+                        "type": "string",
+                        "description": "Hex sha256 of the image to recall (copy from the `[image: ... sha256=<hex>]` marker)."
+                    },
+                    "media_type": {
+                        "type": "string",
+                        "description": "MIME type of the image, e.g. `image/png`, `image/jpeg`, `image/gif`, `image/webp` (copy from the marker)."
+                    }
+                },
+                "required": ["sha256", "media_type"]
+            }),
+        };
+        Self { cache, spec }
+    }
+}
+
+#[async_trait]
+impl Tool for RecallImageTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn execute(&self, _input: &serde_json::Value) -> Result<String> {
+        // Should never be reached: `execute_full` is overridden below.
+        // If something does call this path, surface a clear marker text
+        // rather than a panic — the model can recover.
+        Ok("recall_image returned no image (text-only path).".to_string())
+    }
+
+    async fn execute_full(&self, input: &serde_json::Value) -> Result<ToolOutput> {
+        let sha256 = input
+            .get("sha256")
+            .and_then(|v| v.as_str())
+            .context("Missing required field: sha256")?;
+        let media_type = input
+            .get("media_type")
+            .and_then(|v| v.as_str())
+            .context("Missing required field: media_type")?;
+
+        if !is_hex_sha256(sha256) {
+            anyhow::bail!(
+                "sha256 must be a 64-char lowercase hex string; got {} char(s)",
+                sha256.len()
+            );
+        }
+
+        let bytes = self
+            .cache
+            .get(sha256)
+            .with_context(|| format!("image not in cache (sha256={sha256})"))?;
+
+        let data_base64 = BASE64_STANDARD.encode(&bytes);
+        let byte_len = bytes.len();
+        Ok(ToolOutput {
+            text: format!(
+                "Recalled image (sha256={sha256}, media_type={media_type}, {byte_len} bytes). \
+                 Image attached to this tool result — refer to it directly."
+            ),
+            images: vec![(media_type.to_string(), data_base64)],
+        })
+    }
+}
+
+fn is_hex_sha256(s: &str) -> bool {
+    s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod recall_image_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn open_cache() -> (TempDir, Arc<ImageCache>) {
+        let tmp = TempDir::new().unwrap();
+        let cache = ImageCache::open(tmp.path().to_path_buf()).unwrap();
+        (tmp, cache)
+    }
+
+    #[tokio::test]
+    async fn returns_image_on_cache_hit() {
+        let (_tmp, cache) = open_cache();
+        let bytes = b"\xff\xd8\xfffake-jpeg".to_vec();
+        let sha = crate::image_cache::sha256_hex(&bytes);
+        cache.put(&sha, &bytes).unwrap();
+
+        let tool = RecallImageTool::new(cache);
+        let out = tool
+            .execute_full(&json!({"sha256": sha, "media_type": "image/jpeg"}))
+            .await
+            .unwrap();
+        assert_eq!(out.images.len(), 1);
+        assert_eq!(out.images[0].0, "image/jpeg");
+        assert_eq!(
+            BASE64_STANDARD.decode(&out.images[0].1).unwrap(),
+            bytes
+        );
+        assert!(out.text.contains(&sha));
+    }
+
+    #[tokio::test]
+    async fn errors_on_cache_miss() {
+        let (_tmp, cache) = open_cache();
+        let tool = RecallImageTool::new(cache);
+        let sha = "0".repeat(64);
+        let err = tool
+            .execute_full(&json!({"sha256": sha, "media_type": "image/png"}))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("not in cache"));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_sha() {
+        let (_tmp, cache) = open_cache();
+        let tool = RecallImageTool::new(cache);
+        let err = tool
+            .execute_full(&json!({"sha256": "abc", "media_type": "image/png"}))
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("64-char"));
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,14 +11,55 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+/// Output of a tool execution.
+///
+/// Most tools return only text — for those, construct via `String` (impl
+/// `From<String>` below). Tools that also need to deliver image bytes to
+/// a multimodal model (e.g. `recall_image`, fetching a past image from
+/// the cache) populate `images` so the agent runtime can attach them to
+/// the user message carrying the tool_result block.
+#[derive(Debug, Clone, Default)]
+pub struct ToolOutput {
+    /// Text content of the tool result.
+    pub text: String,
+    /// Optional inline image attachments — `(media_type, data_base64)`.
+    /// Attached as `ContentPart::Image` parts on the tool_result user
+    /// message; only providers that understand image input use them.
+    pub images: Vec<(String, String)>,
+}
+
+impl From<String> for ToolOutput {
+    fn from(text: String) -> Self {
+        Self {
+            text,
+            images: Vec::new(),
+        }
+    }
+}
+
+impl From<&str> for ToolOutput {
+    fn from(text: &str) -> Self {
+        Self::from(text.to_string())
+    }
+}
+
 /// A tool the agent can invoke.
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// The spec advertised to the LLM.
     fn spec(&self) -> &ToolSpec;
 
-    /// Execute the tool with the given JSON input.
+    /// Execute the tool with the given JSON input. Used by all tools
+    /// that return only text — which is most of them.
     async fn execute(&self, input: &serde_json::Value) -> Result<String>;
+
+    /// Execute the tool and return a `ToolOutput` carrying both text
+    /// and any image attachments. The default impl wraps `execute`;
+    /// override when the tool needs to return image bytes (e.g.
+    /// `recall_image`).
+    async fn execute_full(&self, input: &serde_json::Value) -> Result<ToolOutput> {
+        Ok(ToolOutput::from(self.execute(input).await?))
+    }
 }
 
 /// A collection of tools with their specs.
@@ -50,18 +91,21 @@ impl ToolSet {
         self.inner.read().await.specs.clone()
     }
 
-    /// Execute a tool call; returns a human-readable result string.
-    pub async fn execute(&self, call: &ToolCall) -> String {
+    /// Execute a tool call. The returned `ToolOutput` carries the
+    /// text result plus any image attachments the tool produced; the
+    /// caller is responsible for assembling them into a tool_result
+    /// user message.
+    pub async fn execute(&self, call: &ToolCall) -> ToolOutput {
         let inner = self.inner.read().await;
         for tool in &inner.tools {
             if tool.spec().name == call.name {
-                return match tool.execute(&call.input).await {
-                    Ok(result) => result,
-                    Err(e) => format!("Error: {e:#}"),
+                return match tool.execute_full(&call.input).await {
+                    Ok(output) => output,
+                    Err(e) => ToolOutput::from(format!("Error: {e:#}")),
                 };
             }
         }
-        format!("Unknown tool: {}", call.name)
+        ToolOutput::from(format!("Unknown tool: {}", call.name))
     }
 
     /// Check all MCP clients for `tools_changed` flags and refresh their


### PR DESCRIPTION
## Summary
- 過去ターンの画像を毎回 Anthropic に送り直す現状をやめ、**履歴の画像は SHA-256 marker テキストに降格**(`hydrate_history` 改修)。当ターンに添付された画像はこれまで通り inline で渡る。
- 過去画像を本当に見たい時のための **`recall_image` ツール** を追加。`(sha256, media_type)` を渡すとキャッシュからバイトを取得し、tool_result と同じ user message に `Image` ブロックとして並べる。Anthropic は tool_result と兄弟関係の content block を許容しているのでそのまま読める。
- Tool 周りのインフラ拡張:
  - `ToolOutput { text, images }` — テキストに加えて画像添付を返せる戻り値型
  - `Tool::execute_full` — デフォルト実装で `execute` をラップ。既存 ~20 ツールは変更不要
  - `ChatMessage::tool_results_with_images` — `[ToolResult..., Image...]` を含む user message ビルダー

## Why
履歴の `ImageRef` を毎ターン `Image` に膨らませて送っていたので、画像入力トークン × ターン数のコストが累積していた。Haiku 4.5 でも長セッションだとじわじわ効くし、Sonnet/Opus なら無視できない。

ユーザーが画像を送るのは「感想を聞きたい」程度の即時要件が中心なので、デフォルトの履歴では画像を保持せず、必要なときだけツール経由で復元する設計に切り替える。

## Cost impact (Haiku 4.5 想定、`tokens ≒ (W×H)/750`)
- 1024×1024 画像 ≒ 1.4k tokens/枚。10 ターン続く会話に 5 枚溜まると、改修前は 5×10×1.4k = 70k tokens を画像分だけで毎回送っていた。改修後はそれぞれ最初に登場したターンしか送らないので、累計コストは送信回数に比例して下がる。

## Test plan
- [x] `cargo build --bin sapphire-agent`
- [x] `cargo test --bin sapphire-agent` — 144 passed (`recall_image_tests` 3 件 + 既存 `hydrate_*` テスト更新を含む)
- [x] `cargo clippy --bin sapphire-agent --tests -- -D warnings`
- [ ] 実環境で Discord に画像を送って Anthropic 応答が来ることを確認
- [ ] 続けて別メッセージを送り、過去画像が text marker として扱われている(課金が減る)ことをログで確認
- [ ] 「さっきの画像見て」と頼んだ時に `recall_image` が呼ばれ、Anthropic が画像内容を再度参照できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)