### PR TITLE
feat(features): promote voice-sherpa to default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,15 @@ name = "sapphire-agent"
 path = "src/main.rs"
 
 [features]
-default = ["lancedb-store", "fastembed-embed", "git-sync"]
+default = ["lancedb-store", "fastembed-embed", "git-sync", "voice-sherpa"]
 lancedb-store = ["sapphire-workspace/lancedb-store"]
 fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync = ["sapphire-workspace/git-sync"]
-# Compile in the local sherpa-onnx STT + TTS providers. Off by default
-# because sherpa-onnx-sys pulls in a large C++ build (sherpa-onnx +
-# ONNX runtime, ~5–10 minutes on a cold cache). Users who only run the
-# Gradio TTS path or who don't need voice at all should skip it.
+# Compile in the local sherpa-onnx STT + TTS providers. Enabled by
+# default, but note that sherpa-onnx-sys pulls in a large C++ build
+# (sherpa-onnx + ONNX runtime, ~5–10 minutes on a cold cache). Users
+# who only run the Gradio TTS path or who don't need voice at all can
+# opt out with `--no-default-features` plus the other defaults.
 voice-sherpa = ["dep:sherpa-onnx", "dep:tar", "dep:bzip2"]
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Add `voice-sherpa` to the default feature set in the root `Cargo.toml` so local sherpa-onnx STT + TTS is compiled by default.
- Refresh the inline comment: it still warns about the long sherpa-onnx-sys C++ build (~5–10 min cold cache) and now documents the `--no-default-features` opt-out for users on the Gradio TTS path or no-voice setups.

## Test plan
- [x] `cargo check` on the workspace with the new defaults
- [ ] Manual: confirm a fresh `cargo build --no-default-features --features lancedb-store,fastembed-embed,git-sync` still skips sherpa-onnx-sys
- [ ] Manual: confirm voice path works end-to-end on a default build

🤖 Generated with [Claude Code](https://claude.com/claude-code)