### PR TITLE
refactor(rpc): rename sapphire-agent-api crate to sapphire-agent-rpc (#112 PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`sapphire-agent-api` crate renamed to `sapphire-agent-rpc`** to match
+  the `/rpc` endpoint it talks to. The session-kind directory it persists
+  to also moves: `sessions/<ns>/api/` → `sessions/<ns>/rpc/`. Until the
+  bundled session migration runs (separate PR), readers transparently
+  fall through to the legacy `api/` directory so existing files remain
+  visible. The `api_keys` config field on `[room_profile.<n>]` is
+  deliberately unchanged — it gates `/rpc`, `/mcp`, and `/a2a` together
+  and the broad "api" name still fits. (#112)
+
 ## [0.6.1] - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,7 +7636,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "sapphire-agent-api"
+name = "sapphire-agent-rpc"
 version = "0.6.1"
 dependencies = [
  "anyhow",
@@ -7660,7 +7660,7 @@ dependencies = [
  "ndarray 0.17.2",
  "ort",
  "reqwest",
- "sapphire-agent-api",
+ "sapphire-agent-rpc",
  "serde",
  "sha2 0.11.0",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/sapphire-agent-api", "crates/sapphire-call"]
+members = [".", "crates/sapphire-agent-rpc", "crates/sapphire-call"]
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/crates/sapphire-agent-rpc/Cargo.toml
+++ b/crates/sapphire-agent-rpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "sapphire-agent-api"
+name = "sapphire-agent-rpc"
 version.workspace = true
 edition.workspace = true
-description = "Client library and shared types for sapphire-agent"
+description = "Client library and shared types for sapphire-agent's RPC surface"
 license.workspace = true
 repository.workspace = true
 

--- a/crates/sapphire-agent-rpc/src/lib.rs
+++ b/crates/sapphire-agent-rpc/src/lib.rs
@@ -1,6 +1,6 @@
 //! Client library for `sapphire-agent`.
 //!
-//! Provides an HTTP client for the sapphire-agent control API
+//! Provides an HTTP client for the sapphire-agent RPC surface
 //! (`/rpc`, JSON-RPC 2.0) and an interactive REPL that can be embedded
 //! in any binary (`sapphire-agent call` or the standalone
 //! `sapphire-call`).
@@ -60,7 +60,7 @@ impl DeviceMetadata {
 ///
 /// `token` is sent as `Authorization: Bearer <token>` and selects the
 /// room_profile server-side (the token must match an `api_keys` entry
-/// on some `[room_profile.<n>]`). The control API requires this on
+/// on some `[room_profile.<n>]`). The RPC surface requires this on
 /// every `/rpc` call — there is no anonymous mode.
 pub async fn initialize(
     client: &reqwest::Client,

--- a/crates/sapphire-agent-rpc/src/voice.rs
+++ b/crates/sapphire-agent-rpc/src/voice.rs
@@ -25,7 +25,7 @@ fn next_id() -> u64 {
 
 /// Pipeline sample rate. Must match the server-side constant in
 /// `sapphire-agent::voice::PIPELINE_SAMPLE_RATE`. Duplicated here so
-/// the API crate doesn't depend on the agent binary.
+/// the RPC crate doesn't depend on the agent binary.
 pub const PIPELINE_SAMPLE_RATE: u32 = 16_000;
 
 /// Wake-word configuration fetched from the server's `voice/config`

--- a/crates/sapphire-call/Cargo.toml
+++ b/crates/sapphire-call/Cargo.toml
@@ -11,7 +11,7 @@ name = "sapphire-call"
 path = "src/main.rs"
 
 [dependencies]
-sapphire-agent-api = { path = "../sapphire-agent-api", version = "0.6.1" }
+sapphire-agent-rpc = { path = "../sapphire-agent-rpc", version = "0.6.1" }
 
 # Async runtime — voice subcommand needs sync, time, and rt features.
 tokio = { workspace = true, features = ["sync", "time", "rt-multi-thread", "macros", "signal"] }

--- a/crates/sapphire-call/src/config.rs
+++ b/crates/sapphire-call/src/config.rs
@@ -103,11 +103,11 @@ pub struct DeviceConfig {
 impl DeviceConfig {
     /// Convert into the API crate's wire-format struct. Empty when no
     /// field is set so we don't send a meaningless `device: {}` block.
-    pub fn to_api(&self) -> Option<sapphire_agent_api::DeviceMetadata> {
+    pub fn to_api(&self) -> Option<sapphire_agent_rpc::DeviceMetadata> {
         if self.name.is_none() && self.description.is_none() {
             return None;
         }
-        Some(sapphire_agent_api::DeviceMetadata {
+        Some(sapphire_agent_rpc::DeviceMetadata {
             name: self.name.clone(),
             description: self.description.clone(),
         })

--- a/crates/sapphire-call/src/main.rs
+++ b/crates/sapphire-call/src/main.rs
@@ -160,7 +160,7 @@ async fn main() -> Result<()> {
         .await;
     }
 
-    sapphire_agent_api::run(
+    sapphire_agent_rpc::run(
         server,
         session,
         cli.list,

--- a/crates/sapphire-call/src/voice/mod.rs
+++ b/crates/sapphire-call/src/voice/mod.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, anyhow};
 use cpal::SampleFormat;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use sapphire_agent_api::{
+use sapphire_agent_rpc::{
     VoiceEvent, VoicePushEvent, voice::PIPELINE_SAMPLE_RATE, voice_pipeline_run, voice_subscribe,
 };
 use sherpa_onnx::{SileroVadModelConfig, VadModelConfig, VoiceActivityDetector};
@@ -73,7 +73,7 @@ pub struct VoiceOptions {
     pub output_device: Option<String>,
     /// Optional device identity sent in every `voice/pipeline_run` so the
     /// agent can render "voice channel with <name>" in the system prompt.
-    pub device: Option<sapphire_agent_api::DeviceMetadata>,
+    pub device: Option<sapphire_agent_rpc::DeviceMetadata>,
     /// Listen-state UX: confirmation beeps + post-reply follow-up
     /// listening window. See [`crate::config::BehaviorConfig`].
     pub behavior: crate::config::BehaviorConfig,
@@ -299,13 +299,13 @@ pub async fn run(
     eprintln!("sapphire-call voice (device: {device_id})");
 
     // ── Wake-word config: fetch the inline ONNX from the server ─────────
-    let server_wake = sapphire_agent_api::voice_config(&client, &base, &token)
+    let server_wake = sapphire_agent_rpc::voice_config(&client, &base, &token)
         .await
         .unwrap_or_else(|e| {
             eprintln!(
                 "warning: voice/config fetch failed ({e:#}); proceeding without wake-word gating"
             );
-            sapphire_agent_api::WakeWordConfig::default()
+            sapphire_agent_rpc::WakeWordConfig::default()
         });
 
     // ── VAD model ────────────────────────────────────────────────────────
@@ -329,7 +329,7 @@ pub async fn run(
     // ── Optional wake-word detector ─────────────────────────────────────
     let wake_detector: Option<oww::OpenWakeWordDetector> = match server_wake.model {
         Some(model) => {
-            let sapphire_agent_api::WakeWordModel {
+            let sapphire_agent_rpc::WakeWordModel {
                 filename,
                 sha256,
                 bytes,
@@ -556,7 +556,7 @@ struct ListenCtx {
     token: String,
     device_id: String,
     language: Option<String>,
-    device: Option<sapphire_agent_api::DeviceMetadata>,
+    device: Option<sapphire_agent_rpc::DeviceMetadata>,
     shutdown: Arc<AtomicBool>,
     vad: VoiceActivityDetector,
     /// `Some` enables wake-word mode; the satellite gates VAD behind
@@ -1536,7 +1536,7 @@ async fn process_utterance(
     device_id: &str,
     pcm_16khz: &[i16],
     language: Option<&str>,
-    device_meta: Option<&sapphire_agent_api::DeviceMetadata>,
+    device_meta: Option<&sapphire_agent_rpc::DeviceMetadata>,
     playback_queue: Arc<std::sync::Mutex<VecDeque<i16>>>,
     output_rate: u32,
 ) -> Result<()> {

--- a/crates/sapphire-call/src/voice/oww.rs
+++ b/crates/sapphire-call/src/voice/oww.rs
@@ -29,7 +29,7 @@ use ort::session::{Session, builder::GraphOptimizationLevel};
 use ort::value::TensorRef;
 
 #[cfg(test)]
-use sapphire_agent_api::voice::PIPELINE_SAMPLE_RATE;
+use sapphire_agent_rpc::voice::PIPELINE_SAMPLE_RATE;
 
 /// 80 ms at 16 kHz. The OWW pipeline only advances state on this
 /// boundary; sub-chunk audio is buffered until the next multiple.

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -102,9 +102,10 @@ pub struct RoomInfo {
     /// Free-form description / topic. `None` when the channel side has
     /// nothing to offer (e.g. Matrix DM with no topic).
     pub description: Option<String>,
-    /// Originating channel name: `"matrix"`, `"discord"`, `"api"`,
-    /// or `"voice"`. Lets the system prompt tell the model whether
-    /// transcripts may contain STT errors etc.
+    /// Originating channel name: `"matrix"`, `"discord"`, `"rpc"`
+    /// (legacy `"api"` until the bundled session migration rewrites
+    /// stored values), or `"voice"`. Lets the system prompt tell the
+    /// model whether transcripts may contain STT errors etc.
     pub kind: String,
 }
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -67,12 +67,13 @@ pub struct Heartbeat {
 
 impl Heartbeat {
     /// Resolve which namespace a session belongs to. Matrix/Discord rooms
-    /// follow `Config::namespace_for_room`. API sessions (channel="api")
-    /// fall back to the default namespace because their per-session
-    /// profile pinning is in-memory only and not persisted in the JSONL
-    /// metadata.
+    /// follow `Config::namespace_for_room`. RPC sessions (`channel="rpc"`,
+    /// or legacy `"api"` until the bundled session migration rewrites
+    /// stored values) fall back to the default namespace because their
+    /// per-session profile pinning is in-memory only and not persisted
+    /// in the JSONL metadata.
     fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
-        if meta.channel == "api" {
+        if meta.channel == "rpc" || meta.channel == "api" {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()
         } else {
             self.config.namespace_for_room(&meta.room_id).to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,10 +262,10 @@ async fn main() -> Result<()> {
                     .context("Failed to build provider registry")?,
             );
 
-            // ── API session store (sessions/<namespace>/api/) ──────────────
-            let api_session_store = Arc::new(SessionStore::with_workspace(
+            // ── RPC session store (sessions/<namespace>/rpc/) ──────────────
+            let rpc_session_store = Arc::new(SessionStore::with_workspace(
                 sessions_base.clone(),
-                "api",
+                "rpc",
                 Arc::clone(&ws_state),
             ));
 
@@ -350,7 +350,7 @@ async fn main() -> Result<()> {
                 Arc::clone(&registry),
                 Arc::clone(&workspace),
                 Arc::clone(&tool_set),
-                Arc::clone(&api_session_store),
+                Arc::clone(&rpc_session_store),
                 Arc::clone(&mcp_session_store),
                 voice_providers,
                 image_cache.clone(),
@@ -415,7 +415,10 @@ async fn main() -> Result<()> {
                     let cfg_for_predicate = config.clone();
                     let ns_for_predicate = ns.clone();
                     let predicate = move |meta: &session::SessionMeta| -> bool {
-                        if meta.channel == "api" {
+                        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112)
+                        // until the bundled session migration rewrites stored
+                        // `meta.channel` strings.
+                        if meta.channel == "api" || meta.channel == "rpc" {
                             return ns_for_predicate == config::DEFAULT_NAMESPACE_NAME;
                         }
                         cfg_for_predicate.namespace_for_room(&meta.room_id) == ns_for_predicate
@@ -497,7 +500,7 @@ async fn main() -> Result<()> {
                     let workspace_for_loop = Arc::clone(&workspace);
                     let workspace_dir_for_loop = workspace_dir.clone();
                     let channel_store_for_loop = Arc::clone(&channel_session_store);
-                    let api_store_for_loop = Arc::clone(&api_session_store);
+                    let rpc_store_for_loop = Arc::clone(&rpc_session_store);
                     let agent_for_loop = Arc::clone(&agent);
                     tokio::spawn(async move {
                         let mut tick = tokio::time::interval(dur);
@@ -518,7 +521,7 @@ async fn main() -> Result<()> {
                                 &workspace_for_loop,
                                 &workspace_dir_for_loop,
                                 &channel_store_for_loop,
-                                &api_store_for_loop,
+                                &rpc_store_for_loop,
                                 &agent_for_loop,
                             )
                             .await;
@@ -533,7 +536,7 @@ async fn main() -> Result<()> {
                         &workspace,
                         &workspace_dir,
                         &channel_session_store,
-                        &api_session_store,
+                        &rpc_session_store,
                         &agent,
                     )
                     .await;
@@ -626,7 +629,7 @@ async fn rebuild_today_digests(
     workspace: &Arc<Workspace>,
     workspace_dir: &std::path::Path,
     channel_store: &Arc<SessionStore>,
-    api_store: &Arc<SessionStore>,
+    rpc_store: &Arc<SessionStore>,
     agent: &Arc<Agent>,
 ) {
     let today = session::local_date_for_timestamp(chrono::Local::now(), config.day_boundary_hour);
@@ -637,7 +640,7 @@ async fn rebuild_today_digests(
         today,
         config.day_boundary_hour,
         channel_store,
-        Some(api_store.as_ref()),
+        Some(rpc_store.as_ref()),
         |room_id: &str| cfg.namespace_for_room(room_id).to_string(),
     );
     let had_content = !map.is_empty();
@@ -660,7 +663,10 @@ async fn rebuild_today_digests(
 fn migrate_sessions_to_namespaced_layout(sessions_base: &std::path::Path) -> anyhow::Result<()> {
     use std::io::{BufRead, BufReader};
 
-    for kind in ["channel", "api"] {
+    // Pre-namespace migration covers both the legacy `"api"` kind dir and
+    // the post-#112 `"rpc"` dir; either may exist in a long-lived workspace
+    // that skipped a release.
+    for kind in ["channel", "api", "rpc"] {
         let kind_dir = sessions_base.join(kind);
         if !kind_dir.is_dir() {
             continue;

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -1184,7 +1184,10 @@ where
 
     let mut lines: Vec<String> = Vec::new();
     for (meta, digest) in entries {
-        let ns = if meta.channel == "api" {
+        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112) until the
+        // bundled session migration rewrites stored `meta.channel` strings.
+        let is_rpc = meta.channel == "rpc" || meta.channel == "api";
+        let ns = if is_rpc {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()
         } else {
             room_to_namespace(&meta.room_id)
@@ -1192,10 +1195,10 @@ where
         if ns != namespace {
             continue;
         }
-        let room_label = if meta.channel == "api" {
-            meta.title
-                .clone()
-                .unwrap_or_else(|| format!("api/{}", short_id(&meta.session_id)))
+        let room_label = if is_rpc {
+            meta.title.clone().unwrap_or_else(|| {
+                format!("{}/{}", meta.channel, short_id(&meta.session_id))
+            })
         } else {
             format!("{}/{}", meta.channel, short_id(&meta.room_id))
         };

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -59,10 +59,10 @@ pub struct ServeState {
     pub(crate) registry: Arc<ProviderRegistry>,
     pub(crate) workspace: Arc<Workspace>,
     pub(crate) tools: Arc<ToolSet>,
-    pub(crate) api_session_store: Arc<SessionStore>,
+    pub(crate) rpc_session_store: Arc<SessionStore>,
     /// MCP session store (kind = `"mcp"`). Holds long-lived
     /// per-project sessions written through `/mcp`'s `write_report`
-    /// tool — kept physically separate from `api_session_store` so the
+    /// tool — kept physically separate from `rpc_session_store` so the
     /// project index scan and any future MCP-specific retention only
     /// see MCP traffic.
     pub(crate) mcp_session_store: Arc<SessionStore>,
@@ -111,7 +111,7 @@ pub struct ServeState {
 }
 
 impl ServeState {
-    /// Construct a runtime ready for both the HTTP API server and
+    /// Construct a runtime ready for both the HTTP RPC server and
     /// the in-process channel handlers (Discord voice in particular).
     /// Shared across both so they read from the same session store /
     /// in-memory conversation map.
@@ -121,7 +121,7 @@ impl ServeState {
         registry: Arc<ProviderRegistry>,
         workspace: Arc<Workspace>,
         tools: Arc<ToolSet>,
-        api_session_store: Arc<SessionStore>,
+        rpc_session_store: Arc<SessionStore>,
         mcp_session_store: Arc<SessionStore>,
         voice: Option<Arc<VoiceProviders>>,
         image_cache: Option<Arc<crate::image_cache::ImageCache>>,
@@ -148,7 +148,7 @@ impl ServeState {
             registry,
             workspace,
             tools,
-            api_session_store,
+            rpc_session_store,
             mcp_session_store,
             mcp_project_index: tokio::sync::Mutex::new(mcp_index),
             sessions: tokio::sync::Mutex::new(HashMap::new()),
@@ -281,7 +281,7 @@ fn error_event(id: &Value, code: i32, message: &str) -> Event {
 pub async fn run(addr: String, state: Arc<ServeState>) -> anyhow::Result<()> {
     // Routes are intentionally separated so future protocol endpoints
     // (`/mcp` for the MCP server in #79/#80) can be mounted alongside
-    // `/rpc` without colliding with the control API methods (`chat`,
+    // `/rpc` without colliding with the methods (`chat`,
     // `initialize`, `voice/*`, …) that live here. The A2A protocol
     // endpoints below are mounted unconditionally — the handler refuses
     // requests when `[a2a].enabled = false` so we don't pay a route
@@ -327,7 +327,7 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
         return;
     }
     info!(
-        "Graceful shutdown: summarizing {} API session(s)",
+        "Graceful shutdown: summarizing {} RPC session(s)",
         snapshot.len()
     );
     for (session_id, messages) in snapshot {
@@ -335,14 +335,14 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
         match generate_summary(&*provider, &messages).await {
             Ok(summary) if !summary.trim().is_empty() => {
                 if let Err(e) = state
-                    .api_session_store
+                    .rpc_session_store
                     .append_summary(&session_id, &summary)
                 {
                     warn!("Failed to persist shutdown summary for {session_id}: {e}");
                 }
                 if let Err(e) =
                     state
-                        .api_session_store
+                        .rpc_session_store
                         .append_intraday_digest(&session_id, &summary, None)
                 {
                     warn!("Failed to persist shutdown intra-day digest for {session_id}: {e}");
@@ -475,7 +475,7 @@ async fn handle_initialize(
 
         match param_id {
             None => None,
-            Some(ref id) if id.len() == 7 => match state.api_session_store.find_by_public_id(id) {
+            Some(ref id) if id.len() == 7 => match state.rpc_session_store.find_by_public_id(id) {
                 Some(uuid) => Some(uuid),
                 None => {
                     let body = error_response(req_id, -32602, "Session not found");
@@ -495,7 +495,7 @@ async fn handle_initialize(
 
     let (session_id, is_new) = match resolved {
         Some(id) => {
-            let exists = state.api_session_store.load_session(&id).is_some();
+            let exists = state.rpc_session_store.load_session(&id).is_some();
             (id, !exists)
         }
         None => (uuid::Uuid::now_v7().to_string(), true),
@@ -517,13 +517,13 @@ async fn handle_initialize(
         let mut sessions = state.sessions.lock().await;
         sessions.entry(session_id.clone()).or_insert_with(|| {
             state
-                .api_session_store
+                .rpc_session_store
                 .load_session(&session_id)
                 .unwrap_or_default()
         });
         // Look up the public_id from the existing file metadata.
         state
-            .api_session_store
+            .rpc_session_store
             .list_sessions()
             .into_iter()
             .find(|m| m.session_id == session_id)
@@ -645,7 +645,7 @@ async fn handle_chat(
 // ---------------------------------------------------------------------------
 
 async fn handle_list_sessions(state: Arc<ServeState>, req_id: Value) -> axum::response::Response {
-    let metas = state.api_session_store.list_sessions();
+    let metas = state.rpc_session_store.list_sessions();
     let items: Vec<Value> = metas
         .into_iter()
         .map(|m| {
@@ -689,7 +689,7 @@ async fn handle_get_session(
     };
 
     let messages = state
-        .api_session_store
+        .rpc_session_store
         .load_session(&session_id)
         .unwrap_or_default();
 
@@ -706,7 +706,7 @@ async fn handle_get_session(
                 .map(|p| match p {
                     ContentPart::Text(t) => json!({ "type": "text", "text": t }),
                     ContentPart::Image { media_type, .. } => {
-                        // Image bytes are not exposed via the API listing; surface a marker only.
+                        // Image bytes are not exposed via the RPC listing; surface a marker only.
                         json!({ "type": "image", "media_type": media_type })
                     }
                     ContentPart::ImageRef { media_type, sha256 } => {
@@ -1347,7 +1347,7 @@ async fn run_voice_turn_from_text_sse(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_text, &reply).await
-                && let Err(e) = state2.api_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }
@@ -1561,7 +1561,7 @@ async fn run_llm_turn(
             .entry(session_id.clone())
             .or_insert_with(|| {
                 state
-                    .api_session_store
+                    .rpc_session_store
                     .load_session(&session_id)
                     .unwrap_or_default()
             })
@@ -1589,8 +1589,8 @@ async fn run_llm_turn(
     let key: ConversationKey = (session_id.clone(), None);
     let pending_pub_id = state.pending_sessions.lock().await.remove(&session_id);
     if let Err(e) = state
-        .api_session_store
-        .ensure_session(&session_id, &key, "api", pending_pub_id, &namespace)
+        .rpc_session_store
+        .ensure_session(&session_id, &key, "rpc", pending_pub_id, &namespace)
         .map(|_| ())
     {
         warn!("Failed to ensure session file: {e}");
@@ -1620,7 +1620,7 @@ async fn run_llm_turn(
     //    `SessionStore::append` so the in-memory history keeps full image
     //    bytes for the provider call while JSONL gets a hash marker.
     history.push(user_msg.clone());
-    if let Err(e) = state.api_session_store.append(&session_id, &user_msg) {
+    if let Err(e) = state.rpc_session_store.append(&session_id, &user_msg) {
         warn!("Failed to persist user message: {e}");
     }
 
@@ -1649,7 +1649,7 @@ async fn run_llm_turn(
             Ok(Some(result)) => {
                 history = result.compressed;
                 if let Err(e) = state
-                    .api_session_store
+                    .rpc_session_store
                     .append_summary(&session_id, &result.summary)
                 {
                     warn!("Failed to persist compaction summary: {e}");
@@ -1682,7 +1682,7 @@ async fn run_llm_turn(
                 let text = resp.text.unwrap_or_default();
                 let msg = ChatMessage::assistant(&text);
                 history.push(msg.clone());
-                if let Err(e) = state.api_session_store.append(&session_id, &msg) {
+                if let Err(e) = state.rpc_session_store.append(&session_id, &msg) {
                     warn!("Failed to persist assistant message: {e}");
                 }
                 if !text.is_empty() {
@@ -1827,7 +1827,7 @@ async fn run_turn(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_msg, &text).await
-                && let Err(e) = state2.api_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -174,9 +174,11 @@ pub struct SessionStore {
     /// so retrieve indexing can scope itself by directory and never
     /// accidentally mix NSFW sessions with default-namespace ones.
     pub base_dir: PathBuf,
-    /// Second-level subdirectory: `"channel"` for Matrix/Discord, `"api"`
-    /// for HTTP. Lets the Agent and ServeState keep separate
-    /// `SessionStore` instances while sharing one base dir.
+    /// Second-level subdirectory: `"channel"` for Matrix/Discord, `"rpc"`
+    /// for HTTP (renamed from `"api"` in #112; readers transparently
+    /// fall through to the legacy `"api"` dir until the bundled session
+    /// migration moves the files). Lets the Agent and ServeState keep
+    /// separate `SessionStore` instances while sharing one base dir.
     pub kind: &'static str,
     /// Optional sapphire-workspace state. When set, file modifications notify
     /// the workspace so the index/cache and git staging stay in sync.
@@ -639,8 +641,9 @@ impl SessionStore {
     /// Ensure a session file exists for the given caller-supplied ID.
     /// Unlike `create_session`, this uses the provided ID rather than generating a new UUID.
     ///
-    /// For API sessions (`channel == "api"`), a grain-id `public_id` is generated on creation
-    /// unless `public_id_override` is supplied (used to commit a deferred public_id).
+    /// For RPC sessions (`channel == "rpc"`, or legacy `"api"`), a grain-id
+    /// `public_id` is generated on creation unless `public_id_override` is
+    /// supplied (used to commit a deferred public_id).
     /// Returns the `public_id` if present (new or existing).
     pub fn ensure_session(
         &self,
@@ -659,7 +662,7 @@ impl SessionStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let public_id = if channel == "api" {
+        let public_id = if channel == "rpc" || channel == "api" {
             Some(public_id_override.unwrap_or_else(|| grain_id::GrainId::random().to_string()))
         } else {
             None
@@ -885,24 +888,36 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// Enumerate `<base_dir>/<namespace>/<kind>/*.jsonl` across every namespace
 /// directory. Returns an empty Vec when `base_dir` doesn't exist yet (fresh
 /// install) or has no namespace subdirs. Each returned path is absolute.
+///
+/// Dual-read shim for #112: when `kind == "rpc"`, the legacy `"api"` directory
+/// is also scanned so post-rename builds keep surfacing pre-migration files.
+/// The bundled session-store migration removes the shim once it has moved the
+/// files into the new layout.
 fn collect_session_files(base_dir: &Path, kind: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let Ok(entries) = fs::read_dir(base_dir) else {
         return out;
+    };
+    let scan_kinds: &[&str] = if kind == "rpc" {
+        &["rpc", "api"]
+    } else {
+        std::slice::from_ref(&kind)
     };
     for entry in entries.flatten() {
         let ns_dir = entry.path();
         if !ns_dir.is_dir() {
             continue;
         }
-        let kind_dir = ns_dir.join(kind);
-        let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
-            continue;
-        };
-        for k_entry in kind_entries.flatten() {
-            let path = k_entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                out.push(path);
+        for k in scan_kinds {
+            let kind_dir = ns_dir.join(k);
+            let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
+                continue;
+            };
+            for k_entry in kind_entries.flatten() {
+                let path = k_entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                    out.push(path);
+                }
             }
         }
     }
@@ -1118,5 +1133,37 @@ mod tests {
             scrub_images_for_storage(&msg).is_none(),
             "scrub should leave ImageRef-only messages untouched"
         );
+    }
+
+    /// Post-#112 dual-read shim: when scanning for `"rpc"` files, the
+    /// legacy `"api"` sub-directory must also be visible so existing
+    /// sessions stay reachable until the bundled migration moves them.
+    #[test]
+    fn collect_session_files_dual_reads_legacy_api_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ns = tmp.path().join("default");
+        let api_dir = ns.join("api");
+        let rpc_dir = ns.join("rpc");
+        fs::create_dir_all(&api_dir).unwrap();
+        fs::create_dir_all(&rpc_dir).unwrap();
+        let legacy = api_dir.join("old.jsonl");
+        let fresh = rpc_dir.join("new.jsonl");
+        std::fs::write(&legacy, b"").unwrap();
+        std::fs::write(&fresh, b"").unwrap();
+
+        // Stray file that should NOT be picked up (wrong extension).
+        std::fs::write(rpc_dir.join("ignore.txt"), b"").unwrap();
+
+        let mut found = collect_session_files(tmp.path(), "rpc");
+        found.sort();
+        assert_eq!(found, {
+            let mut expected = vec![legacy, fresh];
+            expected.sort();
+            expected
+        });
+
+        // Sanity: scanning a non-rpc kind does NOT pull in the api dir.
+        let channel_only = collect_session_files(tmp.path(), "channel");
+        assert!(channel_only.is_empty(), "channel scan must not see rpc/api dirs");
     }
 }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -34,7 +34,7 @@ pub const PIPELINE_SAMPLE_RATE: u32 = 16_000;
 
 /// Server-internal push event delivered to a `voice/subscribe` writer
 /// task, which translates to wire-format SSE notifications. Mirrors the
-/// public `VoicePushEvent` in `sapphire-agent-api` plus enough metadata
+/// public `VoicePushEvent` in `sapphire-agent-rpc` plus enough metadata
 /// to reconstruct the heartbeat task name on the wire.
 #[derive(Debug, Clone)]
 pub enum VoicePushItem {


### PR DESCRIPTION
## Summary

First of three PRs implementing #112 + the bundled session-model migration (#122). This PR is the **pure rename** half of #112 with no behaviour change — safe to ship alone.

- Renames the `sapphire-agent-api` crate to `sapphire-agent-rpc` to align with the `/rpc` endpoint it talks to. Updates `sapphire-call`'s dependency accordingly.
- Renames the session-kind directory: new sessions write to `sessions/<ns>/rpc/`; existing files in `sessions/<ns>/api/` remain readable via a dual-read shim in `collect_session_files`.
- Renames `ServeState::api_session_store` → `rpc_session_store` (~16 sites in `src/serve/mod.rs`) and the matching local bindings in `src/main.rs`.
- Sweeps doc strings referring to "the API" or "the api crate" → "the RPC surface" / "the rpc crate". Skips cases where "API" refers to external systems (Anthropic API, Matrix SDK API).
- `meta.channel == "api"` comparison sites in `heartbeat.rs`, `periodic_log.rs`, and `main.rs` now dual-accept both `"api"` and `"rpc"` so legacy stored sessions still flow through namespace / digest logic correctly.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Intentionally untouched

- **`api_keys` config field** on `[room_profile.<n>]` — gates `/rpc` + `/mcp` + `/a2a` together, so naming it after any single endpoint would mislead. The "api" here is used in its broad sense and stays. Documented decision: #112 (comment).
- `src/provider/anthropic.rs:77` — `"api"` is part of a programming-keywords list, unrelated to this rename.

## How the dual-read shim works

After this PR, the running server writes to `sessions/<ns>/rpc/` but old files in `sessions/<ns>/api/` are still on disk. `collect_session_files` is extended so a scan for `kind="rpc"` also walks the legacy `api/` sub-directory, and stored `meta.channel` values are accepted as either `"api"` or `"rpc"` until the bundled session migration (PR 3) rewrites them.

This shim is **temporary** — PR 3 moves the files and removes the dual-read branch.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 173 tests pass (144 + 3 + 26)
- [x] New unit test `session::tests::collect_session_files_dual_reads_legacy_api_dir` covers the shim
- [ ] Manual smoke against live `~/.saph1na_workspace/` (which has `default/api/voice-08ae74768935ca67.jsonl`) — confirm the voice session is still readable

## Follow-ups

- **PR 2**: implement the device-default + cross-device session model (#122) — separate routing logic, new directory layouts, no migration yet
- **PR 3**: bundled migration script that moves files from `api/` → `rpc/`, voice sessions to a `legacy-voice/` quarantine, text sessions to `cross-device/`, and removes the dual-read shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)