### PR TITLE
feat(sessions): device-default sessions for voice/heartbeat (#122 PR 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Device-default sessions** — a new session kind keyed by
+  `(device_id, room_profile)` that voice satellites and heartbeat
+  pushes route into when no other session is selected. Stored under
+  `sessions/<ns>/device-default/<uuid>.jsonl`; lazy-created (no file
+  appears until a satellite is actually used); daily-rotated by the
+  "most-recent-from-today" lookup, so a satellite that connects after
+  the local-day boundary lands in a fresh session automatically. The
+  previous deterministic `voice-<sha256>.jsonl` scheme is retired —
+  voice traffic now flows through the same `SessionStore` surface as
+  every other kind. (#122)
+
 ### Changed
 
 - **`sapphire-agent-api` crate renamed to `sapphire-agent-rpc`** to match
@@ -17,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   visible. The `api_keys` config field on `[room_profile.<n>]` is
   deliberately unchanged — it gates `/rpc`, `/mcp`, and `/a2a` together
   and the broad "api" name still fits. (#112)
+- **`ServeState::rpc_session_store` → `cross_device_session_store`** —
+  user-selectable, multi-device sessions resumed via `--resume
+  <grain-id>` are now logically separated from device-default sessions.
+  The on-disk directory remains `sessions/<ns>/rpc/` for now; the
+  bundled session migration (PR 3) renames it to `cross-device/`. (#122)
 
 ## [0.6.1] - 2026-05-18
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -67,14 +67,20 @@ pub struct Heartbeat {
 
 impl Heartbeat {
     /// Resolve which namespace a session belongs to. Matrix/Discord rooms
-    /// follow `Config::namespace_for_room`. RPC sessions (`channel="rpc"`,
-    /// or legacy `"api"` until the bundled session migration rewrites
-    /// stored values) fall back to the default namespace because their
-    /// per-session profile pinning is in-memory only and not persisted
-    /// in the JSONL metadata.
+    /// follow `Config::namespace_for_room`. Device-default sessions
+    /// (channel=`"device-default"`) and RPC cross-device sessions
+    /// (`"rpc"`, or legacy `"api"` until the bundled session migration
+    /// rewrites stored values) persist their resolved namespace in the
+    /// JSONL meta — trust that first, falling back to the default
+    /// namespace for old files that predate the field.
     fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
-        if meta.channel == "rpc" || meta.channel == "api" {
-            crate::config::DEFAULT_NAMESPACE_NAME.to_string()
+        if meta.channel == "device-default"
+            || meta.channel == "rpc"
+            || meta.channel == "api"
+        {
+            meta.namespace
+                .clone()
+                .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())
         } else {
             self.config.namespace_for_room(&meta.room_id).to_string()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,10 +262,25 @@ async fn main() -> Result<()> {
                     .context("Failed to build provider registry")?,
             );
 
-            // ── RPC session store (sessions/<namespace>/rpc/) ──────────────
-            let rpc_session_store = Arc::new(SessionStore::with_workspace(
+            // ── Cross-device session store (sessions/<namespace>/rpc/) ─────
+            // Cross-device sessions are the user-selectable, multi-device
+            // conversation threads (resumed via `--resume <grain-id>`).
+            // The on-disk directory is still `rpc/` until the bundled
+            // session migration (#122 PR 3) renames it to `cross-device/`;
+            // the kind constant matches.
+            let cross_device_session_store = Arc::new(SessionStore::with_workspace(
                 sessions_base.clone(),
                 "rpc",
+                Arc::clone(&ws_state),
+            ));
+
+            // ── Device-default session store (sessions/<ns>/device-default/) ─
+            // Lazy-created, daily-rotated per `(device_id, room_profile)` —
+            // the heartbeat target and the implicit session for a satellite
+            // with nothing else selected. See #122.
+            let device_default_session_store = Arc::new(SessionStore::with_workspace(
+                sessions_base.clone(),
+                "device-default",
                 Arc::clone(&ws_state),
             ));
 
@@ -350,7 +365,8 @@ async fn main() -> Result<()> {
                 Arc::clone(&registry),
                 Arc::clone(&workspace),
                 Arc::clone(&tool_set),
-                Arc::clone(&rpc_session_store),
+                Arc::clone(&cross_device_session_store),
+                Arc::clone(&device_default_session_store),
                 Arc::clone(&mcp_session_store),
                 voice_providers,
                 image_cache.clone(),
@@ -500,7 +516,8 @@ async fn main() -> Result<()> {
                     let workspace_for_loop = Arc::clone(&workspace);
                     let workspace_dir_for_loop = workspace_dir.clone();
                     let channel_store_for_loop = Arc::clone(&channel_session_store);
-                    let rpc_store_for_loop = Arc::clone(&rpc_session_store);
+                    let cross_device_store_for_loop = Arc::clone(&cross_device_session_store);
+                    let device_default_store_for_loop = Arc::clone(&device_default_session_store);
                     let agent_for_loop = Arc::clone(&agent);
                     tokio::spawn(async move {
                         let mut tick = tokio::time::interval(dur);
@@ -521,7 +538,8 @@ async fn main() -> Result<()> {
                                 &workspace_for_loop,
                                 &workspace_dir_for_loop,
                                 &channel_store_for_loop,
-                                &rpc_store_for_loop,
+                                &cross_device_store_for_loop,
+                                &device_default_store_for_loop,
                                 &agent_for_loop,
                             )
                             .await;
@@ -536,7 +554,8 @@ async fn main() -> Result<()> {
                         &workspace,
                         &workspace_dir,
                         &channel_session_store,
-                        &rpc_session_store,
+                        &cross_device_session_store,
+                        &device_default_session_store,
                         &agent,
                     )
                     .await;
@@ -629,7 +648,8 @@ async fn rebuild_today_digests(
     workspace: &Arc<Workspace>,
     workspace_dir: &std::path::Path,
     channel_store: &Arc<SessionStore>,
-    rpc_store: &Arc<SessionStore>,
+    cross_device_store: &Arc<SessionStore>,
+    device_default_store: &Arc<SessionStore>,
     agent: &Arc<Agent>,
 ) {
     let today = session::local_date_for_timestamp(chrono::Local::now(), config.day_boundary_hour);
@@ -640,7 +660,8 @@ async fn rebuild_today_digests(
         today,
         config.day_boundary_hour,
         channel_store,
-        Some(rpc_store.as_ref()),
+        Some(cross_device_store.as_ref()),
+        Some(device_default_store.as_ref()),
         |room_id: &str| cfg.namespace_for_room(room_id).to_string(),
     );
     let had_content = !map.is_empty();

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -1156,9 +1156,10 @@ pub async fn catchup_pending_yearly_logs(
 // ---------------------------------------------------------------------------
 
 /// Render the bullet block that goes under `# Today's Cross-Session Notes`
-/// for `namespace`. Walks `channel_store` and `api_store` for digests
-/// whose `digest_at` falls inside `today`'s local window, keeping only
-/// the latest per session that maps to `namespace` via `room_to_namespace`.
+/// for `namespace`. Walks `channel_store`, `cross_device_store`, and
+/// `device_default_store` for digests whose `digest_at` falls inside
+/// `today`'s local window, keeping only the latest per session that
+/// maps to `namespace`.
 ///
 /// Returns `None` when no qualifying digest exists, so the caller can
 /// omit the namespace from the cache map and the system prompt block.
@@ -1167,7 +1168,8 @@ pub fn build_today_digest_for_namespace<F>(
     today: NaiveDate,
     boundary_hour: u8,
     channel_store: &SessionStore,
-    api_store: Option<&SessionStore>,
+    cross_device_store: Option<&SessionStore>,
+    device_default_store: Option<&SessionStore>,
     room_to_namespace: F,
 ) -> Option<String>
 where
@@ -1175,8 +1177,11 @@ where
 {
     let mut entries: Vec<(SessionMeta, crate::session::IntradayDigestLine)> = Vec::new();
     entries.extend(channel_store.intraday_digests_for_day(today, boundary_hour));
-    if let Some(api) = api_store {
-        entries.extend(api.intraday_digests_for_day(today, boundary_hour));
+    if let Some(s) = cross_device_store {
+        entries.extend(s.intraday_digests_for_day(today, boundary_hour));
+    }
+    if let Some(s) = device_default_store {
+        entries.extend(s.intraday_digests_for_day(today, boundary_hour));
     }
     if entries.is_empty() {
         return None;
@@ -1187,15 +1192,23 @@ where
         // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112) until the
         // bundled session migration rewrites stored `meta.channel` strings.
         let is_rpc = meta.channel == "rpc" || meta.channel == "api";
+        let is_device_default = meta.channel == "device-default";
         let ns = if is_rpc {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()
+        } else if is_device_default {
+            // Device-default sessions pin their namespace at create time —
+            // honour it directly so an NSFW-profile satellite's digests
+            // don't leak into the default namespace.
+            meta.namespace
+                .clone()
+                .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())
         } else {
             room_to_namespace(&meta.room_id)
         };
         if ns != namespace {
             continue;
         }
-        let room_label = if is_rpc {
+        let room_label = if is_rpc || is_device_default {
             meta.title.clone().unwrap_or_else(|| {
                 format!("{}/{}", meta.channel, short_id(&meta.session_id))
             })
@@ -1226,7 +1239,8 @@ pub fn build_all_today_digests<F>(
     today: NaiveDate,
     boundary_hour: u8,
     channel_store: &SessionStore,
-    api_store: Option<&SessionStore>,
+    cross_device_store: Option<&SessionStore>,
+    device_default_store: Option<&SessionStore>,
     room_to_namespace: F,
 ) -> HashMap<String, String>
 where
@@ -1239,7 +1253,8 @@ where
             today,
             boundary_hour,
             channel_store,
-            api_store,
+            cross_device_store,
+            device_default_store,
             room_to_namespace,
         ) {
             out.insert(ns.clone(), text);

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -59,10 +59,19 @@ pub struct ServeState {
     pub(crate) registry: Arc<ProviderRegistry>,
     pub(crate) workspace: Arc<Workspace>,
     pub(crate) tools: Arc<ToolSet>,
-    pub(crate) rpc_session_store: Arc<SessionStore>,
+    /// Cross-device session store (kind = `"rpc"` for now; #122 PR 3
+    /// renames the on-disk dir to `cross-device/`). Holds the
+    /// user-selectable, multi-device sessions resumed via
+    /// `--resume <grain-id>`.
+    pub(crate) cross_device_session_store: Arc<SessionStore>,
+    /// Device-default session store (kind = `"device-default"`). Holds the
+    /// per-`(device_id, room_profile)` always-on session that heartbeat
+    /// pushes target and that a satellite falls into when no other session
+    /// is selected. Lazy-created, daily-rotated. See #122.
+    pub(crate) device_default_session_store: Arc<SessionStore>,
     /// MCP session store (kind = `"mcp"`). Holds long-lived
     /// per-project sessions written through `/mcp`'s `write_report`
-    /// tool — kept physically separate from `rpc_session_store` so the
+    /// tool — kept physically separate from `cross_device_session_store` so the
     /// project index scan and any future MCP-specific retention only
     /// see MCP traffic.
     pub(crate) mcp_session_store: Arc<SessionStore>,
@@ -121,7 +130,8 @@ impl ServeState {
         registry: Arc<ProviderRegistry>,
         workspace: Arc<Workspace>,
         tools: Arc<ToolSet>,
-        rpc_session_store: Arc<SessionStore>,
+        cross_device_session_store: Arc<SessionStore>,
+        device_default_session_store: Arc<SessionStore>,
         mcp_session_store: Arc<SessionStore>,
         voice: Option<Arc<VoiceProviders>>,
         image_cache: Option<Arc<crate::image_cache::ImageCache>>,
@@ -148,7 +158,8 @@ impl ServeState {
             registry,
             workspace,
             tools,
-            rpc_session_store,
+            cross_device_session_store,
+            device_default_session_store,
             mcp_session_store,
             mcp_project_index: tokio::sync::Mutex::new(mcp_index),
             sessions: tokio::sync::Mutex::new(HashMap::new()),
@@ -158,6 +169,24 @@ impl ServeState {
             voice,
             voice_subscribers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             image_cache,
+        }
+    }
+
+    /// Pick the [`SessionStore`] that owns `session_id`. Device-default
+    /// sessions land in `device-default/`; everything else (cross-device
+    /// text sessions, deferred sessions awaiting their first message)
+    /// lives in `cross_device_session_store`'s `rpc/` tree. Falls back
+    /// to the cross-device store so newly-`ensure_session`'d files
+    /// (which haven't hit disk yet) commit to the right place. See #122.
+    pub(crate) fn store_for_session(&self, session_id: &str) -> &Arc<SessionStore> {
+        if self
+            .device_default_session_store
+            .absolute_path_for(session_id)
+            .is_some()
+        {
+            &self.device_default_session_store
+        } else {
+            &self.cross_device_session_store
         }
     }
 
@@ -332,19 +361,13 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
     );
     for (session_id, messages) in snapshot {
         let provider = state.provider_for_session(&session_id).await;
+        let store = state.store_for_session(&session_id);
         match generate_summary(&*provider, &messages).await {
             Ok(summary) if !summary.trim().is_empty() => {
-                if let Err(e) = state
-                    .rpc_session_store
-                    .append_summary(&session_id, &summary)
-                {
+                if let Err(e) = store.append_summary(&session_id, &summary) {
                     warn!("Failed to persist shutdown summary for {session_id}: {e}");
                 }
-                if let Err(e) =
-                    state
-                        .rpc_session_store
-                        .append_intraday_digest(&session_id, &summary, None)
-                {
+                if let Err(e) = store.append_intraday_digest(&session_id, &summary, None) {
                     warn!("Failed to persist shutdown intra-day digest for {session_id}: {e}");
                 }
             }
@@ -475,7 +498,7 @@ async fn handle_initialize(
 
         match param_id {
             None => None,
-            Some(ref id) if id.len() == 7 => match state.rpc_session_store.find_by_public_id(id) {
+            Some(ref id) if id.len() == 7 => match state.cross_device_session_store.find_by_public_id(id) {
                 Some(uuid) => Some(uuid),
                 None => {
                     let body = error_response(req_id, -32602, "Session not found");
@@ -495,7 +518,7 @@ async fn handle_initialize(
 
     let (session_id, is_new) = match resolved {
         Some(id) => {
-            let exists = state.rpc_session_store.load_session(&id).is_some();
+            let exists = state.cross_device_session_store.load_session(&id).is_some();
             (id, !exists)
         }
         None => (uuid::Uuid::now_v7().to_string(), true),
@@ -517,13 +540,13 @@ async fn handle_initialize(
         let mut sessions = state.sessions.lock().await;
         sessions.entry(session_id.clone()).or_insert_with(|| {
             state
-                .rpc_session_store
+                .cross_device_session_store
                 .load_session(&session_id)
                 .unwrap_or_default()
         });
         // Look up the public_id from the existing file metadata.
         state
-            .rpc_session_store
+            .cross_device_session_store
             .list_sessions()
             .into_iter()
             .find(|m| m.session_id == session_id)
@@ -645,7 +668,7 @@ async fn handle_chat(
 // ---------------------------------------------------------------------------
 
 async fn handle_list_sessions(state: Arc<ServeState>, req_id: Value) -> axum::response::Response {
-    let metas = state.rpc_session_store.list_sessions();
+    let metas = state.cross_device_session_store.list_sessions();
     let items: Vec<Value> = metas
         .into_iter()
         .map(|m| {
@@ -689,7 +712,7 @@ async fn handle_get_session(
     };
 
     let messages = state
-        .rpc_session_store
+        .store_for_session(&session_id)
         .load_session(&session_id)
         .unwrap_or_default();
 
@@ -834,12 +857,31 @@ async fn handle_voice_pipeline_run(
     // `rpc_post`; clients no longer pass it as a param.
     let language = params["language"].as_str().map(|s| s.to_string());
 
-    // Derive a deterministic session id from (device_id, room_profile)
-    // so the satellite can resume the conversation thread across
-    // restarts / day boundaries without juggling explicit session
-    // tokens. Pin the room_profile so run_llm_turn picks up the
-    // right LLM profile + memory namespace + voice config.
-    let session_id = voice_session_id(&device_id, &room_profile);
+    // Resolve / lazily-create the device-default session for this
+    // `(device_id, room_profile)` pair under that profile's memory
+    // namespace. Daily rotation falls out naturally: a satellite
+    // reconnecting after the day boundary finds yesterday's file as
+    // "not in today's window" and a fresh UUID file is opened. See #122.
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&room_profile)
+        .to_string();
+    let session_id = match state.device_default_session_store.find_or_create_for_device(
+        &device_id,
+        &room_profile,
+        &namespace,
+        state.config.day_boundary_hour,
+    ) {
+        Ok(id) => id,
+        Err(e) => {
+            let body = error_response(
+                req_id,
+                -32603,
+                &format!("failed to resolve device-default session: {e}"),
+            );
+            return body.into_response();
+        }
+    };
     state
         .session_room_profiles
         .lock()
@@ -997,28 +1039,6 @@ async fn translate_voice_pushes(
     }
 }
 
-/// Deterministic session id derived from `(device_id, room_profile)`.
-/// Always-same input ⇒ always-same id, so a satellite reconnecting
-/// after a crash or day rollover resumes the same conversation file.
-///
-/// Format: `voice-<first 16 hex chars of SHA-256>`. Filesystem-safe,
-/// unique enough for any realistic deployment.
-pub(crate) fn voice_session_id(device_id: &str, room_profile: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(b"voice:");
-    hasher.update(device_id.as_bytes());
-    hasher.update(b":");
-    hasher.update(room_profile.as_bytes());
-    let hash = hasher.finalize();
-    let mut s = String::with_capacity(22);
-    s.push_str("voice-");
-    for b in &hash[..8] {
-        use std::fmt::Write;
-        let _ = write!(&mut s, "{b:02x}");
-    }
-    s
-}
 
 async fn run_voice_turn(
     state: Arc<ServeState>,
@@ -1347,7 +1367,7 @@ async fn run_voice_turn_from_text_sse(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_text, &reply).await
-                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.store_for_session(&sid).set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }
@@ -1403,9 +1423,23 @@ pub(crate) async fn push_voice_text_to_subscriber(
         return Err(VoicePushError::NotConfigured);
     }
 
-    // Pin the room_profile on the synthetic session id so
-    // `resolve_voice_pipeline` and `run_llm_turn` find the right config.
-    let session_id = voice_session_id(&device_id, &room_profile);
+    // Resolve / lazily-create the device-default session for this
+    // `(device_id, room_profile)` pair under that profile's memory
+    // namespace, then pin the room_profile so `resolve_voice_pipeline`
+    // and `run_llm_turn` find the right config. See #122.
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&room_profile)
+        .to_string();
+    let session_id = state
+        .device_default_session_store
+        .find_or_create_for_device(
+            &device_id,
+            &room_profile,
+            &namespace,
+            state.config.day_boundary_hour,
+        )
+        .map_err(|e| VoicePushError::Other(format!("device-default lookup: {e}")))?;
     state
         .session_room_profiles
         .lock()
@@ -1554,17 +1588,16 @@ async fn run_llm_turn(
         }
     };
 
+    // Pick the right store up front so every persistence call in this
+    // turn lands in the same place (device-default vs cross-device).
+    let store = Arc::clone(state.store_for_session(&session_id));
+
     // 1. Load or lazy-hydrate in-memory history
     let mut history: Vec<ChatMessage> = {
         let mut sessions = state.sessions.lock().await;
         sessions
             .entry(session_id.clone())
-            .or_insert_with(|| {
-                state
-                    .rpc_session_store
-                    .load_session(&session_id)
-                    .unwrap_or_default()
-            })
+            .or_insert_with(|| store.load_session(&session_id).unwrap_or_default())
             .clone()
     };
     let was_first_turn = history.is_empty();
@@ -1586,14 +1619,21 @@ async fn run_llm_turn(
 
     // 2b. Ensure JSONL file exists. If this session was deferred at initialize
     //     time, commit it now using the reserved public_id.
+    //
+    // Device-default sessions are always already-on-disk by the time
+    // run_llm_turn runs (find_or_create_for_device writes the meta
+    // line at create time) so `ensure_session` against them is a
+    // no-op. Skip it to avoid synthesising a spurious grain-id
+    // public_id that device-default sessions don't need.
     let key: ConversationKey = (session_id.clone(), None);
-    let pending_pub_id = state.pending_sessions.lock().await.remove(&session_id);
-    if let Err(e) = state
-        .rpc_session_store
-        .ensure_session(&session_id, &key, "rpc", pending_pub_id, &namespace)
-        .map(|_| ())
-    {
-        warn!("Failed to ensure session file: {e}");
+    if Arc::ptr_eq(&store, &state.cross_device_session_store) {
+        let pending_pub_id = state.pending_sessions.lock().await.remove(&session_id);
+        if let Err(e) = store
+            .ensure_session(&session_id, &key, "rpc", pending_pub_id, &namespace)
+            .map(|_| ())
+        {
+            warn!("Failed to ensure session file: {e}");
+        }
     }
 
     // 3a. System prompt (rebuilt fresh per request).
@@ -1620,7 +1660,7 @@ async fn run_llm_turn(
     //    `SessionStore::append` so the in-memory history keeps full image
     //    bytes for the provider call while JSONL gets a hash marker.
     history.push(user_msg.clone());
-    if let Err(e) = state.rpc_session_store.append(&session_id, &user_msg) {
+    if let Err(e) = store.append(&session_id, &user_msg) {
         warn!("Failed to persist user message: {e}");
     }
 
@@ -1648,10 +1688,7 @@ async fn run_llm_turn(
         match maybe_compress(&*provider, system.as_deref(), &history, compression_config).await {
             Ok(Some(result)) => {
                 history = result.compressed;
-                if let Err(e) = state
-                    .rpc_session_store
-                    .append_summary(&session_id, &result.summary)
-                {
+                if let Err(e) = store.append_summary(&session_id, &result.summary) {
                     warn!("Failed to persist compaction summary: {e}");
                 }
             }
@@ -1682,7 +1719,7 @@ async fn run_llm_turn(
                 let text = resp.text.unwrap_or_default();
                 let msg = ChatMessage::assistant(&text);
                 history.push(msg.clone());
-                if let Err(e) = state.rpc_session_store.append(&session_id, &msg) {
+                if let Err(e) = store.append(&session_id, &msg) {
                     warn!("Failed to persist assistant message: {e}");
                 }
                 if !text.is_empty() {
@@ -1827,7 +1864,7 @@ async fn run_turn(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_msg, &text).await
-                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.store_for_session(&sid).set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -62,6 +62,19 @@ pub struct SessionMeta {
     /// chat/API/voice sessions.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub project: Option<String>,
+    /// Originating device id for device-default sessions (kind =
+    /// `"device-default"`). Combined with `room_profile` below, this
+    /// pair is the routing key — `find_or_create_for_device` returns
+    /// the most-recent file matching both. Absent on every other kind.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub device_id: Option<String>,
+    /// Resolved room_profile name for device-default sessions. Pinned
+    /// at creation time (from the bearer token's `api_keys` match) so
+    /// rotation and `find_or_create_for_device` don't accidentally
+    /// hand a session to a different profile after `[room_profile]`
+    /// reshuffles. Absent on every other kind.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub room_profile: Option<String>,
     /// Short auto-generated title, populated from a later `session_title` line.
     #[serde(skip)]
     pub title: Option<String>,
@@ -337,6 +350,8 @@ impl SessionStore {
             public_id: None,
             namespace: Some(namespace.to_string()),
             project: None,
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -598,6 +613,8 @@ impl SessionStore {
             public_id: None,
             namespace: Some(namespace.to_string()),
             project: Some(project.to_string()),
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -676,6 +693,8 @@ impl SessionStore {
             public_id: public_id.clone(),
             namespace: Some(namespace.to_string()),
             project: None,
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -684,6 +703,85 @@ impl SessionStore {
         drop(file);
         self.notify_updated(&path);
         Ok(public_id)
+    }
+
+    /// Find the most-recent device-default session for `(device_id, room_profile)`
+    /// that falls within today's local-day window (per `boundary_hour`), or
+    /// create a new file when none qualifies.
+    ///
+    /// Used by the voice `/rpc` methods and heartbeat fires to route into a
+    /// device's always-on session (#122). Lazy: nothing lands on disk until a
+    /// satellite that's actually used calls this. Closed sessions (those with
+    /// a `closed_at` marker) are skipped so an explicit boundary close still
+    /// rotates the file even before the next day window kicks in.
+    ///
+    /// Returns the resolved session_id. The caller is expected to follow up
+    /// with `append` for the message that triggered the lookup.
+    pub fn find_or_create_for_device(
+        &self,
+        device_id: &str,
+        room_profile: &str,
+        namespace: &str,
+        boundary_hour: u8,
+    ) -> anyhow::Result<String> {
+        let today = local_date_for_timestamp(Local::now(), boundary_hour);
+        let (today_start, today_end) = day_window(today, boundary_hour);
+
+        let mut best: Option<(DateTime<Utc>, String)> = None;
+        for path in collect_session_files(&self.base_dir, self.kind) {
+            let Some((meta, _, is_closed, _)) = load_session_file(&path) else {
+                continue;
+            };
+            if is_closed {
+                continue;
+            }
+            if meta.namespace.as_deref() != Some(namespace) {
+                continue;
+            }
+            if meta.device_id.as_deref() != Some(device_id) {
+                continue;
+            }
+            if meta.room_profile.as_deref() != Some(room_profile) {
+                continue;
+            }
+            if meta.created_at < today_start || meta.created_at >= today_end {
+                continue;
+            }
+            match &best {
+                Some((ts, _)) if *ts >= meta.created_at => {}
+                _ => best = Some((meta.created_at, meta.session_id.clone())),
+            }
+        }
+        if let Some((_, id)) = best {
+            // Seed the path cache so the upcoming `append` skips a rescan.
+            let _ = self.resolve_path(&id);
+            return Ok(id);
+        }
+
+        let session_id = Uuid::now_v7().to_string();
+        let path = self.path_for_new(&session_id, namespace);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let meta = SessionMeta {
+            session_id: session_id.clone(),
+            room_id: String::new(),
+            thread_id: None,
+            channel: "device-default".to_string(),
+            created_at: Utc::now(),
+            public_id: None,
+            namespace: Some(namespace.to_string()),
+            project: None,
+            device_id: Some(device_id.to_string()),
+            room_profile: Some(room_profile.to_string()),
+            title: None,
+        };
+        let line = serde_json::to_string(&MetaLine { meta })?;
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        writeln!(file, "{line}")?;
+        drop(file);
+        self.notify_updated(&path);
+        Ok(session_id)
     }
 
     /// Append a title for a session (append-only; last line wins on read).
@@ -1165,5 +1263,131 @@ mod tests {
         // Sanity: scanning a non-rpc kind does NOT pull in the api dir.
         let channel_only = collect_session_files(tmp.path(), "channel");
         assert!(channel_only.is_empty(), "channel scan must not see rpc/api dirs");
+    }
+
+    // ── device-default session routing (#122) ────────────────────────────
+
+    fn new_device_default_store() -> (tempfile::TempDir, SessionStore) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path().to_path_buf(), "device-default");
+        (tmp, store)
+    }
+
+    /// Fresh dir: returns a brand-new UUID, persists meta with the right
+    /// `(device_id, room_profile, channel, namespace)` fields.
+    #[test]
+    fn find_or_create_for_device_creates_new_session() {
+        let (_tmp, store) = new_device_default_store();
+        let sid = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .expect("find_or_create");
+        // Resolve from disk and verify the meta the store wrote.
+        let path = store.absolute_path_for(&sid).expect("path cached");
+        let (meta, _msgs, is_closed, _summary) =
+            load_session_file(&path).expect("meta line present");
+        assert_eq!(meta.session_id, sid);
+        assert_eq!(meta.channel, "device-default");
+        assert_eq!(meta.device_id.as_deref(), Some("device-a"));
+        assert_eq!(meta.room_profile.as_deref(), Some("default"));
+        assert_eq!(meta.namespace.as_deref(), Some("default"));
+        assert!(meta.public_id.is_none(), "device-default has no grain-id");
+        assert!(!is_closed);
+    }
+
+    /// Second call within the same local day returns the same session_id.
+    #[test]
+    fn find_or_create_for_device_is_idempotent_within_day() {
+        let (_tmp, store) = new_device_default_store();
+        let first = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let second = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    /// Different device_id ⇒ separate file.
+    #[test]
+    fn find_or_create_for_device_distinguishes_devices() {
+        let (_tmp, store) = new_device_default_store();
+        let a = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let b = store
+            .find_or_create_for_device("device-b", "default", "default", 4)
+            .unwrap();
+        assert_ne!(a, b);
+    }
+
+    /// Different room_profile ⇒ separate file (NSFW isolation).
+    #[test]
+    fn find_or_create_for_device_distinguishes_room_profiles() {
+        let (_tmp, store) = new_device_default_store();
+        let sfw = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let nsfw = store
+            .find_or_create_for_device("device-a", "private_nsfw", "user_nsfw", 4)
+            .unwrap();
+        assert_ne!(sfw, nsfw);
+    }
+
+    /// Closing the active session ⇒ next call rotates to a fresh UUID.
+    #[test]
+    fn find_or_create_for_device_skips_closed_sessions() {
+        let (_tmp, store) = new_device_default_store();
+        let first = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        store.close_session(&first).expect("close");
+        let second = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        assert_ne!(
+            first, second,
+            "closed session must not be reused — boundary rotation depends on this"
+        );
+    }
+
+    /// A meta file dated outside today's local window must not be reused —
+    /// next call must create a fresh session.
+    #[test]
+    fn find_or_create_for_device_skips_yesterday_session() {
+        let (tmp, store) = new_device_default_store();
+        let boundary = 4u8;
+
+        // Hand-craft a meta file whose `created_at` falls in yesterday's
+        // local-day window so the most-recent scan rejects it.
+        let yesterday_date =
+            local_date_for_timestamp(Local::now(), boundary) - Duration::days(1);
+        let (yesterday_start, _) = day_window(yesterday_date, boundary);
+        let stale_id = Uuid::now_v7().to_string();
+        let stale_dir = tmp.path().join("default").join("device-default");
+        fs::create_dir_all(&stale_dir).unwrap();
+        let stale_path = stale_dir.join(format!("{stale_id}.jsonl"));
+        let stale_meta = SessionMeta {
+            session_id: stale_id.clone(),
+            room_id: String::new(),
+            thread_id: None,
+            channel: "device-default".to_string(),
+            created_at: yesterday_start + Duration::hours(2),
+            public_id: None,
+            namespace: Some("default".to_string()),
+            project: None,
+            device_id: Some("device-a".to_string()),
+            room_profile: Some("default".to_string()),
+            title: None,
+        };
+        let line = serde_json::to_string(&MetaLine { meta: stale_meta }).unwrap();
+        std::fs::write(&stale_path, format!("{line}\n")).unwrap();
+
+        let fresh = store
+            .find_or_create_for_device("device-a", "default", "default", boundary)
+            .unwrap();
+        assert_ne!(
+            stale_id, fresh,
+            "yesterday's session must not be picked up; daily rotation depends on it"
+        );
     }
 }


### PR DESCRIPTION
**Stacked on top of #123 (PR 1).** Merge after PR 1.

## Summary

Second of three PRs implementing #122 + #112. Server-side half of the session-model redesign — introduces the device-default session kind and routes voice/heartbeat traffic through it. No on-disk migration yet (PR 3 ships that).

### Device-default sessions
- New session kind `device-default`, files under \`sessions/<ns>/device-default/<uuid>.jsonl\`. UUID-named like every other kind; \`(device_id, room_profile)\` lives in \`SessionMeta\` so \`find_or_create_for_device\` is a most-recent-from-today scan.
- **Lazy**: no file appears until a satellite is actually used.
- **Daily rotation falls out naturally**: a yesterday meta is rejected by the today-window filter and a fresh UUID is opened. No explicit boundary task needed for the default \"Reset\" semantics — that simplification lets future \`session_policy\` extensions (Compact, None) layer on top without re-plumbing.

### Voice path migration
- \`voice/pipeline_run\` and \`push_voice_text_to_subscriber\` now route through \`device_default_session_store.find_or_create_for_device(...)\` instead of the deterministic \`voice-<sha256>\` hash.
- Retired \`voice_session_id\` helper.

### Plumbing
- \`ServeState::rpc_session_store\` → split into \`cross_device_session_store\` (kind stays \"rpc\" until PR 3) and \`device_default_session_store\`.
- New \`ServeState::store_for_session(uuid)\` helper picks the right store by probing device-default first; \`run_llm_turn\`, graceful shutdown, title generation, and \`get_session\` route transparently.
- \`periodic_log\` digest collection extends to \`device-default\`, with per-session namespace pinning honoured directly from \`meta.namespace\` (NSFW profiles don't leak into the default namespace's daily log).
- \`heartbeat::namespace_for_session\` honours \`meta.namespace\` for both RPC and device-default sessions.

## Intentionally out of scope (follow-up PRs)

- **\`handle_initialize\` text-mode routing to device-default.** The CLI text path still creates a new cross-device session when no \`--resume\` is passed — \`sapphire-call\` would need to start sending its \`device_id\` on initialize, which is a sapphire-call-side change. Splitting it out keeps PR 2 focused on the server-side data model.
- **\`--new-topic\` flag in sapphire-call.** Will land alongside the text-mode routing change above.
- **\`SessionPolicy::Compact\` / \`None\` for device-default.** Default behaviour matches \`Reset\`. Custom policies for device-default can be wired later if anyone wants them.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 180 tests pass (151 + 3 + 26)
- [x] Six new unit tests on \`find_or_create_for_device\`:
  - Creates a fresh session with the right meta
  - Idempotent within the same local day
  - Distinguishes device_id
  - Distinguishes room_profile (NSFW isolation)
  - Skips closed sessions (explicit-rotation path)
  - Skips a meta dated to yesterday (daily-rotation path)
- [ ] Manual smoke against the live workspace — confirm a voice subscribe → push fire writes into the new \`device-default/\` tree

## Follow-up

- **PR 3** (#122 migration): move existing files (rpc/ → cross-device/, legacy voice → legacy-voice/), rewrite \`meta.channel = \"api\"\` → \`\"rpc\"\`, remove the PR 1 dual-read shim. Single startup-sync migration, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)