### PR TITLE
feat(sessions): bundled migration for cross-device + legacy-voice (#122 PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ServeState::rpc_session_store` → `cross_device_session_store`** —
   user-selectable, multi-device sessions resumed via `--resume
   <grain-id>` are now logically separated from device-default sessions.
-  The on-disk directory remains `sessions/<ns>/rpc/` for now; the
-  bundled session migration (PR 3) renames it to `cross-device/`. (#122)
+  On-disk directory moves to `sessions/<ns>/cross-device/`; the bundled
+  session migration relocates pre-existing files. (#122)
+
+### Migration
+
+- **One-shot session-store migration** runs on first startup of this
+  version, completing both #112 and #122:
+  - `sessions/<ns>/api/<uuid>.jsonl` and `sessions/<ns>/rpc/<uuid>.jsonl`
+    cross-device files move to `sessions/<ns>/cross-device/<uuid>.jsonl`.
+    Stored `meta.channel = "api"` is rewritten to `"rpc"` along the way.
+  - Pre-redesign voice files (`voice-<hash>.jsonl`) are quarantined to
+    `sessions/<ns>/legacy-voice/`. Their `(device_id, room_profile)`
+    routing key was hashed into the filename and is unrecoverable; the
+    daily-log archive still indexes their content so nothing is lost
+    for FTS / semantic search, only the live conversation continuation.
+  - The PR-1 dual-read shim and dual-accept `"api"`/`"rpc"` fallbacks
+    are removed after this migration runs.
+  - Idempotent and safe to interrupt. No backup is taken — the
+    workspace is expected to be under git.
 
 ## [0.6.1] - 2026-05-18
 

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -102,10 +102,9 @@ pub struct RoomInfo {
     /// Free-form description / topic. `None` when the channel side has
     /// nothing to offer (e.g. Matrix DM with no topic).
     pub description: Option<String>,
-    /// Originating channel name: `"matrix"`, `"discord"`, `"rpc"`
-    /// (legacy `"api"` until the bundled session migration rewrites
-    /// stored values), or `"voice"`. Lets the system prompt tell the
-    /// model whether transcripts may contain STT errors etc.
+    /// Originating channel name: `"matrix"`, `"discord"`, `"rpc"`,
+    /// `"device-default"`, or `"voice"`. Lets the system prompt tell
+    /// the model whether transcripts may contain STT errors etc.
     pub kind: String,
 }
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -68,16 +68,12 @@ pub struct Heartbeat {
 impl Heartbeat {
     /// Resolve which namespace a session belongs to. Matrix/Discord rooms
     /// follow `Config::namespace_for_room`. Device-default sessions
-    /// (channel=`"device-default"`) and RPC cross-device sessions
-    /// (`"rpc"`, or legacy `"api"` until the bundled session migration
-    /// rewrites stored values) persist their resolved namespace in the
-    /// JSONL meta — trust that first, falling back to the default
-    /// namespace for old files that predate the field.
+    /// (channel=`"device-default"`) and cross-device sessions
+    /// (channel=`"rpc"`) persist their resolved namespace in the JSONL
+    /// meta — trust that first, falling back to the default namespace
+    /// for old files that predate the field.
     fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
-        if meta.channel == "device-default"
-            || meta.channel == "rpc"
-            || meta.channel == "api"
-        {
+        if meta.channel == "device-default" || meta.channel == "rpc" {
             meta.namespace
                 .clone()
                 .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,15 @@ async fn main() -> Result<()> {
             if let Err(e) = migrate_sessions_to_namespaced_layout(&sessions_base_for_migration) {
                 anyhow::bail!("Session namespace migration failed: {e:#}");
             }
+            // ── Split sessions/<ns>/{api,rpc}/ into cross-device + legacy-voice ─
+            // Quarantines pre-redesign voice files (their `voice-<hash>`
+            // names can't be re-hydrated into the new
+            // `(device_id, room_profile)` keying) and moves remaining
+            // sessions into the new `cross-device/` directory, rewriting
+            // stored `meta.channel = "api"` → `"rpc"` along the way.
+            if let Err(e) = migrate_to_device_default_layout(&sessions_base_for_migration) {
+                anyhow::bail!("Device-default session migration failed: {e:#}");
+            }
 
             // ── Bootstrap file loader (AGENTS.md, SOUL.md, MEMORY.md …) ────
             let workspace = Arc::new(Workspace::new(workspace_dir.clone(), config.digest.clone()));
@@ -262,15 +271,14 @@ async fn main() -> Result<()> {
                     .context("Failed to build provider registry")?,
             );
 
-            // ── Cross-device session store (sessions/<namespace>/rpc/) ─────
+            // ── Cross-device session store (sessions/<namespace>/cross-device/) ─
             // Cross-device sessions are the user-selectable, multi-device
             // conversation threads (resumed via `--resume <grain-id>`).
-            // The on-disk directory is still `rpc/` until the bundled
-            // session migration (#122 PR 3) renames it to `cross-device/`;
-            // the kind constant matches.
+            // The bundled session migration moves pre-PR-3 files into
+            // this dir from the legacy `api/` and `rpc/` locations.
             let cross_device_session_store = Arc::new(SessionStore::with_workspace(
                 sessions_base.clone(),
-                "rpc",
+                "cross-device",
                 Arc::clone(&ws_state),
             ));
 
@@ -431,10 +439,7 @@ async fn main() -> Result<()> {
                     let cfg_for_predicate = config.clone();
                     let ns_for_predicate = ns.clone();
                     let predicate = move |meta: &session::SessionMeta| -> bool {
-                        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112)
-                        // until the bundled session migration rewrites stored
-                        // `meta.channel` strings.
-                        if meta.channel == "api" || meta.channel == "rpc" {
+                        if meta.channel == "rpc" {
                             return ns_for_predicate == config::DEFAULT_NAMESPACE_NAME;
                         }
                         cfg_for_predicate.namespace_for_room(&meta.room_id) == ns_for_predicate
@@ -759,6 +764,161 @@ fn migrate_sessions_to_namespaced_layout(sessions_base: &std::path::Path) -> any
     Ok(())
 }
 
+/// One-shot migration completing #112 + #122: split each
+/// `sessions/<ns>/{api,rpc}/` directory into the new layout.
+///
+/// - Files whose name starts with `voice-` are pre-redesign voice
+///   sessions. Their `(device_id, room_profile)` was hashed into the
+///   filename and is unrecoverable from disk, so we can't slot them
+///   into the new device-default layout. They move to
+///   `sessions/<ns>/legacy-voice/` instead — the daily-log archive
+///   still indexes their content for FTS / semantic search; only the
+///   live continuation is given up.
+/// - Everything else moves to `sessions/<ns>/cross-device/`, with
+///   stored `meta.channel = "api"` rewritten to `"rpc"` in-place.
+/// - The PR 1 dual-read shim and dual-accept fallbacks become
+///   unnecessary after this run.
+///
+/// Idempotent: a workspace that's already migrated has no `api/` or
+/// `rpc/` directory under any namespace and the function exits silently.
+/// Refuses to run when a name collision would clobber an existing
+/// destination (extremely unlikely with UUIDs but handled for safety).
+fn migrate_to_device_default_layout(sessions_base: &std::path::Path) -> anyhow::Result<()> {
+    use std::io::{BufRead, BufReader, Write};
+
+    let Ok(ns_entries) = std::fs::read_dir(sessions_base) else {
+        return Ok(());
+    };
+
+    let mut moved = 0usize;
+    let mut quarantined = 0usize;
+
+    for ns_entry in ns_entries.flatten() {
+        let ns_dir = ns_entry.path();
+        if !ns_dir.is_dir() {
+            continue;
+        }
+
+        for src_kind in ["api", "rpc"] {
+            let src_dir = ns_dir.join(src_kind);
+            if !src_dir.is_dir() {
+                continue;
+            }
+            let entries = match std::fs::read_dir(&src_dir) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("Skipping {}: {e}", src_dir.display());
+                    continue;
+                }
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_file()
+                    || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
+                {
+                    continue;
+                }
+                let Some(file_name) = path.file_name() else {
+                    continue;
+                };
+                let is_voice = file_name
+                    .to_str()
+                    .map(|s| s.starts_with("voice-"))
+                    .unwrap_or(false);
+
+                let (dst_dir, needs_meta_rewrite) = if is_voice {
+                    (ns_dir.join("legacy-voice"), false)
+                } else {
+                    // Cross-device files moving from the legacy `api/`
+                    // directory still carry `meta.channel = "api"` in
+                    // their first line — rewrite to `"rpc"` so the
+                    // dual-accept fallbacks can be removed.
+                    (ns_dir.join("cross-device"), src_kind == "api")
+                };
+                std::fs::create_dir_all(&dst_dir)
+                    .with_context(|| format!("create {}", dst_dir.display()))?;
+                let dst = dst_dir.join(file_name);
+                if dst.exists() {
+                    anyhow::bail!(
+                        "Refusing to migrate {}: destination {} already exists. \
+                         Reconcile manually before starting.",
+                        path.display(),
+                        dst.display(),
+                    );
+                }
+
+                if needs_meta_rewrite {
+                    // Stream the source into a temp file at the
+                    // destination dir (so `fs::rename` stays
+                    // intra-filesystem and atomic), rewriting just the
+                    // first line. Then drop the source.
+                    let tmp = dst.with_extension("partial");
+                    let src_file = std::fs::File::open(&path)
+                        .with_context(|| format!("open {}", path.display()))?;
+                    let mut reader = BufReader::new(src_file);
+                    let mut first_line = String::new();
+                    reader
+                        .read_line(&mut first_line)
+                        .with_context(|| format!("read first line of {}", path.display()))?;
+
+                    let rewritten = rewrite_meta_channel(first_line.trim(), "rpc")?;
+                    let mut writer = std::fs::File::create(&tmp)
+                        .with_context(|| format!("create {}", tmp.display()))?;
+                    writeln!(writer, "{rewritten}")
+                        .with_context(|| format!("write {}", tmp.display()))?;
+                    std::io::copy(&mut reader, &mut writer)
+                        .with_context(|| format!("copy body of {}", path.display()))?;
+                    drop(writer);
+                    std::fs::rename(&tmp, &dst).with_context(|| {
+                        format!("rename {} -> {}", tmp.display(), dst.display())
+                    })?;
+                    std::fs::remove_file(&path)
+                        .with_context(|| format!("remove {}", path.display()))?;
+                } else {
+                    std::fs::rename(&path, &dst).with_context(|| {
+                        format!("rename {} -> {}", path.display(), dst.display())
+                    })?;
+                }
+
+                if is_voice {
+                    quarantined += 1;
+                } else {
+                    moved += 1;
+                }
+            }
+            // Remove the now-empty source dir; non-fatal if it has
+            // leftovers (e.g. operator dropped unrelated files).
+            let _ = std::fs::remove_dir(&src_dir);
+        }
+    }
+
+    if moved > 0 || quarantined > 0 {
+        tracing::info!(
+            "Session migration: {moved} cross-device session(s), \
+             {quarantined} legacy voice file(s) quarantined under legacy-voice/"
+        );
+    }
+    Ok(())
+}
+
+/// Parse a session-meta JSONL line, set `meta.channel` to `new_channel`,
+/// and re-serialise. Used by `migrate_to_device_default_layout` to
+/// rewrite legacy `"api"` strings to `"rpc"` while preserving all
+/// other meta fields.
+fn rewrite_meta_channel(line: &str, new_channel: &str) -> anyhow::Result<String> {
+    let mut value: serde_json::Value =
+        serde_json::from_str(line).with_context(|| format!("parse meta line: {line}"))?;
+    if let Some(meta) = value.get_mut("meta").and_then(|m| m.as_object_mut()) {
+        meta.insert(
+            "channel".to_string(),
+            serde_json::Value::String(new_channel.to_string()),
+        );
+    } else {
+        anyhow::bail!("first JSONL line missing `meta` object: {line}");
+    }
+    Ok(serde_json::to_string(&value)?)
+}
+
 /// One-shot migration from the per-channel session layout
 /// (`sessions/matrix/` + `sessions/discord/`) to the consolidated
 /// `sessions/channel/` directory. The originating channel is still
@@ -1051,6 +1211,151 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(base.join("channel/01H1.jsonl")).unwrap(),
+            "pre-existing"
+        );
+    }
+
+    // ── device-default layout migration (#122 PR 3) ──────────────────────
+
+    /// Render a minimal meta line for the device-default migration tests.
+    /// Only `session_id` and `channel` are exercised by the migration —
+    /// everything else just rides along untouched.
+    fn meta_line(session_id: &str, channel: &str) -> String {
+        format!(
+            r#"{{"meta":{{"session_id":"{session_id}","room_id":"","thread_id":null,"channel":"{channel}","created_at":"2026-05-22T00:00:00Z","namespace":"default"}}}}"#
+        )
+    }
+
+    #[test]
+    fn device_default_migration_no_op_on_fresh_workspace() {
+        let td = tempfile::tempdir().unwrap();
+        migrate_to_device_default_layout(td.path()).expect("clean migration");
+        // No directories should be created on an empty workspace.
+        assert!(!td.path().join("default").exists());
+    }
+
+    /// Cross-device text sessions move into `cross-device/`;
+    /// `voice-<hash>` files go into `legacy-voice/`. Both source dirs
+    /// are removed afterwards.
+    #[test]
+    fn device_default_migration_moves_cross_device_and_quarantines_voice() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("uuid-text-modern.jsonl"),
+            &meta_line("uuid-text-modern", "rpc"),
+        );
+        write_stub(
+            &ns.join("api").join("voice-deadbeef.jsonl"),
+            &meta_line("voice-deadbeef", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("voice-feedface.jsonl"),
+            &meta_line("voice-feedface", "rpc"),
+        );
+
+        migrate_to_device_default_layout(base).expect("migration");
+
+        assert!(ns.join("cross-device/uuid-text.jsonl").exists());
+        assert!(ns.join("cross-device/uuid-text-modern.jsonl").exists());
+        assert!(ns.join("legacy-voice/voice-deadbeef.jsonl").exists());
+        assert!(ns.join("legacy-voice/voice-feedface.jsonl").exists());
+        assert!(!ns.join("api").exists(), "api dir should be removed");
+        assert!(!ns.join("rpc").exists(), "rpc dir should be removed");
+    }
+
+    /// Files that arrive from the legacy `api/` dir get their stored
+    /// `meta.channel = "api"` rewritten to `"rpc"`; files from `rpc/`
+    /// keep their meta unchanged. Voice files in `legacy-voice/` are
+    /// preserved verbatim (no rewrite — they're never re-loaded).
+    #[test]
+    fn device_default_migration_rewrites_legacy_meta_channel() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-from-api.jsonl"),
+            &meta_line("uuid-from-api", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("uuid-from-rpc.jsonl"),
+            &meta_line("uuid-from-rpc", "rpc"),
+        );
+        write_stub(
+            &ns.join("api").join("voice-cafe.jsonl"),
+            &meta_line("voice-cafe", "api"),
+        );
+
+        migrate_to_device_default_layout(base).expect("migration");
+
+        let api_migrated =
+            std::fs::read_to_string(ns.join("cross-device/uuid-from-api.jsonl")).unwrap();
+        assert!(
+            api_migrated.contains(r#""channel":"rpc""#),
+            "legacy `api` meta must be rewritten to `rpc`: {api_migrated}"
+        );
+        assert!(
+            !api_migrated.contains(r#""channel":"api""#),
+            "legacy `api` meta should no longer appear: {api_migrated}"
+        );
+
+        let rpc_migrated =
+            std::fs::read_to_string(ns.join("cross-device/uuid-from-rpc.jsonl")).unwrap();
+        assert!(
+            rpc_migrated.contains(r#""channel":"rpc""#),
+            "post-PR1 `rpc` meta stays as-is: {rpc_migrated}"
+        );
+
+        let voice_quarantined =
+            std::fs::read_to_string(ns.join("legacy-voice/voice-cafe.jsonl")).unwrap();
+        assert!(
+            voice_quarantined.contains(r#""channel":"api""#),
+            "voice meta is preserved verbatim (no rewrite): {voice_quarantined}"
+        );
+    }
+
+    #[test]
+    fn device_default_migration_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        migrate_to_device_default_layout(base).expect("first");
+        migrate_to_device_default_layout(base).expect("second is a no-op");
+        assert!(ns.join("cross-device/uuid-text.jsonl").exists());
+    }
+
+    #[test]
+    fn device_default_migration_refuses_on_collision() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        write_stub(
+            &ns.join("cross-device").join("uuid-text.jsonl"),
+            "pre-existing",
+        );
+
+        let err = migrate_to_device_default_layout(base).expect_err("collision");
+        assert!(
+            format!("{err:#}").contains("already exists"),
+            "got: {err:#}"
+        );
+        // Source untouched.
+        assert!(ns.join("api/uuid-text.jsonl").exists());
+        assert_eq!(
+            std::fs::read_to_string(ns.join("cross-device/uuid-text.jsonl")).unwrap(),
             "pre-existing"
         );
     }

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -1189,9 +1189,7 @@ where
 
     let mut lines: Vec<String> = Vec::new();
     for (meta, digest) in entries {
-        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112) until the
-        // bundled session migration rewrites stored `meta.channel` strings.
-        let is_rpc = meta.channel == "rpc" || meta.channel == "api";
+        let is_rpc = meta.channel == "rpc";
         let is_device_default = meta.channel == "device-default";
         let ns = if is_rpc {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,11 +187,11 @@ pub struct SessionStore {
     /// so retrieve indexing can scope itself by directory and never
     /// accidentally mix NSFW sessions with default-namespace ones.
     pub base_dir: PathBuf,
-    /// Second-level subdirectory: `"channel"` for Matrix/Discord, `"rpc"`
-    /// for HTTP (renamed from `"api"` in #112; readers transparently
-    /// fall through to the legacy `"api"` dir until the bundled session
-    /// migration moves the files). Lets the Agent and ServeState keep
-    /// separate `SessionStore` instances while sharing one base dir.
+    /// Second-level subdirectory: `"channel"` for Matrix/Discord,
+    /// `"cross-device"` for user-selectable RPC sessions,
+    /// `"device-default"` for per-`(device_id, room_profile)` sessions,
+    /// `"mcp"` for MCP project sessions. Lets the Agent and ServeState
+    /// keep separate `SessionStore` instances while sharing one base dir.
     pub kind: &'static str,
     /// Optional sapphire-workspace state. When set, file modifications notify
     /// the workspace so the index/cache and git staging stay in sync.
@@ -658,9 +658,9 @@ impl SessionStore {
     /// Ensure a session file exists for the given caller-supplied ID.
     /// Unlike `create_session`, this uses the provided ID rather than generating a new UUID.
     ///
-    /// For RPC sessions (`channel == "rpc"`, or legacy `"api"`), a grain-id
-    /// `public_id` is generated on creation unless `public_id_override` is
-    /// supplied (used to commit a deferred public_id).
+    /// For RPC sessions (`channel == "rpc"`), a grain-id `public_id` is
+    /// generated on creation unless `public_id_override` is supplied
+    /// (used to commit a deferred public_id).
     /// Returns the `public_id` if present (new or existing).
     pub fn ensure_session(
         &self,
@@ -679,7 +679,7 @@ impl SessionStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let public_id = if channel == "rpc" || channel == "api" {
+        let public_id = if channel == "rpc" {
             Some(public_id_override.unwrap_or_else(|| grain_id::GrainId::random().to_string()))
         } else {
             None
@@ -986,36 +986,24 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// Enumerate `<base_dir>/<namespace>/<kind>/*.jsonl` across every namespace
 /// directory. Returns an empty Vec when `base_dir` doesn't exist yet (fresh
 /// install) or has no namespace subdirs. Each returned path is absolute.
-///
-/// Dual-read shim for #112: when `kind == "rpc"`, the legacy `"api"` directory
-/// is also scanned so post-rename builds keep surfacing pre-migration files.
-/// The bundled session-store migration removes the shim once it has moved the
-/// files into the new layout.
 fn collect_session_files(base_dir: &Path, kind: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let Ok(entries) = fs::read_dir(base_dir) else {
         return out;
-    };
-    let scan_kinds: &[&str] = if kind == "rpc" {
-        &["rpc", "api"]
-    } else {
-        std::slice::from_ref(&kind)
     };
     for entry in entries.flatten() {
         let ns_dir = entry.path();
         if !ns_dir.is_dir() {
             continue;
         }
-        for k in scan_kinds {
-            let kind_dir = ns_dir.join(k);
-            let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
-                continue;
-            };
-            for k_entry in kind_entries.flatten() {
-                let path = k_entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                    out.push(path);
-                }
+        let kind_dir = ns_dir.join(kind);
+        let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
+            continue;
+        };
+        for k_entry in kind_entries.flatten() {
+            let path = k_entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                out.push(path);
             }
         }
     }
@@ -1231,38 +1219,6 @@ mod tests {
             scrub_images_for_storage(&msg).is_none(),
             "scrub should leave ImageRef-only messages untouched"
         );
-    }
-
-    /// Post-#112 dual-read shim: when scanning for `"rpc"` files, the
-    /// legacy `"api"` sub-directory must also be visible so existing
-    /// sessions stay reachable until the bundled migration moves them.
-    #[test]
-    fn collect_session_files_dual_reads_legacy_api_dir() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let ns = tmp.path().join("default");
-        let api_dir = ns.join("api");
-        let rpc_dir = ns.join("rpc");
-        fs::create_dir_all(&api_dir).unwrap();
-        fs::create_dir_all(&rpc_dir).unwrap();
-        let legacy = api_dir.join("old.jsonl");
-        let fresh = rpc_dir.join("new.jsonl");
-        std::fs::write(&legacy, b"").unwrap();
-        std::fs::write(&fresh, b"").unwrap();
-
-        // Stray file that should NOT be picked up (wrong extension).
-        std::fs::write(rpc_dir.join("ignore.txt"), b"").unwrap();
-
-        let mut found = collect_session_files(tmp.path(), "rpc");
-        found.sort();
-        assert_eq!(found, {
-            let mut expected = vec![legacy, fresh];
-            expected.sort();
-            expected
-        });
-
-        // Sanity: scanning a non-rpc kind does NOT pull in the api dir.
-        let channel_only = collect_session_files(tmp.path(), "channel");
-        assert!(channel_only.is_empty(), "channel scan must not see rpc/api dirs");
     }
 
     // ── device-default session routing (#122) ────────────────────────────


### PR DESCRIPTION
**Stacked on top of #124 (PR 2), which is stacked on #123 (PR 1).** Merge order: #123 → #124 → this.

## Summary

Third and final PR for #112 + #122. Single startup-sync migration that completes both:

- **#112 file moves**: \`sessions/<ns>/api/\` files migrate to their final home (no intermediate \`rpc/\` stop).
- **#122 redesign**: cross-device sessions land in \`sessions/<ns>/cross-device/\`; pre-redesign voice files (\`voice-<hash>.jsonl\`) are quarantined in \`sessions/<ns>/legacy-voice/\`.
- **Cleanup**: the PR 1 dual-read shim and the \`\"api\"\`/\`\"rpc\"\` dual-accept fallbacks across the codebase are removed.

### Migration logic

For each \`sessions/<ns>/{api,rpc}/<file>.jsonl\`:

| File pattern | Destination | meta.channel rewrite |
|---|---|---|
| starts with \`voice-\` | \`sessions/<ns>/legacy-voice/\` | none (preserved verbatim) |
| anything else, from \`api/\` | \`sessions/<ns>/cross-device/\` | \`\"api\"\` → \`\"rpc\"\` |
| anything else, from \`rpc/\` | \`sessions/<ns>/cross-device/\` | none (already correct) |

The empty \`api/\` and \`rpc/\` dirs are removed afterwards. The function is idempotent (a workspace that's already migrated has no source dirs and exits silently) and safe to interrupt (each file is moved with \`fs::rename\`, atomic on POSIX; the meta-rewrite path uses temp-file + rename for the same guarantee).

### Why voice files are quarantined, not migrated

The pre-redesign voice session id was \`voice-<sha256(device_id:room_profile)[..8]>\` — a one-way hash. The new device-default layout keys files by \`(device_id, room_profile)\` carried in \`SessionMeta\`, but those original values aren't recoverable from the hashed filename or anywhere else on disk. Hand-rebuilding the live continuation would be guesswork; the daily-log archive already absorbs the historical content for FTS / semantic search, so the only thing given up is the \"resume mid-conversation\" affordance for sessions that haven't seen activity since this upgrade lands. New voice sessions write to the new layout from the first satellite connect onward.

### Cleanup carried by this PR

- \`collect_session_files\` reverts to a plain single-kind scan (the PR 1 \`rpc → api\` fall-through is dead code post-migration).
- \`meta.channel == \"api\"\` accept clauses in \`heartbeat.rs\`, \`periodic_log.rs\`, \`main.rs\`, and \`session.rs::ensure_session\` are dropped — the migration rewrites stored meta, so only \`\"rpc\"\` appears now.
- The obsolete \`collect_session_files_dual_reads_legacy_api_dir\` test from PR 1 is removed.

### No backup

Per the owner's earlier call (the workspace lives under git with a periodic remote push), the migration does **not** snapshot \`sessions/\` before running. Git history is the rollback path: \`git -C ~/.saph1na_workspace reset --hard <pre-upgrade-sha>\` after downgrading the binary.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 184 tests pass (155 + 3 + 26); +4 net (5 new migration tests, -1 obsolete dual-read test)
- [x] Migration tests cover: fresh-workspace no-op; cross-device + voice file dispatch; \`meta.channel = \"api\"\` rewrite to \`\"rpc\"\`; idempotence across re-runs; collision refusal (pre-existing destination)
- [ ] Manual smoke against the live workspace (which has the live \`default/api/voice-08ae74768935ca67.jsonl\`): start the new binary, confirm the file lands in \`default/legacy-voice/voice-08ae74768935ca67.jsonl\` and a new voice subscribe lands in \`default/device-default/<uuid>.jsonl\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)