### PR TITLE
feat(sessions): device-default sessions + bundled migration (#122, re-targeted to main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Device-default sessions** — a new session kind keyed by
+  `(device_id, room_profile)` that voice satellites and heartbeat
+  pushes route into when no other session is selected. Stored under
+  `sessions/<ns>/device-default/<uuid>.jsonl`; lazy-created (no file
+  appears until a satellite is actually used); daily-rotated by the
+  "most-recent-from-today" lookup, so a satellite that connects after
+  the local-day boundary lands in a fresh session automatically. The
+  previous deterministic `voice-<sha256>.jsonl` scheme is retired —
+  voice traffic now flows through the same `SessionStore` surface as
+  every other kind. (#122)
+
 ### Changed
 
 - **`sapphire-agent-api` crate renamed to `sapphire-agent-rpc`** to match
@@ -17,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   visible. The `api_keys` config field on `[room_profile.<n>]` is
   deliberately unchanged — it gates `/rpc`, `/mcp`, and `/a2a` together
   and the broad "api" name still fits. (#112)
+- **`ServeState::rpc_session_store` → `cross_device_session_store`** —
+  user-selectable, multi-device sessions resumed via `--resume
+  <grain-id>` are now logically separated from device-default sessions.
+  The on-disk directory remains `sessions/<ns>/rpc/` for now; the
+  bundled session migration (PR 3) renames it to `cross-device/`. (#122)
 
 ## [0.6.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ServeState::rpc_session_store` → `cross_device_session_store`** —
   user-selectable, multi-device sessions resumed via `--resume
   <grain-id>` are now logically separated from device-default sessions.
-  The on-disk directory remains `sessions/<ns>/rpc/` for now; the
-  bundled session migration (PR 3) renames it to `cross-device/`. (#122)
+  On-disk directory moves to `sessions/<ns>/cross-device/`; the bundled
+  session migration relocates pre-existing files. (#122)
+
+### Migration
+
+- **One-shot session-store migration** runs on first startup of this
+  version, completing both #112 and #122:
+  - `sessions/<ns>/api/<uuid>.jsonl` and `sessions/<ns>/rpc/<uuid>.jsonl`
+    cross-device files move to `sessions/<ns>/cross-device/<uuid>.jsonl`.
+    Stored `meta.channel = "api"` is rewritten to `"rpc"` along the way.
+  - Pre-redesign voice files (`voice-<hash>.jsonl`) are quarantined to
+    `sessions/<ns>/legacy-voice/`. Their `(device_id, room_profile)`
+    routing key was hashed into the filename and is unrecoverable; the
+    daily-log archive still indexes their content so nothing is lost
+    for FTS / semantic search, only the live conversation continuation.
+  - The PR-1 dual-read shim and dual-accept `"api"`/`"rpc"` fallbacks
+    are removed after this migration runs.
+  - Idempotent and safe to interrupt. No backup is taken — the
+    workspace is expected to be under git.
 
 ## [0.6.1] - 2026-05-18
 

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -102,10 +102,9 @@ pub struct RoomInfo {
     /// Free-form description / topic. `None` when the channel side has
     /// nothing to offer (e.g. Matrix DM with no topic).
     pub description: Option<String>,
-    /// Originating channel name: `"matrix"`, `"discord"`, `"rpc"`
-    /// (legacy `"api"` until the bundled session migration rewrites
-    /// stored values), or `"voice"`. Lets the system prompt tell the
-    /// model whether transcripts may contain STT errors etc.
+    /// Originating channel name: `"matrix"`, `"discord"`, `"rpc"`,
+    /// `"device-default"`, or `"voice"`. Lets the system prompt tell
+    /// the model whether transcripts may contain STT errors etc.
     pub kind: String,
 }
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -68,16 +68,12 @@ pub struct Heartbeat {
 impl Heartbeat {
     /// Resolve which namespace a session belongs to. Matrix/Discord rooms
     /// follow `Config::namespace_for_room`. Device-default sessions
-    /// (channel=`"device-default"`) and RPC cross-device sessions
-    /// (`"rpc"`, or legacy `"api"` until the bundled session migration
-    /// rewrites stored values) persist their resolved namespace in the
-    /// JSONL meta — trust that first, falling back to the default
-    /// namespace for old files that predate the field.
+    /// (channel=`"device-default"`) and cross-device sessions
+    /// (channel=`"rpc"`) persist their resolved namespace in the JSONL
+    /// meta — trust that first, falling back to the default namespace
+    /// for old files that predate the field.
     fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
-        if meta.channel == "device-default"
-            || meta.channel == "rpc"
-            || meta.channel == "api"
-        {
+        if meta.channel == "device-default" || meta.channel == "rpc" {
             meta.namespace
                 .clone()
                 .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -67,14 +67,20 @@ pub struct Heartbeat {
 
 impl Heartbeat {
     /// Resolve which namespace a session belongs to. Matrix/Discord rooms
-    /// follow `Config::namespace_for_room`. RPC sessions (`channel="rpc"`,
-    /// or legacy `"api"` until the bundled session migration rewrites
-    /// stored values) fall back to the default namespace because their
-    /// per-session profile pinning is in-memory only and not persisted
-    /// in the JSONL metadata.
+    /// follow `Config::namespace_for_room`. Device-default sessions
+    /// (channel=`"device-default"`) and RPC cross-device sessions
+    /// (`"rpc"`, or legacy `"api"` until the bundled session migration
+    /// rewrites stored values) persist their resolved namespace in the
+    /// JSONL meta — trust that first, falling back to the default
+    /// namespace for old files that predate the field.
     fn namespace_for_session(&self, meta: &crate::session::SessionMeta) -> String {
-        if meta.channel == "rpc" || meta.channel == "api" {
-            crate::config::DEFAULT_NAMESPACE_NAME.to_string()
+        if meta.channel == "device-default"
+            || meta.channel == "rpc"
+            || meta.channel == "api"
+        {
+            meta.namespace
+                .clone()
+                .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())
         } else {
             self.config.namespace_for_room(&meta.room_id).to_string()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,10 +262,25 @@ async fn main() -> Result<()> {
                     .context("Failed to build provider registry")?,
             );
 
-            // ── RPC session store (sessions/<namespace>/rpc/) ──────────────
-            let rpc_session_store = Arc::new(SessionStore::with_workspace(
+            // ── Cross-device session store (sessions/<namespace>/rpc/) ─────
+            // Cross-device sessions are the user-selectable, multi-device
+            // conversation threads (resumed via `--resume <grain-id>`).
+            // The on-disk directory is still `rpc/` until the bundled
+            // session migration (#122 PR 3) renames it to `cross-device/`;
+            // the kind constant matches.
+            let cross_device_session_store = Arc::new(SessionStore::with_workspace(
                 sessions_base.clone(),
                 "rpc",
+                Arc::clone(&ws_state),
+            ));
+
+            // ── Device-default session store (sessions/<ns>/device-default/) ─
+            // Lazy-created, daily-rotated per `(device_id, room_profile)` —
+            // the heartbeat target and the implicit session for a satellite
+            // with nothing else selected. See #122.
+            let device_default_session_store = Arc::new(SessionStore::with_workspace(
+                sessions_base.clone(),
+                "device-default",
                 Arc::clone(&ws_state),
             ));
 
@@ -350,7 +365,8 @@ async fn main() -> Result<()> {
                 Arc::clone(&registry),
                 Arc::clone(&workspace),
                 Arc::clone(&tool_set),
-                Arc::clone(&rpc_session_store),
+                Arc::clone(&cross_device_session_store),
+                Arc::clone(&device_default_session_store),
                 Arc::clone(&mcp_session_store),
                 voice_providers,
                 image_cache.clone(),
@@ -500,7 +516,8 @@ async fn main() -> Result<()> {
                     let workspace_for_loop = Arc::clone(&workspace);
                     let workspace_dir_for_loop = workspace_dir.clone();
                     let channel_store_for_loop = Arc::clone(&channel_session_store);
-                    let rpc_store_for_loop = Arc::clone(&rpc_session_store);
+                    let cross_device_store_for_loop = Arc::clone(&cross_device_session_store);
+                    let device_default_store_for_loop = Arc::clone(&device_default_session_store);
                     let agent_for_loop = Arc::clone(&agent);
                     tokio::spawn(async move {
                         let mut tick = tokio::time::interval(dur);
@@ -521,7 +538,8 @@ async fn main() -> Result<()> {
                                 &workspace_for_loop,
                                 &workspace_dir_for_loop,
                                 &channel_store_for_loop,
-                                &rpc_store_for_loop,
+                                &cross_device_store_for_loop,
+                                &device_default_store_for_loop,
                                 &agent_for_loop,
                             )
                             .await;
@@ -536,7 +554,8 @@ async fn main() -> Result<()> {
                         &workspace,
                         &workspace_dir,
                         &channel_session_store,
-                        &rpc_session_store,
+                        &cross_device_session_store,
+                        &device_default_session_store,
                         &agent,
                     )
                     .await;
@@ -629,7 +648,8 @@ async fn rebuild_today_digests(
     workspace: &Arc<Workspace>,
     workspace_dir: &std::path::Path,
     channel_store: &Arc<SessionStore>,
-    rpc_store: &Arc<SessionStore>,
+    cross_device_store: &Arc<SessionStore>,
+    device_default_store: &Arc<SessionStore>,
     agent: &Arc<Agent>,
 ) {
     let today = session::local_date_for_timestamp(chrono::Local::now(), config.day_boundary_hour);
@@ -640,7 +660,8 @@ async fn rebuild_today_digests(
         today,
         config.day_boundary_hour,
         channel_store,
-        Some(rpc_store.as_ref()),
+        Some(cross_device_store.as_ref()),
+        Some(device_default_store.as_ref()),
         |room_id: &str| cfg.namespace_for_room(room_id).to_string(),
     );
     let had_content = !map.is_empty();

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,15 @@ async fn main() -> Result<()> {
             if let Err(e) = migrate_sessions_to_namespaced_layout(&sessions_base_for_migration) {
                 anyhow::bail!("Session namespace migration failed: {e:#}");
             }
+            // ── Split sessions/<ns>/{api,rpc}/ into cross-device + legacy-voice ─
+            // Quarantines pre-redesign voice files (their `voice-<hash>`
+            // names can't be re-hydrated into the new
+            // `(device_id, room_profile)` keying) and moves remaining
+            // sessions into the new `cross-device/` directory, rewriting
+            // stored `meta.channel = "api"` → `"rpc"` along the way.
+            if let Err(e) = migrate_to_device_default_layout(&sessions_base_for_migration) {
+                anyhow::bail!("Device-default session migration failed: {e:#}");
+            }
 
             // ── Bootstrap file loader (AGENTS.md, SOUL.md, MEMORY.md …) ────
             let workspace = Arc::new(Workspace::new(workspace_dir.clone(), config.digest.clone()));
@@ -262,15 +271,14 @@ async fn main() -> Result<()> {
                     .context("Failed to build provider registry")?,
             );
 
-            // ── Cross-device session store (sessions/<namespace>/rpc/) ─────
+            // ── Cross-device session store (sessions/<namespace>/cross-device/) ─
             // Cross-device sessions are the user-selectable, multi-device
             // conversation threads (resumed via `--resume <grain-id>`).
-            // The on-disk directory is still `rpc/` until the bundled
-            // session migration (#122 PR 3) renames it to `cross-device/`;
-            // the kind constant matches.
+            // The bundled session migration moves pre-PR-3 files into
+            // this dir from the legacy `api/` and `rpc/` locations.
             let cross_device_session_store = Arc::new(SessionStore::with_workspace(
                 sessions_base.clone(),
-                "rpc",
+                "cross-device",
                 Arc::clone(&ws_state),
             ));
 
@@ -431,10 +439,7 @@ async fn main() -> Result<()> {
                     let cfg_for_predicate = config.clone();
                     let ns_for_predicate = ns.clone();
                     let predicate = move |meta: &session::SessionMeta| -> bool {
-                        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112)
-                        // until the bundled session migration rewrites stored
-                        // `meta.channel` strings.
-                        if meta.channel == "api" || meta.channel == "rpc" {
+                        if meta.channel == "rpc" {
                             return ns_for_predicate == config::DEFAULT_NAMESPACE_NAME;
                         }
                         cfg_for_predicate.namespace_for_room(&meta.room_id) == ns_for_predicate
@@ -759,6 +764,161 @@ fn migrate_sessions_to_namespaced_layout(sessions_base: &std::path::Path) -> any
     Ok(())
 }
 
+/// One-shot migration completing #112 + #122: split each
+/// `sessions/<ns>/{api,rpc}/` directory into the new layout.
+///
+/// - Files whose name starts with `voice-` are pre-redesign voice
+///   sessions. Their `(device_id, room_profile)` was hashed into the
+///   filename and is unrecoverable from disk, so we can't slot them
+///   into the new device-default layout. They move to
+///   `sessions/<ns>/legacy-voice/` instead — the daily-log archive
+///   still indexes their content for FTS / semantic search; only the
+///   live continuation is given up.
+/// - Everything else moves to `sessions/<ns>/cross-device/`, with
+///   stored `meta.channel = "api"` rewritten to `"rpc"` in-place.
+/// - The PR 1 dual-read shim and dual-accept fallbacks become
+///   unnecessary after this run.
+///
+/// Idempotent: a workspace that's already migrated has no `api/` or
+/// `rpc/` directory under any namespace and the function exits silently.
+/// Refuses to run when a name collision would clobber an existing
+/// destination (extremely unlikely with UUIDs but handled for safety).
+fn migrate_to_device_default_layout(sessions_base: &std::path::Path) -> anyhow::Result<()> {
+    use std::io::{BufRead, BufReader, Write};
+
+    let Ok(ns_entries) = std::fs::read_dir(sessions_base) else {
+        return Ok(());
+    };
+
+    let mut moved = 0usize;
+    let mut quarantined = 0usize;
+
+    for ns_entry in ns_entries.flatten() {
+        let ns_dir = ns_entry.path();
+        if !ns_dir.is_dir() {
+            continue;
+        }
+
+        for src_kind in ["api", "rpc"] {
+            let src_dir = ns_dir.join(src_kind);
+            if !src_dir.is_dir() {
+                continue;
+            }
+            let entries = match std::fs::read_dir(&src_dir) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("Skipping {}: {e}", src_dir.display());
+                    continue;
+                }
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_file()
+                    || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
+                {
+                    continue;
+                }
+                let Some(file_name) = path.file_name() else {
+                    continue;
+                };
+                let is_voice = file_name
+                    .to_str()
+                    .map(|s| s.starts_with("voice-"))
+                    .unwrap_or(false);
+
+                let (dst_dir, needs_meta_rewrite) = if is_voice {
+                    (ns_dir.join("legacy-voice"), false)
+                } else {
+                    // Cross-device files moving from the legacy `api/`
+                    // directory still carry `meta.channel = "api"` in
+                    // their first line — rewrite to `"rpc"` so the
+                    // dual-accept fallbacks can be removed.
+                    (ns_dir.join("cross-device"), src_kind == "api")
+                };
+                std::fs::create_dir_all(&dst_dir)
+                    .with_context(|| format!("create {}", dst_dir.display()))?;
+                let dst = dst_dir.join(file_name);
+                if dst.exists() {
+                    anyhow::bail!(
+                        "Refusing to migrate {}: destination {} already exists. \
+                         Reconcile manually before starting.",
+                        path.display(),
+                        dst.display(),
+                    );
+                }
+
+                if needs_meta_rewrite {
+                    // Stream the source into a temp file at the
+                    // destination dir (so `fs::rename` stays
+                    // intra-filesystem and atomic), rewriting just the
+                    // first line. Then drop the source.
+                    let tmp = dst.with_extension("partial");
+                    let src_file = std::fs::File::open(&path)
+                        .with_context(|| format!("open {}", path.display()))?;
+                    let mut reader = BufReader::new(src_file);
+                    let mut first_line = String::new();
+                    reader
+                        .read_line(&mut first_line)
+                        .with_context(|| format!("read first line of {}", path.display()))?;
+
+                    let rewritten = rewrite_meta_channel(first_line.trim(), "rpc")?;
+                    let mut writer = std::fs::File::create(&tmp)
+                        .with_context(|| format!("create {}", tmp.display()))?;
+                    writeln!(writer, "{rewritten}")
+                        .with_context(|| format!("write {}", tmp.display()))?;
+                    std::io::copy(&mut reader, &mut writer)
+                        .with_context(|| format!("copy body of {}", path.display()))?;
+                    drop(writer);
+                    std::fs::rename(&tmp, &dst).with_context(|| {
+                        format!("rename {} -> {}", tmp.display(), dst.display())
+                    })?;
+                    std::fs::remove_file(&path)
+                        .with_context(|| format!("remove {}", path.display()))?;
+                } else {
+                    std::fs::rename(&path, &dst).with_context(|| {
+                        format!("rename {} -> {}", path.display(), dst.display())
+                    })?;
+                }
+
+                if is_voice {
+                    quarantined += 1;
+                } else {
+                    moved += 1;
+                }
+            }
+            // Remove the now-empty source dir; non-fatal if it has
+            // leftovers (e.g. operator dropped unrelated files).
+            let _ = std::fs::remove_dir(&src_dir);
+        }
+    }
+
+    if moved > 0 || quarantined > 0 {
+        tracing::info!(
+            "Session migration: {moved} cross-device session(s), \
+             {quarantined} legacy voice file(s) quarantined under legacy-voice/"
+        );
+    }
+    Ok(())
+}
+
+/// Parse a session-meta JSONL line, set `meta.channel` to `new_channel`,
+/// and re-serialise. Used by `migrate_to_device_default_layout` to
+/// rewrite legacy `"api"` strings to `"rpc"` while preserving all
+/// other meta fields.
+fn rewrite_meta_channel(line: &str, new_channel: &str) -> anyhow::Result<String> {
+    let mut value: serde_json::Value =
+        serde_json::from_str(line).with_context(|| format!("parse meta line: {line}"))?;
+    if let Some(meta) = value.get_mut("meta").and_then(|m| m.as_object_mut()) {
+        meta.insert(
+            "channel".to_string(),
+            serde_json::Value::String(new_channel.to_string()),
+        );
+    } else {
+        anyhow::bail!("first JSONL line missing `meta` object: {line}");
+    }
+    Ok(serde_json::to_string(&value)?)
+}
+
 /// One-shot migration from the per-channel session layout
 /// (`sessions/matrix/` + `sessions/discord/`) to the consolidated
 /// `sessions/channel/` directory. The originating channel is still
@@ -1051,6 +1211,151 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(base.join("channel/01H1.jsonl")).unwrap(),
+            "pre-existing"
+        );
+    }
+
+    // ── device-default layout migration (#122 PR 3) ──────────────────────
+
+    /// Render a minimal meta line for the device-default migration tests.
+    /// Only `session_id` and `channel` are exercised by the migration —
+    /// everything else just rides along untouched.
+    fn meta_line(session_id: &str, channel: &str) -> String {
+        format!(
+            r#"{{"meta":{{"session_id":"{session_id}","room_id":"","thread_id":null,"channel":"{channel}","created_at":"2026-05-22T00:00:00Z","namespace":"default"}}}}"#
+        )
+    }
+
+    #[test]
+    fn device_default_migration_no_op_on_fresh_workspace() {
+        let td = tempfile::tempdir().unwrap();
+        migrate_to_device_default_layout(td.path()).expect("clean migration");
+        // No directories should be created on an empty workspace.
+        assert!(!td.path().join("default").exists());
+    }
+
+    /// Cross-device text sessions move into `cross-device/`;
+    /// `voice-<hash>` files go into `legacy-voice/`. Both source dirs
+    /// are removed afterwards.
+    #[test]
+    fn device_default_migration_moves_cross_device_and_quarantines_voice() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("uuid-text-modern.jsonl"),
+            &meta_line("uuid-text-modern", "rpc"),
+        );
+        write_stub(
+            &ns.join("api").join("voice-deadbeef.jsonl"),
+            &meta_line("voice-deadbeef", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("voice-feedface.jsonl"),
+            &meta_line("voice-feedface", "rpc"),
+        );
+
+        migrate_to_device_default_layout(base).expect("migration");
+
+        assert!(ns.join("cross-device/uuid-text.jsonl").exists());
+        assert!(ns.join("cross-device/uuid-text-modern.jsonl").exists());
+        assert!(ns.join("legacy-voice/voice-deadbeef.jsonl").exists());
+        assert!(ns.join("legacy-voice/voice-feedface.jsonl").exists());
+        assert!(!ns.join("api").exists(), "api dir should be removed");
+        assert!(!ns.join("rpc").exists(), "rpc dir should be removed");
+    }
+
+    /// Files that arrive from the legacy `api/` dir get their stored
+    /// `meta.channel = "api"` rewritten to `"rpc"`; files from `rpc/`
+    /// keep their meta unchanged. Voice files in `legacy-voice/` are
+    /// preserved verbatim (no rewrite — they're never re-loaded).
+    #[test]
+    fn device_default_migration_rewrites_legacy_meta_channel() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-from-api.jsonl"),
+            &meta_line("uuid-from-api", "api"),
+        );
+        write_stub(
+            &ns.join("rpc").join("uuid-from-rpc.jsonl"),
+            &meta_line("uuid-from-rpc", "rpc"),
+        );
+        write_stub(
+            &ns.join("api").join("voice-cafe.jsonl"),
+            &meta_line("voice-cafe", "api"),
+        );
+
+        migrate_to_device_default_layout(base).expect("migration");
+
+        let api_migrated =
+            std::fs::read_to_string(ns.join("cross-device/uuid-from-api.jsonl")).unwrap();
+        assert!(
+            api_migrated.contains(r#""channel":"rpc""#),
+            "legacy `api` meta must be rewritten to `rpc`: {api_migrated}"
+        );
+        assert!(
+            !api_migrated.contains(r#""channel":"api""#),
+            "legacy `api` meta should no longer appear: {api_migrated}"
+        );
+
+        let rpc_migrated =
+            std::fs::read_to_string(ns.join("cross-device/uuid-from-rpc.jsonl")).unwrap();
+        assert!(
+            rpc_migrated.contains(r#""channel":"rpc""#),
+            "post-PR1 `rpc` meta stays as-is: {rpc_migrated}"
+        );
+
+        let voice_quarantined =
+            std::fs::read_to_string(ns.join("legacy-voice/voice-cafe.jsonl")).unwrap();
+        assert!(
+            voice_quarantined.contains(r#""channel":"api""#),
+            "voice meta is preserved verbatim (no rewrite): {voice_quarantined}"
+        );
+    }
+
+    #[test]
+    fn device_default_migration_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        migrate_to_device_default_layout(base).expect("first");
+        migrate_to_device_default_layout(base).expect("second is a no-op");
+        assert!(ns.join("cross-device/uuid-text.jsonl").exists());
+    }
+
+    #[test]
+    fn device_default_migration_refuses_on_collision() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let ns = base.join("default");
+        write_stub(
+            &ns.join("api").join("uuid-text.jsonl"),
+            &meta_line("uuid-text", "api"),
+        );
+        write_stub(
+            &ns.join("cross-device").join("uuid-text.jsonl"),
+            "pre-existing",
+        );
+
+        let err = migrate_to_device_default_layout(base).expect_err("collision");
+        assert!(
+            format!("{err:#}").contains("already exists"),
+            "got: {err:#}"
+        );
+        // Source untouched.
+        assert!(ns.join("api/uuid-text.jsonl").exists());
+        assert_eq!(
+            std::fs::read_to_string(ns.join("cross-device/uuid-text.jsonl")).unwrap(),
             "pre-existing"
         );
     }

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -1156,9 +1156,10 @@ pub async fn catchup_pending_yearly_logs(
 // ---------------------------------------------------------------------------
 
 /// Render the bullet block that goes under `# Today's Cross-Session Notes`
-/// for `namespace`. Walks `channel_store` and `api_store` for digests
-/// whose `digest_at` falls inside `today`'s local window, keeping only
-/// the latest per session that maps to `namespace` via `room_to_namespace`.
+/// for `namespace`. Walks `channel_store`, `cross_device_store`, and
+/// `device_default_store` for digests whose `digest_at` falls inside
+/// `today`'s local window, keeping only the latest per session that
+/// maps to `namespace`.
 ///
 /// Returns `None` when no qualifying digest exists, so the caller can
 /// omit the namespace from the cache map and the system prompt block.
@@ -1167,7 +1168,8 @@ pub fn build_today_digest_for_namespace<F>(
     today: NaiveDate,
     boundary_hour: u8,
     channel_store: &SessionStore,
-    api_store: Option<&SessionStore>,
+    cross_device_store: Option<&SessionStore>,
+    device_default_store: Option<&SessionStore>,
     room_to_namespace: F,
 ) -> Option<String>
 where
@@ -1175,8 +1177,11 @@ where
 {
     let mut entries: Vec<(SessionMeta, crate::session::IntradayDigestLine)> = Vec::new();
     entries.extend(channel_store.intraday_digests_for_day(today, boundary_hour));
-    if let Some(api) = api_store {
-        entries.extend(api.intraday_digests_for_day(today, boundary_hour));
+    if let Some(s) = cross_device_store {
+        entries.extend(s.intraday_digests_for_day(today, boundary_hour));
+    }
+    if let Some(s) = device_default_store {
+        entries.extend(s.intraday_digests_for_day(today, boundary_hour));
     }
     if entries.is_empty() {
         return None;
@@ -1187,15 +1192,23 @@ where
         // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112) until the
         // bundled session migration rewrites stored `meta.channel` strings.
         let is_rpc = meta.channel == "rpc" || meta.channel == "api";
+        let is_device_default = meta.channel == "device-default";
         let ns = if is_rpc {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()
+        } else if is_device_default {
+            // Device-default sessions pin their namespace at create time —
+            // honour it directly so an NSFW-profile satellite's digests
+            // don't leak into the default namespace.
+            meta.namespace
+                .clone()
+                .unwrap_or_else(|| crate::config::DEFAULT_NAMESPACE_NAME.to_string())
         } else {
             room_to_namespace(&meta.room_id)
         };
         if ns != namespace {
             continue;
         }
-        let room_label = if is_rpc {
+        let room_label = if is_rpc || is_device_default {
             meta.title.clone().unwrap_or_else(|| {
                 format!("{}/{}", meta.channel, short_id(&meta.session_id))
             })
@@ -1226,7 +1239,8 @@ pub fn build_all_today_digests<F>(
     today: NaiveDate,
     boundary_hour: u8,
     channel_store: &SessionStore,
-    api_store: Option<&SessionStore>,
+    cross_device_store: Option<&SessionStore>,
+    device_default_store: Option<&SessionStore>,
     room_to_namespace: F,
 ) -> HashMap<String, String>
 where
@@ -1239,7 +1253,8 @@ where
             today,
             boundary_hour,
             channel_store,
-            api_store,
+            cross_device_store,
+            device_default_store,
             room_to_namespace,
         ) {
             out.insert(ns.clone(), text);

--- a/src/periodic_log.rs
+++ b/src/periodic_log.rs
@@ -1189,9 +1189,7 @@ where
 
     let mut lines: Vec<String> = Vec::new();
     for (meta, digest) in entries {
-        // Dual-accept `"api"` (legacy) and `"rpc"` (post-#112) until the
-        // bundled session migration rewrites stored `meta.channel` strings.
-        let is_rpc = meta.channel == "rpc" || meta.channel == "api";
+        let is_rpc = meta.channel == "rpc";
         let is_device_default = meta.channel == "device-default";
         let ns = if is_rpc {
             crate::config::DEFAULT_NAMESPACE_NAME.to_string()

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -59,10 +59,19 @@ pub struct ServeState {
     pub(crate) registry: Arc<ProviderRegistry>,
     pub(crate) workspace: Arc<Workspace>,
     pub(crate) tools: Arc<ToolSet>,
-    pub(crate) rpc_session_store: Arc<SessionStore>,
+    /// Cross-device session store (kind = `"rpc"` for now; #122 PR 3
+    /// renames the on-disk dir to `cross-device/`). Holds the
+    /// user-selectable, multi-device sessions resumed via
+    /// `--resume <grain-id>`.
+    pub(crate) cross_device_session_store: Arc<SessionStore>,
+    /// Device-default session store (kind = `"device-default"`). Holds the
+    /// per-`(device_id, room_profile)` always-on session that heartbeat
+    /// pushes target and that a satellite falls into when no other session
+    /// is selected. Lazy-created, daily-rotated. See #122.
+    pub(crate) device_default_session_store: Arc<SessionStore>,
     /// MCP session store (kind = `"mcp"`). Holds long-lived
     /// per-project sessions written through `/mcp`'s `write_report`
-    /// tool — kept physically separate from `rpc_session_store` so the
+    /// tool — kept physically separate from `cross_device_session_store` so the
     /// project index scan and any future MCP-specific retention only
     /// see MCP traffic.
     pub(crate) mcp_session_store: Arc<SessionStore>,
@@ -121,7 +130,8 @@ impl ServeState {
         registry: Arc<ProviderRegistry>,
         workspace: Arc<Workspace>,
         tools: Arc<ToolSet>,
-        rpc_session_store: Arc<SessionStore>,
+        cross_device_session_store: Arc<SessionStore>,
+        device_default_session_store: Arc<SessionStore>,
         mcp_session_store: Arc<SessionStore>,
         voice: Option<Arc<VoiceProviders>>,
         image_cache: Option<Arc<crate::image_cache::ImageCache>>,
@@ -148,7 +158,8 @@ impl ServeState {
             registry,
             workspace,
             tools,
-            rpc_session_store,
+            cross_device_session_store,
+            device_default_session_store,
             mcp_session_store,
             mcp_project_index: tokio::sync::Mutex::new(mcp_index),
             sessions: tokio::sync::Mutex::new(HashMap::new()),
@@ -158,6 +169,24 @@ impl ServeState {
             voice,
             voice_subscribers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             image_cache,
+        }
+    }
+
+    /// Pick the [`SessionStore`] that owns `session_id`. Device-default
+    /// sessions land in `device-default/`; everything else (cross-device
+    /// text sessions, deferred sessions awaiting their first message)
+    /// lives in `cross_device_session_store`'s `rpc/` tree. Falls back
+    /// to the cross-device store so newly-`ensure_session`'d files
+    /// (which haven't hit disk yet) commit to the right place. See #122.
+    pub(crate) fn store_for_session(&self, session_id: &str) -> &Arc<SessionStore> {
+        if self
+            .device_default_session_store
+            .absolute_path_for(session_id)
+            .is_some()
+        {
+            &self.device_default_session_store
+        } else {
+            &self.cross_device_session_store
         }
     }
 
@@ -332,19 +361,13 @@ async fn summarize_all_sessions(state: &Arc<ServeState>) {
     );
     for (session_id, messages) in snapshot {
         let provider = state.provider_for_session(&session_id).await;
+        let store = state.store_for_session(&session_id);
         match generate_summary(&*provider, &messages).await {
             Ok(summary) if !summary.trim().is_empty() => {
-                if let Err(e) = state
-                    .rpc_session_store
-                    .append_summary(&session_id, &summary)
-                {
+                if let Err(e) = store.append_summary(&session_id, &summary) {
                     warn!("Failed to persist shutdown summary for {session_id}: {e}");
                 }
-                if let Err(e) =
-                    state
-                        .rpc_session_store
-                        .append_intraday_digest(&session_id, &summary, None)
-                {
+                if let Err(e) = store.append_intraday_digest(&session_id, &summary, None) {
                     warn!("Failed to persist shutdown intra-day digest for {session_id}: {e}");
                 }
             }
@@ -475,7 +498,7 @@ async fn handle_initialize(
 
         match param_id {
             None => None,
-            Some(ref id) if id.len() == 7 => match state.rpc_session_store.find_by_public_id(id) {
+            Some(ref id) if id.len() == 7 => match state.cross_device_session_store.find_by_public_id(id) {
                 Some(uuid) => Some(uuid),
                 None => {
                     let body = error_response(req_id, -32602, "Session not found");
@@ -495,7 +518,7 @@ async fn handle_initialize(
 
     let (session_id, is_new) = match resolved {
         Some(id) => {
-            let exists = state.rpc_session_store.load_session(&id).is_some();
+            let exists = state.cross_device_session_store.load_session(&id).is_some();
             (id, !exists)
         }
         None => (uuid::Uuid::now_v7().to_string(), true),
@@ -517,13 +540,13 @@ async fn handle_initialize(
         let mut sessions = state.sessions.lock().await;
         sessions.entry(session_id.clone()).or_insert_with(|| {
             state
-                .rpc_session_store
+                .cross_device_session_store
                 .load_session(&session_id)
                 .unwrap_or_default()
         });
         // Look up the public_id from the existing file metadata.
         state
-            .rpc_session_store
+            .cross_device_session_store
             .list_sessions()
             .into_iter()
             .find(|m| m.session_id == session_id)
@@ -645,7 +668,7 @@ async fn handle_chat(
 // ---------------------------------------------------------------------------
 
 async fn handle_list_sessions(state: Arc<ServeState>, req_id: Value) -> axum::response::Response {
-    let metas = state.rpc_session_store.list_sessions();
+    let metas = state.cross_device_session_store.list_sessions();
     let items: Vec<Value> = metas
         .into_iter()
         .map(|m| {
@@ -689,7 +712,7 @@ async fn handle_get_session(
     };
 
     let messages = state
-        .rpc_session_store
+        .store_for_session(&session_id)
         .load_session(&session_id)
         .unwrap_or_default();
 
@@ -834,12 +857,31 @@ async fn handle_voice_pipeline_run(
     // `rpc_post`; clients no longer pass it as a param.
     let language = params["language"].as_str().map(|s| s.to_string());
 
-    // Derive a deterministic session id from (device_id, room_profile)
-    // so the satellite can resume the conversation thread across
-    // restarts / day boundaries without juggling explicit session
-    // tokens. Pin the room_profile so run_llm_turn picks up the
-    // right LLM profile + memory namespace + voice config.
-    let session_id = voice_session_id(&device_id, &room_profile);
+    // Resolve / lazily-create the device-default session for this
+    // `(device_id, room_profile)` pair under that profile's memory
+    // namespace. Daily rotation falls out naturally: a satellite
+    // reconnecting after the day boundary finds yesterday's file as
+    // "not in today's window" and a fresh UUID file is opened. See #122.
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&room_profile)
+        .to_string();
+    let session_id = match state.device_default_session_store.find_or_create_for_device(
+        &device_id,
+        &room_profile,
+        &namespace,
+        state.config.day_boundary_hour,
+    ) {
+        Ok(id) => id,
+        Err(e) => {
+            let body = error_response(
+                req_id,
+                -32603,
+                &format!("failed to resolve device-default session: {e}"),
+            );
+            return body.into_response();
+        }
+    };
     state
         .session_room_profiles
         .lock()
@@ -997,28 +1039,6 @@ async fn translate_voice_pushes(
     }
 }
 
-/// Deterministic session id derived from `(device_id, room_profile)`.
-/// Always-same input ⇒ always-same id, so a satellite reconnecting
-/// after a crash or day rollover resumes the same conversation file.
-///
-/// Format: `voice-<first 16 hex chars of SHA-256>`. Filesystem-safe,
-/// unique enough for any realistic deployment.
-pub(crate) fn voice_session_id(device_id: &str, room_profile: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(b"voice:");
-    hasher.update(device_id.as_bytes());
-    hasher.update(b":");
-    hasher.update(room_profile.as_bytes());
-    let hash = hasher.finalize();
-    let mut s = String::with_capacity(22);
-    s.push_str("voice-");
-    for b in &hash[..8] {
-        use std::fmt::Write;
-        let _ = write!(&mut s, "{b:02x}");
-    }
-    s
-}
 
 async fn run_voice_turn(
     state: Arc<ServeState>,
@@ -1347,7 +1367,7 @@ async fn run_voice_turn_from_text_sse(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_text, &reply).await
-                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.store_for_session(&sid).set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }
@@ -1403,9 +1423,23 @@ pub(crate) async fn push_voice_text_to_subscriber(
         return Err(VoicePushError::NotConfigured);
     }
 
-    // Pin the room_profile on the synthetic session id so
-    // `resolve_voice_pipeline` and `run_llm_turn` find the right config.
-    let session_id = voice_session_id(&device_id, &room_profile);
+    // Resolve / lazily-create the device-default session for this
+    // `(device_id, room_profile)` pair under that profile's memory
+    // namespace, then pin the room_profile so `resolve_voice_pipeline`
+    // and `run_llm_turn` find the right config. See #122.
+    let namespace = state
+        .config
+        .namespace_for_room_profile(&room_profile)
+        .to_string();
+    let session_id = state
+        .device_default_session_store
+        .find_or_create_for_device(
+            &device_id,
+            &room_profile,
+            &namespace,
+            state.config.day_boundary_hour,
+        )
+        .map_err(|e| VoicePushError::Other(format!("device-default lookup: {e}")))?;
     state
         .session_room_profiles
         .lock()
@@ -1554,17 +1588,16 @@ async fn run_llm_turn(
         }
     };
 
+    // Pick the right store up front so every persistence call in this
+    // turn lands in the same place (device-default vs cross-device).
+    let store = Arc::clone(state.store_for_session(&session_id));
+
     // 1. Load or lazy-hydrate in-memory history
     let mut history: Vec<ChatMessage> = {
         let mut sessions = state.sessions.lock().await;
         sessions
             .entry(session_id.clone())
-            .or_insert_with(|| {
-                state
-                    .rpc_session_store
-                    .load_session(&session_id)
-                    .unwrap_or_default()
-            })
+            .or_insert_with(|| store.load_session(&session_id).unwrap_or_default())
             .clone()
     };
     let was_first_turn = history.is_empty();
@@ -1586,14 +1619,21 @@ async fn run_llm_turn(
 
     // 2b. Ensure JSONL file exists. If this session was deferred at initialize
     //     time, commit it now using the reserved public_id.
+    //
+    // Device-default sessions are always already-on-disk by the time
+    // run_llm_turn runs (find_or_create_for_device writes the meta
+    // line at create time) so `ensure_session` against them is a
+    // no-op. Skip it to avoid synthesising a spurious grain-id
+    // public_id that device-default sessions don't need.
     let key: ConversationKey = (session_id.clone(), None);
-    let pending_pub_id = state.pending_sessions.lock().await.remove(&session_id);
-    if let Err(e) = state
-        .rpc_session_store
-        .ensure_session(&session_id, &key, "rpc", pending_pub_id, &namespace)
-        .map(|_| ())
-    {
-        warn!("Failed to ensure session file: {e}");
+    if Arc::ptr_eq(&store, &state.cross_device_session_store) {
+        let pending_pub_id = state.pending_sessions.lock().await.remove(&session_id);
+        if let Err(e) = store
+            .ensure_session(&session_id, &key, "rpc", pending_pub_id, &namespace)
+            .map(|_| ())
+        {
+            warn!("Failed to ensure session file: {e}");
+        }
     }
 
     // 3a. System prompt (rebuilt fresh per request).
@@ -1620,7 +1660,7 @@ async fn run_llm_turn(
     //    `SessionStore::append` so the in-memory history keeps full image
     //    bytes for the provider call while JSONL gets a hash marker.
     history.push(user_msg.clone());
-    if let Err(e) = state.rpc_session_store.append(&session_id, &user_msg) {
+    if let Err(e) = store.append(&session_id, &user_msg) {
         warn!("Failed to persist user message: {e}");
     }
 
@@ -1648,10 +1688,7 @@ async fn run_llm_turn(
         match maybe_compress(&*provider, system.as_deref(), &history, compression_config).await {
             Ok(Some(result)) => {
                 history = result.compressed;
-                if let Err(e) = state
-                    .rpc_session_store
-                    .append_summary(&session_id, &result.summary)
-                {
+                if let Err(e) = store.append_summary(&session_id, &result.summary) {
                     warn!("Failed to persist compaction summary: {e}");
                 }
             }
@@ -1682,7 +1719,7 @@ async fn run_llm_turn(
                 let text = resp.text.unwrap_or_default();
                 let msg = ChatMessage::assistant(&text);
                 history.push(msg.clone());
-                if let Err(e) = state.rpc_session_store.append(&session_id, &msg) {
+                if let Err(e) = store.append(&session_id, &msg) {
                     warn!("Failed to persist assistant message: {e}");
                 }
                 if !text.is_empty() {
@@ -1827,7 +1864,7 @@ async fn run_turn(
         tokio::spawn(async move {
             let p = state2.provider_for_session(&sid).await;
             if let Some(title) = generate_session_title(&*p, &user_msg, &text).await
-                && let Err(e) = state2.rpc_session_store.set_title(&sid, &title)
+                && let Err(e) = state2.store_for_session(&sid).set_title(&sid, &title)
             {
                 warn!("Failed to store session title: {e}");
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -62,6 +62,19 @@ pub struct SessionMeta {
     /// chat/API/voice sessions.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub project: Option<String>,
+    /// Originating device id for device-default sessions (kind =
+    /// `"device-default"`). Combined with `room_profile` below, this
+    /// pair is the routing key — `find_or_create_for_device` returns
+    /// the most-recent file matching both. Absent on every other kind.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub device_id: Option<String>,
+    /// Resolved room_profile name for device-default sessions. Pinned
+    /// at creation time (from the bearer token's `api_keys` match) so
+    /// rotation and `find_or_create_for_device` don't accidentally
+    /// hand a session to a different profile after `[room_profile]`
+    /// reshuffles. Absent on every other kind.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub room_profile: Option<String>,
     /// Short auto-generated title, populated from a later `session_title` line.
     #[serde(skip)]
     pub title: Option<String>,
@@ -337,6 +350,8 @@ impl SessionStore {
             public_id: None,
             namespace: Some(namespace.to_string()),
             project: None,
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -598,6 +613,8 @@ impl SessionStore {
             public_id: None,
             namespace: Some(namespace.to_string()),
             project: Some(project.to_string()),
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -676,6 +693,8 @@ impl SessionStore {
             public_id: public_id.clone(),
             namespace: Some(namespace.to_string()),
             project: None,
+            device_id: None,
+            room_profile: None,
             title: None,
         };
         let line = serde_json::to_string(&MetaLine { meta })?;
@@ -684,6 +703,85 @@ impl SessionStore {
         drop(file);
         self.notify_updated(&path);
         Ok(public_id)
+    }
+
+    /// Find the most-recent device-default session for `(device_id, room_profile)`
+    /// that falls within today's local-day window (per `boundary_hour`), or
+    /// create a new file when none qualifies.
+    ///
+    /// Used by the voice `/rpc` methods and heartbeat fires to route into a
+    /// device's always-on session (#122). Lazy: nothing lands on disk until a
+    /// satellite that's actually used calls this. Closed sessions (those with
+    /// a `closed_at` marker) are skipped so an explicit boundary close still
+    /// rotates the file even before the next day window kicks in.
+    ///
+    /// Returns the resolved session_id. The caller is expected to follow up
+    /// with `append` for the message that triggered the lookup.
+    pub fn find_or_create_for_device(
+        &self,
+        device_id: &str,
+        room_profile: &str,
+        namespace: &str,
+        boundary_hour: u8,
+    ) -> anyhow::Result<String> {
+        let today = local_date_for_timestamp(Local::now(), boundary_hour);
+        let (today_start, today_end) = day_window(today, boundary_hour);
+
+        let mut best: Option<(DateTime<Utc>, String)> = None;
+        for path in collect_session_files(&self.base_dir, self.kind) {
+            let Some((meta, _, is_closed, _)) = load_session_file(&path) else {
+                continue;
+            };
+            if is_closed {
+                continue;
+            }
+            if meta.namespace.as_deref() != Some(namespace) {
+                continue;
+            }
+            if meta.device_id.as_deref() != Some(device_id) {
+                continue;
+            }
+            if meta.room_profile.as_deref() != Some(room_profile) {
+                continue;
+            }
+            if meta.created_at < today_start || meta.created_at >= today_end {
+                continue;
+            }
+            match &best {
+                Some((ts, _)) if *ts >= meta.created_at => {}
+                _ => best = Some((meta.created_at, meta.session_id.clone())),
+            }
+        }
+        if let Some((_, id)) = best {
+            // Seed the path cache so the upcoming `append` skips a rescan.
+            let _ = self.resolve_path(&id);
+            return Ok(id);
+        }
+
+        let session_id = Uuid::now_v7().to_string();
+        let path = self.path_for_new(&session_id, namespace);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let meta = SessionMeta {
+            session_id: session_id.clone(),
+            room_id: String::new(),
+            thread_id: None,
+            channel: "device-default".to_string(),
+            created_at: Utc::now(),
+            public_id: None,
+            namespace: Some(namespace.to_string()),
+            project: None,
+            device_id: Some(device_id.to_string()),
+            room_profile: Some(room_profile.to_string()),
+            title: None,
+        };
+        let line = serde_json::to_string(&MetaLine { meta })?;
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        writeln!(file, "{line}")?;
+        drop(file);
+        self.notify_updated(&path);
+        Ok(session_id)
     }
 
     /// Append a title for a session (append-only; last line wins on read).
@@ -1165,5 +1263,131 @@ mod tests {
         // Sanity: scanning a non-rpc kind does NOT pull in the api dir.
         let channel_only = collect_session_files(tmp.path(), "channel");
         assert!(channel_only.is_empty(), "channel scan must not see rpc/api dirs");
+    }
+
+    // ── device-default session routing (#122) ────────────────────────────
+
+    fn new_device_default_store() -> (tempfile::TempDir, SessionStore) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path().to_path_buf(), "device-default");
+        (tmp, store)
+    }
+
+    /// Fresh dir: returns a brand-new UUID, persists meta with the right
+    /// `(device_id, room_profile, channel, namespace)` fields.
+    #[test]
+    fn find_or_create_for_device_creates_new_session() {
+        let (_tmp, store) = new_device_default_store();
+        let sid = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .expect("find_or_create");
+        // Resolve from disk and verify the meta the store wrote.
+        let path = store.absolute_path_for(&sid).expect("path cached");
+        let (meta, _msgs, is_closed, _summary) =
+            load_session_file(&path).expect("meta line present");
+        assert_eq!(meta.session_id, sid);
+        assert_eq!(meta.channel, "device-default");
+        assert_eq!(meta.device_id.as_deref(), Some("device-a"));
+        assert_eq!(meta.room_profile.as_deref(), Some("default"));
+        assert_eq!(meta.namespace.as_deref(), Some("default"));
+        assert!(meta.public_id.is_none(), "device-default has no grain-id");
+        assert!(!is_closed);
+    }
+
+    /// Second call within the same local day returns the same session_id.
+    #[test]
+    fn find_or_create_for_device_is_idempotent_within_day() {
+        let (_tmp, store) = new_device_default_store();
+        let first = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let second = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    /// Different device_id ⇒ separate file.
+    #[test]
+    fn find_or_create_for_device_distinguishes_devices() {
+        let (_tmp, store) = new_device_default_store();
+        let a = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let b = store
+            .find_or_create_for_device("device-b", "default", "default", 4)
+            .unwrap();
+        assert_ne!(a, b);
+    }
+
+    /// Different room_profile ⇒ separate file (NSFW isolation).
+    #[test]
+    fn find_or_create_for_device_distinguishes_room_profiles() {
+        let (_tmp, store) = new_device_default_store();
+        let sfw = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        let nsfw = store
+            .find_or_create_for_device("device-a", "private_nsfw", "user_nsfw", 4)
+            .unwrap();
+        assert_ne!(sfw, nsfw);
+    }
+
+    /// Closing the active session ⇒ next call rotates to a fresh UUID.
+    #[test]
+    fn find_or_create_for_device_skips_closed_sessions() {
+        let (_tmp, store) = new_device_default_store();
+        let first = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        store.close_session(&first).expect("close");
+        let second = store
+            .find_or_create_for_device("device-a", "default", "default", 4)
+            .unwrap();
+        assert_ne!(
+            first, second,
+            "closed session must not be reused — boundary rotation depends on this"
+        );
+    }
+
+    /// A meta file dated outside today's local window must not be reused —
+    /// next call must create a fresh session.
+    #[test]
+    fn find_or_create_for_device_skips_yesterday_session() {
+        let (tmp, store) = new_device_default_store();
+        let boundary = 4u8;
+
+        // Hand-craft a meta file whose `created_at` falls in yesterday's
+        // local-day window so the most-recent scan rejects it.
+        let yesterday_date =
+            local_date_for_timestamp(Local::now(), boundary) - Duration::days(1);
+        let (yesterday_start, _) = day_window(yesterday_date, boundary);
+        let stale_id = Uuid::now_v7().to_string();
+        let stale_dir = tmp.path().join("default").join("device-default");
+        fs::create_dir_all(&stale_dir).unwrap();
+        let stale_path = stale_dir.join(format!("{stale_id}.jsonl"));
+        let stale_meta = SessionMeta {
+            session_id: stale_id.clone(),
+            room_id: String::new(),
+            thread_id: None,
+            channel: "device-default".to_string(),
+            created_at: yesterday_start + Duration::hours(2),
+            public_id: None,
+            namespace: Some("default".to_string()),
+            project: None,
+            device_id: Some("device-a".to_string()),
+            room_profile: Some("default".to_string()),
+            title: None,
+        };
+        let line = serde_json::to_string(&MetaLine { meta: stale_meta }).unwrap();
+        std::fs::write(&stale_path, format!("{line}\n")).unwrap();
+
+        let fresh = store
+            .find_or_create_for_device("device-a", "default", "default", boundary)
+            .unwrap();
+        assert_ne!(
+            stale_id, fresh,
+            "yesterday's session must not be picked up; daily rotation depends on it"
+        );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,11 +187,11 @@ pub struct SessionStore {
     /// so retrieve indexing can scope itself by directory and never
     /// accidentally mix NSFW sessions with default-namespace ones.
     pub base_dir: PathBuf,
-    /// Second-level subdirectory: `"channel"` for Matrix/Discord, `"rpc"`
-    /// for HTTP (renamed from `"api"` in #112; readers transparently
-    /// fall through to the legacy `"api"` dir until the bundled session
-    /// migration moves the files). Lets the Agent and ServeState keep
-    /// separate `SessionStore` instances while sharing one base dir.
+    /// Second-level subdirectory: `"channel"` for Matrix/Discord,
+    /// `"cross-device"` for user-selectable RPC sessions,
+    /// `"device-default"` for per-`(device_id, room_profile)` sessions,
+    /// `"mcp"` for MCP project sessions. Lets the Agent and ServeState
+    /// keep separate `SessionStore` instances while sharing one base dir.
     pub kind: &'static str,
     /// Optional sapphire-workspace state. When set, file modifications notify
     /// the workspace so the index/cache and git staging stay in sync.
@@ -658,9 +658,9 @@ impl SessionStore {
     /// Ensure a session file exists for the given caller-supplied ID.
     /// Unlike `create_session`, this uses the provided ID rather than generating a new UUID.
     ///
-    /// For RPC sessions (`channel == "rpc"`, or legacy `"api"`), a grain-id
-    /// `public_id` is generated on creation unless `public_id_override` is
-    /// supplied (used to commit a deferred public_id).
+    /// For RPC sessions (`channel == "rpc"`), a grain-id `public_id` is
+    /// generated on creation unless `public_id_override` is supplied
+    /// (used to commit a deferred public_id).
     /// Returns the `public_id` if present (new or existing).
     pub fn ensure_session(
         &self,
@@ -679,7 +679,7 @@ impl SessionStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let public_id = if channel == "rpc" || channel == "api" {
+        let public_id = if channel == "rpc" {
             Some(public_id_override.unwrap_or_else(|| grain_id::GrainId::random().to_string()))
         } else {
             None
@@ -986,36 +986,24 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// Enumerate `<base_dir>/<namespace>/<kind>/*.jsonl` across every namespace
 /// directory. Returns an empty Vec when `base_dir` doesn't exist yet (fresh
 /// install) or has no namespace subdirs. Each returned path is absolute.
-///
-/// Dual-read shim for #112: when `kind == "rpc"`, the legacy `"api"` directory
-/// is also scanned so post-rename builds keep surfacing pre-migration files.
-/// The bundled session-store migration removes the shim once it has moved the
-/// files into the new layout.
 fn collect_session_files(base_dir: &Path, kind: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let Ok(entries) = fs::read_dir(base_dir) else {
         return out;
-    };
-    let scan_kinds: &[&str] = if kind == "rpc" {
-        &["rpc", "api"]
-    } else {
-        std::slice::from_ref(&kind)
     };
     for entry in entries.flatten() {
         let ns_dir = entry.path();
         if !ns_dir.is_dir() {
             continue;
         }
-        for k in scan_kinds {
-            let kind_dir = ns_dir.join(k);
-            let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
-                continue;
-            };
-            for k_entry in kind_entries.flatten() {
-                let path = k_entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                    out.push(path);
-                }
+        let kind_dir = ns_dir.join(kind);
+        let Ok(kind_entries) = fs::read_dir(&kind_dir) else {
+            continue;
+        };
+        for k_entry in kind_entries.flatten() {
+            let path = k_entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                out.push(path);
             }
         }
     }
@@ -1231,38 +1219,6 @@ mod tests {
             scrub_images_for_storage(&msg).is_none(),
             "scrub should leave ImageRef-only messages untouched"
         );
-    }
-
-    /// Post-#112 dual-read shim: when scanning for `"rpc"` files, the
-    /// legacy `"api"` sub-directory must also be visible so existing
-    /// sessions stay reachable until the bundled migration moves them.
-    #[test]
-    fn collect_session_files_dual_reads_legacy_api_dir() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let ns = tmp.path().join("default");
-        let api_dir = ns.join("api");
-        let rpc_dir = ns.join("rpc");
-        fs::create_dir_all(&api_dir).unwrap();
-        fs::create_dir_all(&rpc_dir).unwrap();
-        let legacy = api_dir.join("old.jsonl");
-        let fresh = rpc_dir.join("new.jsonl");
-        std::fs::write(&legacy, b"").unwrap();
-        std::fs::write(&fresh, b"").unwrap();
-
-        // Stray file that should NOT be picked up (wrong extension).
-        std::fs::write(rpc_dir.join("ignore.txt"), b"").unwrap();
-
-        let mut found = collect_session_files(tmp.path(), "rpc");
-        found.sort();
-        assert_eq!(found, {
-            let mut expected = vec![legacy, fresh];
-            expected.sort();
-            expected
-        });
-
-        // Sanity: scanning a non-rpc kind does NOT pull in the api dir.
-        let channel_only = collect_session_files(tmp.path(), "channel");
-        assert!(channel_only.is_empty(), "channel scan must not see rpc/api dirs");
     }
 
     // ── device-default session routing (#122) ────────────────────────────


### PR DESCRIPTION
## Why this PR

#124 and #125 originally landed as stacked PRs on top of #123, but GitHub merged them into their respective stale base branches (\`refactor/rename-api-to-rpc\` and \`feat/device-default-sessions\`) instead of forwarding the changes to \`main\` after #123 merged. \`main\` only ended up with #123. This PR re-targets the same two commits to \`main\` directly. No code differences from #124 + #125.

## Contents

Two commits, cherry-picked verbatim from the original branches:

1. **\`feat(sessions): introduce device-default sessions for voice/heartbeat routing\`** (originally #124) — Server-side data model + voice path migration. Adds the \`device-default\` session kind, retires the deterministic \`voice-<sha256>\` filename trick, splits \`ServeState::rpc_session_store\` into \`cross_device_session_store\` + \`device_default_session_store\`, threads everything through the new \`ServeState::store_for_session\` helper. Six new unit tests on \`find_or_create_for_device\`.
2. **\`feat(sessions): bundled migration for cross-device + legacy-voice split\`** (originally #125) — One-shot startup migration. Moves cross-device sessions into \`sessions/<ns>/cross-device/\`; quarantines pre-redesign \`voice-<hash>.jsonl\` files into \`sessions/<ns>/legacy-voice/\`; rewrites stored \`meta.channel = \"api\"\` → \`\"rpc\"\`; removes the PR 1 dual-read shim and the dual-accept channel fallbacks. Five new migration tests.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean (on the original branches)
- [x] \`cargo test --workspace\` — 184 tests pass (on the original branches; cherry-picks are clean)
- [ ] Re-run CI after this PR opens to confirm nothing diverged in the cherry-pick

## Related

- Replaces #124 and #125 (already \"merged\" into stale parent branches, content never reached main)
- Builds on #123 (rename to \`sapphire-agent-rpc\`, dual-read shim) which IS already in main

🤖 Generated with [Claude Code](https://claude.com/claude-code)