### PR TITLE
feat(messages): tag user messages with input modality and user_id

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -544,6 +544,8 @@ impl Agent {
         let filtered = ChatMessage {
             role: msg.role.clone(),
             parts: kept,
+            input_kind: msg.input_kind.clone(),
+            user_id: msg.user_id.clone(),
         };
         if let Err(e) = self.session_store.append(session_id, &filtered) {
             warn!("Failed to persist message: {e}");
@@ -658,6 +660,8 @@ impl Agent {
                 parts: vec![ContentPart::Text(format!(
                     "[Context Summary — prior-day messages were compacted]\n\n{summary}"
                 ))],
+                input_kind: None,
+                user_id: None,
             },
             ChatMessage::assistant(
                 "Understood. I have the context from the prior day's conversation.",

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -119,6 +119,8 @@ pub async fn maybe_compress(
         parts: vec![ContentPart::Text(format!(
             "[Context Summary — earlier messages were compressed]\n\n{summary}"
         ))],
+        input_kind: None,
+        user_id: None,
     });
     compressed.push(ChatMessage::assistant(
         "Understood. I have the context from our earlier conversation.",

--- a/src/image_cache.rs
+++ b/src/image_cache.rs
@@ -165,6 +165,8 @@ pub fn hydrate_history(history: &[ChatMessage]) -> Vec<ChatMessage> {
                     other => other.clone(),
                 })
                 .collect(),
+            input_kind: msg.input_kind.clone(),
+            user_id: msg.user_id.clone(),
         })
         .collect()
 }
@@ -262,6 +264,8 @@ mod tests {
                 media_type: "image/jpeg".to_string(),
                 sha256: "abc123".to_string(),
             }],
+            input_kind: None,
+            user_id: None,
         }];
         let hydrated = hydrate_history(&history);
         match &hydrated[0].parts[0] {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -72,11 +72,39 @@ pub enum ContentPart {
     },
 }
 
+/// Input modality of a user-role message. Voice inputs reach the model
+/// via server-side STT and can carry transcription errors, so the
+/// model is told the modality via a prefix label (see
+/// `apply_input_kind_label` in `serve`). `Voice` is a unit variant on
+/// purpose: when voice-print speaker identification is later added,
+/// new variants (`KnownVoice { speaker_id, .. }` / `UnknownVoice`)
+/// will be introduced alongside this one — `Voice` remains the
+/// "identification disabled / not yet run" default and existing
+/// `{"kind":"voice"}` JSONL stays readable without migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UserInputKind {
+    Text,
+    Voice,
+}
+
 /// A message in the conversation history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
     pub parts: Vec<ContentPart>,
+    /// Modality this message was authored in. Meaningful only for
+    /// `Role::User`; `None` on assistant/tool messages and on
+    /// channel-side user messages that don't have a meaningful
+    /// modality (e.g. heartbeat-injected user lines).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_kind: Option<UserInputKind>,
+    /// Identifier of the authenticated user this message is attributed
+    /// to. Currently always `None` — populated in a future task once
+    /// API-key / channel-ID → user_id mapping lands. The corresponding
+    /// profile lives in `<workspace>/users/<namespace>/<user_id>.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
 }
 
 impl ChatMessage {
@@ -84,6 +112,21 @@ impl ChatMessage {
         Self {
             role: Role::User,
             parts: vec![ContentPart::Text(text.into())],
+            input_kind: Some(UserInputKind::Text),
+            user_id: None,
+        }
+    }
+
+    /// User message produced from a voice (STT) input. Speaker
+    /// identification is not implemented yet, so all such messages
+    /// carry `UserInputKind::Voice` — once voice-print clustering
+    /// lands, this constructor will accept a richer variant.
+    pub fn user_voice(text: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            parts: vec![ContentPart::Text(text.into())],
+            input_kind: Some(UserInputKind::Voice),
+            user_id: None,
         }
     }
 
@@ -108,6 +151,8 @@ impl ChatMessage {
         Self {
             role: Role::User,
             parts,
+            input_kind: Some(UserInputKind::Text),
+            user_id: None,
         }
     }
 
@@ -115,6 +160,8 @@ impl ChatMessage {
         Self {
             role: Role::Assistant,
             parts: vec![ContentPart::Text(text.into())],
+            input_kind: None,
+            user_id: None,
         }
     }
 
@@ -134,6 +181,8 @@ impl ChatMessage {
         Self {
             role: Role::Assistant,
             parts,
+            input_kind: None,
+            user_id: None,
         }
     }
 
@@ -168,6 +217,8 @@ impl ChatMessage {
         Self {
             role: Role::User,
             parts,
+            input_kind: None,
+            user_id: None,
         }
     }
 

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -16,7 +16,7 @@ use crate::channel::RoomInfo;
 use crate::config::Config;
 use crate::context_compression::{generate_summary, maybe_compress};
 use crate::provider::registry::ProviderRegistry;
-use crate::provider::{ChatMessage, ContentPart, Provider};
+use crate::provider::{ChatMessage, ContentPart, Provider, UserInputKind};
 use crate::session::{ConversationKey, SessionStore};
 use crate::tools::ToolSet;
 use crate::voice::VoiceProviders;
@@ -1247,7 +1247,7 @@ async fn run_voice_turn_from_text_sse(
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        ChatMessage::user(&user_text),
+        ChatMessage::user_voice(&user_text),
         req_id.clone(),
         tx.clone(),
         device_id
@@ -1471,10 +1471,18 @@ pub(crate) async fn push_voice_text_to_subscriber(
     // notifications by draining the sink in a background task).
     let (sink_tx, mut sink_rx) = mpsc::channel::<Result<Event, Infallible>>(32);
     let drain_handle = tokio::spawn(async move { while sink_rx.recv().await.is_some() {} });
+    // Heartbeat-injected user line — synthesised by the timer pipeline,
+    // not authored by a human, so no input modality applies.
+    let injected_msg = ChatMessage {
+        role: crate::provider::Role::User,
+        parts: vec![crate::provider::ContentPart::Text(user_text.clone())],
+        input_kind: None,
+        user_id: None,
+    };
     let outcome = run_llm_turn(
         Arc::clone(&state),
         session_id.clone(),
-        ChatMessage::user(&user_text),
+        injected_msg,
         Value::Null,
         sink_tx,
         Some(crate::timer::TimerOrigin::Voice {
@@ -1556,6 +1564,27 @@ pub(crate) async fn push_voice_text_to_subscriber(
 // ---------------------------------------------------------------------------
 // Turn processing (tool-calling loop)
 // ---------------------------------------------------------------------------
+
+/// Rewrite a user-role message so the model sees the input modality.
+/// Voice transcripts are prefixed with `[voice input]` (English, since
+/// the model is more reliable with English meta-tags) so the assistant
+/// can treat the body as STT output rather than typed text. Text and
+/// modality-less messages pass through unchanged.
+fn apply_input_kind_label(mut msg: ChatMessage) -> ChatMessage {
+    let prefix = match &msg.input_kind {
+        Some(UserInputKind::Voice) => "[voice input]\n",
+        _ => return msg,
+    };
+    for part in msg.parts.iter_mut() {
+        if let ContentPart::Text(s) = part {
+            *s = format!("{prefix}{s}");
+            return msg;
+        }
+    }
+    msg.parts
+        .insert(0, ContentPart::Text(prefix.trim_end().to_string()));
+    msg
+}
 
 /// Outcome of [`run_llm_turn`].
 struct LlmTurnOutcome {
@@ -1704,7 +1733,13 @@ async fn run_llm_turn(
         // `ImageRef` parts are intentionally degraded to text markers
         // so historical images aren't re-billed every turn (the cache
         // still retains the bytes for an on-demand recall tool).
-        let history_for_provider = crate::image_cache::hydrate_history(&history);
+        // After hydration, fold each user message's input modality
+        // into a textual prefix so the model knows when a body is a
+        // voice transcript (likely to contain STT errors).
+        let history_for_provider: Vec<ChatMessage> = crate::image_cache::hydrate_history(&history)
+            .into_iter()
+            .map(apply_input_kind_label)
+            .collect();
         let response = provider
             .chat(system.as_deref(), &history_for_provider, Some(&tool_specs))
             .await;
@@ -1902,5 +1937,70 @@ async fn generate_session_title(
             warn!("Title generation failed: {e:#}");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{Role, UserInputKind};
+
+    #[test]
+    fn apply_label_passes_text_through_unchanged() {
+        let msg = ChatMessage::user("hello");
+        let labeled = apply_input_kind_label(msg.clone());
+        assert_eq!(labeled.parts.len(), 1);
+        match &labeled.parts[0] {
+            ContentPart::Text(s) => assert_eq!(s, "hello"),
+            _ => panic!("expected Text part"),
+        }
+    }
+
+    #[test]
+    fn apply_label_passes_none_input_kind_through_unchanged() {
+        let msg = ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::Text("hi".to_string())],
+            input_kind: None,
+            user_id: None,
+        };
+        let labeled = apply_input_kind_label(msg);
+        match &labeled.parts[0] {
+            ContentPart::Text(s) => assert_eq!(s, "hi"),
+            _ => panic!("expected Text part"),
+        }
+    }
+
+    #[test]
+    fn apply_label_voice_prefixes_first_text_part() {
+        let msg = ChatMessage::user_voice("what's the weather");
+        let labeled = apply_input_kind_label(msg);
+        match &labeled.parts[0] {
+            ContentPart::Text(s) => {
+                assert!(s.starts_with("[voice input]\n"), "got: {s}");
+                assert!(s.ends_with("what's the weather"));
+            }
+            _ => panic!("expected Text part"),
+        }
+    }
+
+    #[test]
+    fn apply_label_voice_inserts_label_when_no_text_part_present() {
+        let msg = ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::Image {
+                media_type: "image/png".to_string(),
+                data_base64: "AAAA".to_string(),
+            }],
+            input_kind: Some(UserInputKind::Voice),
+            user_id: None,
+        };
+        let labeled = apply_input_kind_label(msg);
+        assert_eq!(labeled.parts.len(), 2);
+        match &labeled.parts[0] {
+            ContentPart::Text(s) => assert_eq!(s, "[voice input]"),
+            _ => panic!("expected inserted Text part"),
+        }
+        assert!(matches!(labeled.parts[1], ContentPart::Image { .. }));
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -16,7 +16,7 @@
 //! AI retrieval. `closed_at` acts as an append-only archive marker; presence
 //! of this line means the session is no longer active.
 
-use crate::provider::{ChatMessage, ContentPart, Role};
+use crate::provider::{ChatMessage, ContentPart, Role, UserInputKind};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone, Timelike, Utc};
 use sapphire_workspace::WorkspaceState;
@@ -86,6 +86,17 @@ pub struct StoredMessage {
     pub timestamp: DateTime<Utc>,
     pub role: Role,
     pub parts: Vec<ContentPart>,
+    /// Input modality for user-role messages. `None` for legacy
+    /// pre-existing JSONL (read via `serde(default)`), for assistant
+    /// replies, and for synthetic user lines that don't have a
+    /// meaningful modality (e.g. heartbeat-injected pushes).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub input_kind: Option<UserInputKind>,
+    /// Authenticated user id, when the inbound transport has mapped
+    /// the message to a known identity. Always `None` today;
+    /// reserved for API-key / channel-ID → user_id mapping work.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub user_id: Option<String>,
     /// Provenance for messages written through MCP `write_report`.
     /// Absent on normal chat messages and on assistant-side replies.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -117,6 +128,8 @@ impl StoredMessage {
             timestamp: Utc::now(),
             role: msg.role.clone(),
             parts: msg.parts.clone(),
+            input_kind: msg.input_kind.clone(),
+            user_id: msg.user_id.clone(),
             report_meta: None,
         }
     }
@@ -125,6 +138,8 @@ impl StoredMessage {
         ChatMessage {
             role: self.role,
             parts: self.parts,
+            input_kind: self.input_kind,
+            user_id: self.user_id,
         }
     }
 }
@@ -642,6 +657,8 @@ impl SessionStore {
             timestamp: Utc::now(),
             role: Role::User,
             parts: vec![ContentPart::Text(rendered_text.to_string())],
+            input_kind: None,
+            user_id: None,
             report_meta: Some(meta),
         };
         let line = serde_json::to_string(&stored)?;
@@ -964,6 +981,8 @@ pub(crate) fn scrub_images_for_storage(msg: &ChatMessage) -> Option<ChatMessage>
     Some(ChatMessage {
         role: msg.role.clone(),
         parts,
+        input_kind: msg.input_kind.clone(),
+        user_id: msg.user_id.clone(),
     })
 }
 
@@ -1195,6 +1214,8 @@ mod tests {
                 media_type: "image/png".to_string(),
                 data_base64: "@@@not-base64@@@".to_string(),
             }],
+            input_kind: Some(UserInputKind::Text),
+            user_id: None,
         };
         let scrubbed = scrub_images_for_storage(&msg).expect("scrub should rewrite");
         let has_marker = scrubbed
@@ -1212,6 +1233,8 @@ mod tests {
                 media_type: "image/jpeg".to_string(),
                 sha256: "abc123".to_string(),
             }],
+            input_kind: Some(UserInputKind::Text),
+            user_id: None,
         };
         // ImageRef carries no raw bytes — nothing to scrub, so the
         // helper returns None and append serializes the variant as-is.
@@ -1219,6 +1242,97 @@ mod tests {
             scrub_images_for_storage(&msg).is_none(),
             "scrub should leave ImageRef-only messages untouched"
         );
+    }
+
+    // ── input_kind / user_id round-trip and backward compat ─────────────
+
+    #[test]
+    fn stored_message_without_input_kind_or_user_id_deserializes_as_none() {
+        // Legacy JSONL written before these fields existed must still
+        // load: no `input_kind`, no `user_id`.
+        let legacy =
+            r#"{"timestamp":"2026-04-08T11:30:22.372570890Z","role":"user","parts":[{"Text":"hello"}]}"#;
+        let msg: StoredMessage = serde_json::from_str(legacy).expect("legacy JSONL parses");
+        assert!(msg.input_kind.is_none());
+        assert!(msg.user_id.is_none());
+    }
+
+    #[test]
+    fn stored_message_omits_none_fields_on_serialize() {
+        let msg = StoredMessage {
+            timestamp: Utc::now(),
+            role: Role::Assistant,
+            parts: vec![ContentPart::Text("hi".to_string())],
+            input_kind: None,
+            user_id: None,
+            report_meta: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            !json.contains("input_kind"),
+            "None input_kind must be omitted, got: {json}"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "None user_id must be omitted, got: {json}"
+        );
+        assert!(
+            !json.contains("report_meta"),
+            "None report_meta must be omitted, got: {json}"
+        );
+    }
+
+    #[test]
+    fn stored_message_text_input_kind_round_trip() {
+        let original = StoredMessage {
+            timestamp: Utc::now(),
+            role: Role::User,
+            parts: vec![ContentPart::Text("hi".to_string())],
+            input_kind: Some(UserInputKind::Text),
+            user_id: Some("owner".to_string()),
+            report_meta: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert!(json.contains(r#""input_kind":{"kind":"text"}"#));
+        assert!(json.contains(r#""user_id":"owner""#));
+        let parsed: StoredMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.input_kind, Some(UserInputKind::Text));
+        assert_eq!(parsed.user_id.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn stored_message_voice_input_kind_round_trip() {
+        let original = StoredMessage {
+            timestamp: Utc::now(),
+            role: Role::User,
+            parts: vec![ContentPart::Text("hello there".to_string())],
+            input_kind: Some(UserInputKind::Voice),
+            user_id: None,
+            report_meta: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert!(
+            json.contains(r#""input_kind":{"kind":"voice"}"#),
+            "missing voice tag: {json}"
+        );
+        let parsed: StoredMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.input_kind, Some(UserInputKind::Voice));
+    }
+
+    #[test]
+    fn from_chat_and_into_chat_preserve_input_kind_and_user_id() {
+        let chat = ChatMessage {
+            role: Role::User,
+            parts: vec![ContentPart::Text("hi".to_string())],
+            input_kind: Some(UserInputKind::Voice),
+            user_id: Some("alice".to_string()),
+        };
+        let stored = StoredMessage::from_chat(&chat);
+        assert_eq!(stored.input_kind, Some(UserInputKind::Voice));
+        assert_eq!(stored.user_id.as_deref(), Some("alice"));
+        let round = stored.into_chat_message();
+        assert_eq!(round.input_kind, Some(UserInputKind::Voice));
+        assert_eq!(round.user_id.as_deref(), Some("alice"));
     }
 
     // ── device-default session routing (#122) ────────────────────────────


### PR DESCRIPTION
## Summary
- Add `input_kind: Option<UserInputKind>` (Text/Voice) and `user_id: Option<String>` to `StoredMessage` / `ChatMessage`, so the unified RPC session (`device-default` JSONL) can distinguish voice transcripts from typed text and reserve room for authenticated identity.
- Wire RPC paths: text RPC writes `Text`, voice pipeline (`run_voice_turn_from_text_sse`) writes `Voice`, heartbeat-injected user lines stay `None`. Channel sessions are untouched.
- Right before the provider call, fold `Voice` into a `[voice input]\n` English prefix on the user message so the model knows the body may contain STT errors. All three provider implementations are unchanged.

Both new fields use `serde(default, skip_serializing_if)` — legacy JSONL parses cleanly as `None` and channel-side JSONL bytes are unchanged. Voice-print speaker variants (`KnownVoice`/`UnknownVoice`) are deferred; they can be added later as new enum variants without breaking existing `{\"kind\":\"voice\"}` rows. Likewise `user_id` is a placeholder until API-key / channel-ID → user mapping lands; the per-user profile is expected at `<workspace>/users/<namespace>/<user_id>.md`.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test --bin sapphire-agent` — 164/164 unit tests pass, including:
  - Round-trip serialization for `Text` / `Voice`
  - Legacy JSONL (no `input_kind` / `user_id`) deserializes to `None`
  - `None`-valued fields are omitted on serialize (channel JSONL stays byte-identical)
  - `from_chat` ⇄ `into_chat_message` preserves both new fields
  - `apply_input_kind_label` prefixes `Voice` messages and passes `Text`/`None` through unchanged
- [ ] Smoke-test with a real voice turn against `~/.saph1na_workspace` (verify `"input_kind":{"kind":"voice"}` lands in `sessions/<ns>/device-default/*.jsonl`) — owner to run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)