### PR TITLE
chore(release): introduce release-plz for sapphire-agent + sapphire-agent-rpc

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,59 @@
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+
+# Avoid two release-plz jobs racing for the same branch.
+concurrency:
+  group: release-plz-${{ github.ref }}
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call-cli)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call-cli)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,15 @@
-name: Release
+name: Release binaries
 
+# Triggered by the per-package tag release-plz pushes for sapphire-agent.
+# release-plz creates the GitHub release; this workflow uploads the
+# cross-platform sapphire-agent binaries as assets onto that release.
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  push:
+    tags:
+      - 'sapphire-agent-v*'
 
 jobs:
-  prepare:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Create tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
-
   build:
-    needs: prepare
     continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       fail-fast: false
@@ -56,58 +32,23 @@ jobs:
             asset_name: sapphire-agent-windows-x86_64.exe
             continue-on-error: true
     runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release
-
-      - name: Rename binary
-        run: cp target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.asset_name }}
-          path: ${{ matrix.asset_name }}
-
-  release:
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.prepare.outputs.version }}
-          generate_release_notes: true
-          files: artifacts/*
-
-  publish:
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install ALSA dev libs (cpal build-time dep for sapphire-call)
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
-      - name: Publish workspace crates to crates.io
-        run: cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: cargo build --release --package sapphire-agent
+
+      - name: Rename binary
+        shell: bash
+        run: cp target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: ${{ matrix.asset_name }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,13 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 
 [workspace.package]
-version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-agent"
 
 [package]
 name = "sapphire-agent"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 description = "A personal AI assistant agent with Matrix/Discord channels, Anthropic backend, and a sapphire-workspace memory layer"
 license.workspace = true

--- a/crates/sapphire-agent-rpc/CHANGELOG.md
+++ b/crates/sapphire-agent-rpc/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to `sapphire-agent-rpc` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Historical changes prior to `0.6.1` (when this crate shared the workspace
+version with `sapphire-agent`) are recorded in the root `CHANGELOG.md`.
+
+## [Unreleased]

--- a/crates/sapphire-agent-rpc/Cargo.toml
+++ b/crates/sapphire-agent-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-agent-rpc"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 description = "Client library and shared types for sapphire-agent's RPC surface"
 license.workspace = true

--- a/crates/sapphire-call-cli/Cargo.toml
+++ b/crates/sapphire-call-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call-cli"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 description = "Standalone CLI / voice-satellite client for sapphire-agent"
 license.workspace = true

--- a/crates/sapphire-call-core/Cargo.toml
+++ b/crates/sapphire-call-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call-core"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 description = "Shared config + identity helpers for sapphire-call CLI / desktop clients"
 license.workspace = true

--- a/crates/sapphire-call-desktop/Cargo.toml
+++ b/crates/sapphire-call-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call-desktop"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 description = "Desktop GUI client for sapphire-agent (bevy + egui)"
 license.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,44 @@
+[workspace]
+# Per-package tags / GitHub releases. Existing single-version tags like
+# `v0.6.1` stay as historical anchors; new tags use the per-package form.
+git_tag_name = "{{ package }}-v{{ version }}"
+git_release_name = "{{ package }}-v{{ version }}"
+
+# One PR per release cycle that bundles every package being bumped.
+pr_name = "chore(release): {% for release in releases %}{{ release.package }} {{ release.next_version }}{% if not loop.last %}, {% endif %}{% endfor %}"
+
+[[package]]
+name = "sapphire-agent"
+changelog_path = "./CHANGELOG.md"
+
+[[package]]
+name = "sapphire-agent-rpc"
+changelog_path = "./crates/sapphire-agent-rpc/CHANGELOG.md"
+
+# sapphire-call-* crates are intentionally excluded from release-plz for now.
+# Versions are managed manually until we explicitly opt them in.
+# release-plz will still keep their `version = "x.y.z"` path-dep constraints
+# on sapphire-agent-rpc in sync when rpc gets bumped.
+[[package]]
+name = "sapphire-call-core"
+release = false
+publish = false
+changelog_update = false
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "sapphire-call-cli"
+release = false
+publish = false
+changelog_update = false
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "sapphire-call-desktop"
+release = false
+publish = false
+changelog_update = false
+git_release_enable = false
+git_tag_enable = false


### PR DESCRIPTION
## Summary
- Adopts [release-plz](https://release-plz.dev/) for release automation, scoped to `sapphire-agent` and `sapphire-agent-rpc` only. `sapphire-call-{core,cli,desktop}` are opted out (`release/publish/changelog_update/git_release_enable/git_tag_enable` all false) until their cadence is settled.
- Splits `workspace.package.version` so every crate carries its own explicit version. `sapphire-call-desktop` (GUI) already had `publish = false`; per-crate versions let the GUI iterate independently of the server crates as agreed.
- Replaces the manual `release/<version>` branch flow. release-plz now owns the changelog, version bump PR, tag (`{{ package }}-v{{ version }}`), GitHub release, and crates.io publish.

## Layout
- `release-plz.toml` — workspace + per-package config
- `.github/workflows/release-plz.yml` — `release-pr` + `release` jobs on push to `main`
- `.github/workflows/release.yml` — rewritten to trigger on `sapphire-agent-v*` tags. Builds `--package sapphire-agent` only (skips sherpa-onnx / bevy in the call crates) and uploads cross-platform assets onto the release release-plz creates
- `CHANGELOG.md` (root) — kept as `sapphire-agent`'s changelog
- `crates/sapphire-agent-rpc/CHANGELOG.md` — new, with a note that pre-0.6.1 history lives in the root file

## Notes
- `sapphire-call-core` / `-cli` / `-desktop` keep `version = "0.6.1"` and depend on `sapphire-agent-rpc` via path + version constraint. release-plz updates those constraints in the workspace automatically when rpc bumps, even though the call crates aren't release-plz targets themselves.
- Existing `v0.6.1` tags remain as historical anchors; future tags use the per-package form.
- `CARGO_REGISTRY_TOKEN` is already configured (was used by the old `publish` job).

## Test plan
- [ ] Merge this and confirm release-plz opens a release PR for the next eligible bump
- [ ] Confirm the PR's changelog/version diff looks reasonable before merging
- [ ] After release-plz publishes, confirm the binary build workflow fires on the `sapphire-agent-v*` tag and uploads assets to the GH release

🤖 Generated with [Claude Code](https://claude.com/claude-code)