### PR TITLE
fix(release-plz): replace pr_name template with static title

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,8 +4,11 @@
 git_tag_name = "{{ package }}-v{{ version }}"
 git_release_name = "{{ package }}-v{{ version }}"
 
-# One PR per release cycle that bundles every package being bumped.
-pr_name = "chore(release): {% for release in releases %}{{ release.package }} {{ release.next_version }}{% if not loop.last %}, {% endif %}{% endfor %}"
+# Static PR title. release-plz's `pr_name` context doesn't expose a per-package
+# list (the `releases` variable is only available in `pr_body`), so dynamic
+# titles for multi-package bumps aren't possible. The PR body lists the bumps,
+# and per-package tags / GH releases use `{{ package }}-v{{ version }}` above.
+pr_name = "chore(release): version bump"
 
 [[package]]
 name = "sapphire-agent"


### PR DESCRIPTION
## Summary
- The `pr_name` introduced in #134 referenced `releases` inside a Tera `{% for %}` loop, but `pr_name`'s context doesn't expose `releases` — that variable is only available in `pr_body`. The release-plz workflow has been failing to render the title (`failed to render pr_name`), so the release PR for `sapphire-agent` 0.6.2 was never opened.
- Falls back to a static `chore(release): version bump`. The per-package bumps still appear in the PR body (release-plz populates it from `releases`) and in the `{{ package }}-v{{ version }}` tag / GH release names.

## Notes
- The release job from #134 still ran successfully and published `sapphire-agent-rpc` 0.6.1 to crates.io as a first-time release of the renamed crate. Only the release-PR side was broken.
- Future addition of sapphire-call-* to release-plz won't need a title change — the body will list whatever crates bump.

## Test plan
- [ ] Merge and confirm the next push-to-main fires release-plz cleanly
- [ ] Confirm the release PR opens with title "chore(release): version bump" and a body listing the bumped packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)