### PR TITLE
chore(release): add sapphire-call-core and -cli to release-plz at 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9986,7 +9986,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call-cli"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bzip2 0.6.1",
@@ -10011,7 +10011,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-call-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "directories",

--- a/crates/sapphire-call-cli/CHANGELOG.md
+++ b/crates/sapphire-call-cli/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to `sapphire-call-cli` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This crate is the continuation of the former `sapphire-call` crate
+(published as `sapphire-call` on crates.io up through `0.6.1`). The
+binary it ships is still named `sapphire-call`; only the crate name
+changed. Historical entries describing the voice-satellite pipeline,
+wake / VAD / TTS plumbing, and earlier feature work live in the root
+`CHANGELOG.md`.
+
+## [Unreleased]
+
+## [0.7.0] - 2026-05-23
+
+First release under the new crate name. The version is aligned with
+`sapphire-agent` 0.7.0 so the workspace versions are easy to read at a
+glance; future bumps will track this crate's own change cadence.
+
+### Changed
+
+- **Renamed from `sapphire-call` to `sapphire-call-cli`** as part of the
+  workspace split that introduced `sapphire-call-desktop`. The binary
+  produced by `cargo install sapphire-call-cli` is still
+  `sapphire-call`, so existing scripts and `sapphire-call voice ...`
+  invocations are unaffected. Users installing from crates.io should
+  switch from `cargo install sapphire-call` to
+  `cargo install sapphire-call-cli`.
+- **Shared config + device-id helpers extracted to `sapphire-call-core`.**
+  The CLI now depends on `sapphire-call-core` for `ServerConfig` and
+  per-installation `device_id` resolution, so adding new client targets
+  (e.g. the desktop GUI) doesn't fork those types. The on-disk config
+  format and path (`~/.config/sapphire-call/config.toml`) are
+  unchanged.

--- a/crates/sapphire-call-cli/Cargo.toml
+++ b/crates/sapphire-call-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call-cli"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 description = "Standalone CLI / voice-satellite client for sapphire-agent"
 license.workspace = true
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 sapphire-agent-rpc = { path = "../sapphire-agent-rpc", version = "0.7.0" }
-sapphire-call-core = { path = "../sapphire-call-core", version = "0.6.1" }
+sapphire-call-core = { path = "../sapphire-call-core", version = "0.7.0" }
 
 # Async runtime — voice subcommand needs sync, time, and rt features.
 tokio = { workspace = true, features = ["sync", "time", "rt-multi-thread", "macros", "signal"] }

--- a/crates/sapphire-call-cli/src/main.rs
+++ b/crates/sapphire-call-cli/src/main.rs
@@ -121,17 +121,13 @@ async fn main() -> Result<()> {
         .or(file_cfg.server.url)
         .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string());
     let session = cli.session.clone().or(file_cfg.server.session);
-    let token = cli
-        .token
-        .clone()
-        .or(file_cfg.server.token)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "missing bearer token — set [server].token in the config, pass --token <TOKEN>, \
+    let token = cli.token.clone().or(file_cfg.server.token).ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing bearer token — set [server].token in the config, pass --token <TOKEN>, \
                  or export SAPPHIRE_AGENT_TOKEN; the agent uses it to look up your room_profile \
                  (api_keys on [room_profile.<n>])"
-            )
-        })?;
+        )
+    })?;
     let device = file_cfg.device.to_api();
 
     if let Some(Command::Voice {

--- a/crates/sapphire-call-cli/src/voice/mod.rs
+++ b/crates/sapphire-call-cli/src/voice/mod.rs
@@ -602,9 +602,8 @@ async fn listen_loop(mut ctx: ListenCtx) -> Result<()> {
                     // segment has time to close (min_silence_duration)
                     // and ship to STT normally.
                     if ctx.vad.detected() {
-                        ctx.follow_up_until = Some(
-                            now + Duration::from_secs(SPEECH_IN_PROGRESS_GRACE_SECS),
-                        );
+                        ctx.follow_up_until =
+                            Some(now + Duration::from_secs(SPEECH_IN_PROGRESS_GRACE_SECS));
                         continue;
                     }
                     expire_follow_up(&mut ctx, &mut window_buf).await;
@@ -1651,8 +1650,7 @@ fn enqueue_beep(queue: &Arc<std::sync::Mutex<VecDeque<i16>>>, freq_hz: f32, outp
 /// off / not heard" from "I shipped your utterance".
 fn generate_timeout_beep() -> Vec<i16> {
     let beep = generate_beep(BEEP_TIMEOUT_HZ, BEEP_TIMEOUT_DURATION_MS);
-    let gap_samples =
-        (PIPELINE_SAMPLE_RATE as f32 * BEEP_TIMEOUT_GAP_MS as f32 / 1000.0) as usize;
+    let gap_samples = (PIPELINE_SAMPLE_RATE as f32 * BEEP_TIMEOUT_GAP_MS as f32 / 1000.0) as usize;
     let mut out = Vec::with_capacity(beep.len() * 2 + gap_samples);
     out.extend_from_slice(&beep);
     out.extend(std::iter::repeat_n(0i16, gap_samples));
@@ -1775,8 +1773,8 @@ mod tests {
         // beeps separated by a silence gap. The total length must
         // match 2 × beep + gap, and the gap region must be silent.
         let pcm = generate_timeout_beep();
-        let beep_samples = (PIPELINE_SAMPLE_RATE as usize) * BEEP_TIMEOUT_DURATION_MS as usize
-            / 1000;
+        let beep_samples =
+            (PIPELINE_SAMPLE_RATE as usize) * BEEP_TIMEOUT_DURATION_MS as usize / 1000;
         let gap_samples =
             (PIPELINE_SAMPLE_RATE as f32 * BEEP_TIMEOUT_GAP_MS as f32 / 1000.0) as usize;
         assert_eq!(pcm.len(), beep_samples * 2 + gap_samples);

--- a/crates/sapphire-call-core/CHANGELOG.md
+++ b/crates/sapphire-call-core/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to `sapphire-call-core` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.0] - 2026-05-23
+
+First release of `sapphire-call-core` as a standalone crate. Extracted
+from the former `sapphire-call` crate so the CLI (`sapphire-call-cli`)
+and the desktop GUI (`sapphire-call-desktop`) can share the same source
+of truth for endpoint configuration and per-installation identity.
+
+The version is aligned with `sapphire-agent` / `sapphire-agent-rpc`
+0.7.0 to make the workspace easy to read at a glance; future patch and
+minor bumps will track this crate's own change cadence.
+
+### Added
+
+- **`ServerConfig`** — TOML schema covering the agent endpoint URL and
+  per-`room_profile` bearer-token map. Loaded from
+  `~/.config/sapphire-call/config.toml` by the CLI and from
+  `~/.config/sapphire-call-desktop/config.toml` by the desktop client;
+  both reuse the same struct.
+- **`device_id` resolution** — UUID v7 generated on first run and
+  persisted alongside the config, so the agent's voice / device-default
+  session routing has a stable identifier for each installation.
+- **Path expansion + XDG dir helpers** — `~/` and platform-appropriate
+  config / data / cache dirs are resolved via `shellexpand` +
+  `directories`, surfaced as small helper functions the CLI and desktop
+  binaries both call.

--- a/crates/sapphire-call-core/Cargo.toml
+++ b/crates/sapphire-call-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-call-core"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 description = "Shared config + identity helpers for sapphire-call CLI / desktop clients"
 license.workspace = true

--- a/crates/sapphire-call-desktop/Cargo.toml
+++ b/crates/sapphire-call-desktop/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 sapphire-agent-rpc = { path = "../sapphire-agent-rpc", version = "0.7.0" }
-sapphire-call-core = { path = "../sapphire-call-core", version = "0.6.1" }
+sapphire-call-core = { path = "../sapphire-call-core", version = "0.7.0" }
 
 # Game engine — needed up front for the eventual 3D character work
 # (desktop-mate-style avatar). For the chat-only first cut we use only

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,26 +18,18 @@ changelog_path = "./CHANGELOG.md"
 name = "sapphire-agent-rpc"
 changelog_path = "./crates/sapphire-agent-rpc/CHANGELOG.md"
 
-# sapphire-call-* crates are intentionally excluded from release-plz for now.
-# Versions are managed manually until we explicitly opt them in.
-# release-plz will still keep their `version = "x.y.z"` path-dep constraints
-# on sapphire-agent-rpc in sync when rpc gets bumped.
 [[package]]
 name = "sapphire-call-core"
-release = false
-publish = false
-changelog_update = false
-git_release_enable = false
-git_tag_enable = false
+changelog_path = "./crates/sapphire-call-core/CHANGELOG.md"
 
 [[package]]
 name = "sapphire-call-cli"
-release = false
-publish = false
-changelog_update = false
-git_release_enable = false
-git_tag_enable = false
+changelog_path = "./crates/sapphire-call-cli/CHANGELOG.md"
 
+# sapphire-call-desktop stays opted out: it carries `publish = false` in its
+# Cargo.toml (bevy + bundled font, not intended for crates.io) and iterates
+# on its own cadence. release-plz still keeps its path-dep version
+# constraints on sapphire-agent-rpc / sapphire-call-core in sync.
 [[package]]
 name = "sapphire-call-desktop"
 release = false


### PR DESCRIPTION
## Summary
- Opts `sapphire-call-core` and `sapphire-call-cli` into release-plz; merging this kicks off their first crates.io publish + per-package tags (`sapphire-call-core-v0.7.0` / `sapphire-call-cli-v0.7.0`).
- Bumps both crates to 0.7.0 so workspace versions stay legible at a glance. `sapphire-call-core` is a new crate name (extracted from the former `sapphire-call`); `sapphire-call-cli` is the continuation of `sapphire-call` with the crate renamed (binary name `sapphire-call` unchanged).
- `sapphire-call-desktop` stays opted out — its `publish = false` is intentional (bevy + bundled font aren't appropriate for crates.io, and the GUI iterates on its own cadence).
- Path-dep `version = "..."` constraints in `-cli` and `-desktop` bumped to track the new `-core` version.
- nightly rustfmt + clippy `-D warnings` are clean on both crates.

## Notes for downstream users
- `cargo install sapphire-call` users should switch to `cargo install sapphire-call-cli` after this release. The produced binary is still `sapphire-call`.
- The previous `sapphire-call` crate on crates.io (last version 0.6.1) is not yanked, so existing lockfiles remain usable. New installs should prefer `sapphire-call-cli`.

## Test plan
- [ ] Merge and confirm release-plz publishes `sapphire-call-core@0.7.0` and `sapphire-call-cli@0.7.0`
- [ ] Confirm the per-package tags + GH releases appear (`sapphire-call-core-v0.7.0`, `sapphire-call-cli-v0.7.0`)
- [ ] Confirm `cargo install sapphire-call-cli` produces a working `sapphire-call` binary from crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)