### PR TITLE
fix(serve): slice title snippets by chars, not bytes

### DIFF
--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2056,8 +2056,8 @@ async fn generate_session_title(
     user_message: &str,
     assistant_response: &str,
 ) -> Option<String> {
-    let user_snippet = &user_message[..user_message.len().min(300)];
-    let asst_snippet = &assistant_response[..assistant_response.len().min(300)];
+    let user_snippet: String = user_message.chars().take(300).collect();
+    let asst_snippet: String = assistant_response.chars().take(300).collect();
     let prompt = format!(
         "Generate a concise title (max 60 characters) for this conversation. \
         Respond with only the title text — no quotes, no punctuation at the end.\n\n\


### PR DESCRIPTION
## Summary

- `generate_session_title` ([src/serve/mod.rs:2059-2060](https://github.com/fluo10/sapphire-agent/blob/main/src/serve/mod.rs#L2059-L2060)) was byte-slicing `user_message` / `assistant_response` with `&s[..s.len().min(300)]`, which panics when the 300-byte boundary lands mid-character (UTF-8 multibyte, e.g. Japanese 3-byte chars).
- Replace with `chars().take(300).collect::<String>()` so the truncation always lands on a char boundary. Matches the existing 60-char trimming pattern just below it.

## Repro (observed)

```
thread 'tokio-rt-worker' panicked at src/serve/mod.rs:2063:43:
byte index 300 is not a char boundary; it is inside 'こ' (bytes 298..301)
```

Triggered on a Japanese first-turn response long enough for the assistant snippet to cross 300 bytes.

## Impact

The title-generation task is `tokio::spawn`ed and runs after the final chat result is sent, so the panic doesn't affect the user-visible reply or TTS streaming — it just kills the title task (no title stored). The fix removes the spurious worker-thread panic in the logs.

## Test plan

- [x] `cargo check -p sapphire-agent` clean
- [ ] Manual: trigger a first turn in Japanese long enough to exceed 300 bytes and confirm the title is stored without a panic in journalctl

🤖 Generated with [Claude Code](https://claude.com/claude-code)