### PR TITLE
fix(release-plz): opt sapphire-call-desktop back in with release = true

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,7 +32,13 @@ changelog_path = "./crates/sapphire-call-cli/CHANGELOG.md"
 # the `sapphire-call-desktop-v*` tag + GH release; the
 # `.github/workflows/release-desktop.yml` workflow builds the binaries
 # for that tag and attaches them as release assets.
+#
+# `release = true` is load-bearing: release-plz's default behaviour is
+# to skip any crate whose Cargo.toml has `publish = false`, even if it
+# appears in release-plz.toml. Without this line release-plz silently
+# excludes the package from its scan and never tags new versions.
 [[package]]
 name = "sapphire-call-desktop"
 changelog_path = "./crates/sapphire-call-desktop/CHANGELOG.md"
 publish = false
+release = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,32 @@ pr_name = "chore(release): version bump"
 [[package]]
 name = "sapphire-agent"
 changelog_path = "./CHANGELOG.md"
+# Filter which commits count toward an agent release.
+#
+# `sapphire-agent`'s Cargo.toml lives at the workspace root, so
+# release-plz attributes every root-level file change (Cargo.lock,
+# release-plz.toml, README.md, etc.) to this package — including
+# changes that were really driven by a sibling crate. Without this
+# filter, every desktop or CLI commit that bumps Cargo.lock at the
+# root proposes a sapphire-agent bump too (see the closed
+# misattribution PR #143).
+#
+# Allow:
+#  - unscoped conventional commits (`feat:`, `fix:`, ...)
+#  - agent-internal sub-area scopes (`feat(messages):`, `fix(voice):`)
+#  - workspace-wide infra scopes that legitimately affect agent
+#    builds (`chore(deps):`, `feat(workspace):`)
+#
+# Reject:
+#  - sibling-crate scopes (`feat(desktop):`, `refactor(cli):`,
+#    `fix(rpc):`, ...) — those bump their own crate, not agent
+#  - pure cosmetic/release-infra scopes (`chore(release):`,
+#    `style(fmt):`, `chore(ci):`) — no semver impact
+#
+# Extend the alternation list when introducing new agent-internal
+# sub-area scopes. Rust regex doesn't support negative lookahead, so
+# we maintain an allowlist rather than a blocklist.
+release_commits = '^[a-z]+(\((agent|channel|discord|matrix|features|image-cache|mcp|memory|messages|sessions|timer|heartbeat|voice|serve|chat|search|fts|api|tools|workspace|deps)\))?:'
 
 [[package]]
 name = "sapphire-agent-rpc"


### PR DESCRIPTION
## Summary

Two related release-plz fixes:

### 1. Opt sapphire-call-desktop back in for release-plz tracking
release-plz silently excludes any crate with `publish = false` in its Cargo.toml. The previous config (just `publish = false` in release-plz.toml, no `release = true`) relied on the incorrect assumption that omitting `release = false` would re-include the package — it didn't.

This caused the desktop crate's v0.1.0 push to land on main without release-plz seeing the package at all. v0.1.0 has been tagged + released manually as a one-off ([release](https://github.com/fluo10/sapphire-agent/releases/tag/sapphire-call-desktop-v0.1.0)); from this PR onwards future bumps go through release-plz like the other crates.

### 2. Scope-filter sapphire-agent's release_commits
`sapphire-agent`'s `[package]` block lives at the workspace root, so release-plz attributes every Cargo.lock / release-plz.toml / README.md change to it — including changes that were really driven by a sibling crate. The closed [#143](https://github.com/fluo10/sapphire-agent/pull/143) was the visible symptom: a desktop-only feature bumped sapphire-agent from 0.7.1 to 0.7.2 purely because the commit happened to touch Cargo.lock at the root.

Added a `release_commits` allowlist regex so agent only releases on:
- unscoped conventional commits (`feat:`, `fix:`, ...)
- agent-internal sub-area scopes (`feat(messages):`, `fix(voice):`, ...)
- workspace-wide infra scopes that legitimately affect agent (`chore(deps):`, ...)

Excluded:
- sibling-crate scopes (`feat(desktop):`, `refactor(cli):`, `fix(rpc):`)
- pure release/cosmetic scopes (`chore(release):`, `style(fmt):`, `chore(ci):`)

Rust regex doesn't support negative lookahead, so the filter is an allowlist (extend the alternation list when a new agent-internal scope appears). Verified against the last 100 commits of history.

## Test plan
- [ ] Merge this PR
- [ ] Watch release-plz on the next push to main — `sapphire-call-desktop` should now appear in its package list, and a desktop-only commit should no longer propose a sapphire-agent bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)