### PR TITLE
fix(release-plz): revert non-existent release_commits field

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,32 +13,6 @@ pr_name = "chore(release): version bump"
 [[package]]
 name = "sapphire-agent"
 changelog_path = "./CHANGELOG.md"
-# Filter which commits count toward an agent release.
-#
-# `sapphire-agent`'s Cargo.toml lives at the workspace root, so
-# release-plz attributes every root-level file change (Cargo.lock,
-# release-plz.toml, README.md, etc.) to this package — including
-# changes that were really driven by a sibling crate. Without this
-# filter, every desktop or CLI commit that bumps Cargo.lock at the
-# root proposes a sapphire-agent bump too (see the closed
-# misattribution PR #143).
-#
-# Allow:
-#  - unscoped conventional commits (`feat:`, `fix:`, ...)
-#  - agent-internal sub-area scopes (`feat(messages):`, `fix(voice):`)
-#  - workspace-wide infra scopes that legitimately affect agent
-#    builds (`chore(deps):`, `feat(workspace):`)
-#
-# Reject:
-#  - sibling-crate scopes (`feat(desktop):`, `refactor(cli):`,
-#    `fix(rpc):`, ...) — those bump their own crate, not agent
-#  - pure cosmetic/release-infra scopes (`chore(release):`,
-#    `style(fmt):`, `chore(ci):`) — no semver impact
-#
-# Extend the alternation list when introducing new agent-internal
-# sub-area scopes. Rust regex doesn't support negative lookahead, so
-# we maintain an allowlist rather than a blocklist.
-release_commits = '^[a-z]+(\((agent|channel|discord|matrix|features|image-cache|mcp|memory|messages|sessions|timer|heartbeat|voice|serve|chat|search|fts|api|tools|workspace|deps)\))?:'
 
 [[package]]
 name = "sapphire-agent-rpc"


### PR DESCRIPTION
## Summary

PR #144 added a `release_commits` regex to sapphire-agent's release-plz config, but that field doesn't exist in release-plz's schema. After merging, the release-plz workflow on main fails with:

\`\`\`
TOML parse error at line 13, column 1
unknown field \`release_commits\`
\`\`\`

This PR removes just the regex. The other half of #144 (`release = true` / `publish = false` for sapphire-call-desktop) is correct and stays — that's what got desktop opted back into release-plz tracking.

## Follow-up
The original Cargo.lock-attribution issue is still open. The correct filter mechanism in release-plz is likely git-cliff's `commit_parsers` block via the `changelog_config` path, or moving sapphire-agent into its own subdirectory. Will investigate before retrying.

## Test plan
- [ ] Merge ASAP to unblock release-plz on main
- [ ] After merge: release-plz workflow on main runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)