### PR TITLE
fix(release-plz): filter sibling-scope commits from changelog + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# Repository conventions for AI assistants
+
+Loaded by Claude Code at session start. Keep it short and operational; deep design notes belong in `docs/` or per-crate READMEs.
+
+## Conventional commit scopes
+
+This workspace ships five crates and uses **conventional-commit scopes** to route changelog entries (and only changelog entries — see "Misattribution" below).
+
+| Scope | Targets |
+|---|---|
+| `(desktop)` | `crates/sapphire-call-desktop/` (bevy GUI client) |
+| `(cli)` or `(call)` | `crates/sapphire-call-cli/` (voice satellite binary) |
+| `(rpc)` | `crates/sapphire-agent-rpc/` (RPC client library) |
+| `(core)` | `crates/sapphire-call-core/` (shared config + device_id) |
+| unscoped, or `(agent)` / `(messages)` / `(voice)` / `(serve)` / `(channel)` / `(matrix)` / `(discord)` / `(sessions)` / `(chat)` / `(timer)` / `(heartbeat)` / `(memory)` / `(image-cache)` / `(api)` / `(tools)` / `(search)` / `(fts)` / `(mcp)` / `(features)` / `(workspace)` / `(deps)` | the agent binary itself (top-level crate) |
+| `(release)`, `(release-plz)`, `(fmt)`, `(ci)`, `(test)` | infrastructure — workspace-wide, no semver impact intended |
+
+Use the scope that names the crate or sub-area you're changing. The release-plz changelog filter (`cliff.toml`) keys off this.
+
+## Misattribution: agent gets false-positive release PRs
+
+`sapphire-agent`'s package manifest lives at the workspace root (`./Cargo.toml`), so **release-plz attributes any workspace-root file change to it** — including `Cargo.lock`, `release-plz.toml`, `README.md`. Any sibling-crate commit that touches `Cargo.lock` (which is almost all of them, since deps update) therefore proposes a `sapphire-agent` bump too.
+
+This was investigated and confirmed empirically (see closed [#143](https://github.com/fluo10/sapphire-agent/pull/143), [#144](https://github.com/fluo10/sapphire-agent/pull/144)). release-plz's release-trigger logic is purely path-based; no config (regex filter, git-cliff `skip = true`, etc.) suppresses it. The only structural fix is moving `sapphire-agent` to `crates/sapphire-agent/`, which we explicitly chose not to do — the main agent crate stays at the workspace root.
+
+**Operational rule**: when release-plz proposes a `sapphire-agent` bump whose changelog body is empty or only contains entries unrelated to agent code, treat it as misattribution and close the PR. The `cliff.toml` filter makes this obvious: legitimate agent releases produce a non-empty, agent-focused changelog; misattribution releases produce a blank or noise-only one.
+
+## Extending the changelog filter
+
+`cliff.toml` skips commits whose scope is in this list:
+
+```
+desktop | cli | call | rpc | core | release | release-plz | fmt | ci | test | deps
+```
+
+- **Sibling crate scope, new addition**: extend the alternation in `cliff.toml` → `[[git.commit_parsers]] message = '^[a-z]+\\((…)\\):'` at the same time as the first commit using it. Otherwise the first such commit will pollute the agent changelog.
+- **New agent-internal sub-area** (e.g. you introduce `feat(notifications):`): **no `cliff.toml` change needed**. Agent-internal scopes fall through to the conventional-type parsers (`feat` → "added", `fix` → "fixed", etc.) and show up in the agent changelog as expected.
+
+Rust's `regex` crate has no negative lookahead, so the filter is an allowlist of "scopes to drop" rather than "scopes to keep". This is why new agent-internal scopes don't need re-listing — only new sibling/infra scopes do.
+
+## Release flow recap
+
+- `release-plz` creates per-package tags (`sapphire-agent-v*`, `sapphire-call-desktop-v*`, ...) and GitHub releases on push to main.
+- `.github/workflows/release-plz.yml` parses the `releases` output with `jq` and chains into reusable build workflows (`release.yml`, `release-cli.yml`, `release-desktop.yml`) which attach platform binaries to each release.
+- Tags pushed by `GITHUB_TOKEN` don't fire downstream workflows on their own — the `workflow_call` chain inside `release-plz.yml` is the path; `workflow_dispatch` with `-f tag=…` is the retroactive escape hatch.
+- `sapphire-call-desktop` carries `publish = false`; release-plz still tags + releases it because `release-plz.toml` sets `release = true` explicitly (the default for `publish = false` crates is to skip them).

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,88 @@
+# git-cliff configuration consumed by release-plz via the
+# `changelog_config` setting in release-plz.toml.
+#
+# Scope: this filters the CHANGELOG output only. release-plz's decision
+# of whether to bump a package's version is based on whether commits
+# touched files inside the package's directory, which `skip = true`
+# here does NOT override. In particular: `sapphire-agent`'s package
+# manifest lives at the workspace root, so any commit that touches
+# Cargo.lock or release-plz.toml still triggers an agent bump even
+# when this file filters every commit out of agent's changelog. The
+# trade-off accepted: cliff.toml keeps the changelog clean; the
+# resulting empty / minor-only release PR is left for a human to close
+# or merge. See closed PR #143 / #144 for the history.
+
+[changelog]
+header = ""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]\
+    {%- if release_link -%}\
+        ({{ release_link }})\
+    {% endif %}\
+    {%- if timestamp %} - {{ timestamp | date(format="%Y-%m-%d") }}{% endif %}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}\
+            {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"
+
+# Skip commits whose scope targets a sibling crate or pure workspace
+# infrastructure. The first matching parser wins, so this block must
+# come before the conventional-type group mappings below.
+#
+# Extend the alternation list when introducing a new sibling-crate or
+# workspace-infra scope. New agent-internal scopes (`(messages)`,
+# `(voice)`, ...) need no change here — they fall through to the
+# conventional-type parsers and appear in agent's changelog.
+[[git.commit_parsers]]
+message = '^[a-z]+\((desktop|cli|call|rpc|core|release|release-plz|fmt|ci|test|deps)\):'
+skip = true
+
+# Conventional commit type → changelog group mapping. Mirrors
+# release-plz's defaults so the section ordering stays familiar.
+[[git.commit_parsers]]
+message = '^feat'
+group = "added"
+[[git.commit_parsers]]
+message = '^fix'
+group = "fixed"
+[[git.commit_parsers]]
+message = '^perf'
+group = "performance"
+[[git.commit_parsers]]
+message = '^refactor'
+group = "changed"
+[[git.commit_parsers]]
+message = '^style'
+group = "changed"
+[[git.commit_parsers]]
+message = '^doc'
+group = "documentation"
+[[git.commit_parsers]]
+message = '^test'
+group = "testing"
+[[git.commit_parsers]]
+message = '^chore'
+group = "other"
+[[git.commit_parsers]]
+message = '.*'
+group = "other"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,14 @@ git_release_name = "{{ package }}-v{{ version }}"
 # and per-package tags / GH releases use `{{ package }}-v{{ version }}` above.
 pr_name = "chore(release): version bump"
 
+# Custom git-cliff config to drop sibling-crate-scoped commits from the
+# generated changelog entries. Doesn't suppress the version bump itself
+# (release-plz decides "did this package change?" purely from file
+# paths, and `sapphire-agent` lives at the workspace root so any
+# Cargo.lock touch still counts) — but it keeps the changelog
+# readable. See cliff.toml for details.
+changelog_config = "./cliff.toml"
+
 [[package]]
 name = "sapphire-agent"
 changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
## Summary

Two changes that go together:

### 1. cliff.toml — sibling-scope changelog filter
Add a custom git-cliff configuration wired to release-plz via `changelog_config`. Filters out commits whose conventional-commit scope targets a sibling crate (`(desktop)`, `(cli)`, `(call)`, `(rpc)`, `(core)`) or pure workspace infra (`(release)`, `(release-plz)`, `(fmt)`, `(ci)`, `(test)`, `(deps)`) from generated changelog entries.

**What this does NOT fix**: release-plz's release-trigger decision is purely path-based. Since `sapphire-agent`'s manifest lives at the workspace root, any commit that touches `Cargo.lock` / `release-plz.toml` / `README.md` still proposes an agent bump. Verified locally with `release-plz update` — bump still fires, but the changelog body no longer mentions desktop-only work.

The accepted trade-off (per discussion):
- Keep `sapphire-agent` at the workspace root — that's where the main crate belongs.
- Tolerate the occasional false-positive bump PR; the empty/minimal changelog is the visible signal that it's misattribution.
- Real agent changes still surface in the changelog under this filter, so signal/noise stays good on legitimate releases.

### 2. CLAUDE.md — document the conventions
Add a repo-root `CLAUDE.md` capturing:
- Scope → crate mapping so commits land in the right changelog
- The misattribution caveat with operational guidance (close the empty PRs)
- The rule for extending the `cliff.toml` skip list (new sibling/infra scopes need to be added; new agent-internal scopes don't)
- A short release-flow recap covering the workflow_call chain and the `GITHUB_TOKEN` tag-push limitation

## Test plan
- [x] Local `release-plz update` produces a clean filtered changelog (`feat(desktop):` / `style(fmt):` gone, `ci:` retained as expected)
- [ ] After merge: next time a desktop/cli/rpc/core commit lands, observe that release-plz still proposes an agent bump but the changelog body excludes the sibling-scope entry — close it by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)