### PR TITLE
chore(ci): add cargo-deny for license and advisory checks

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,27 @@
+name: cargo-deny
+
+# License compatibility, advisory (RUSTSEC) scanning, banned crates, and
+# unknown-source checks. The weekly schedule catches newly-filed advisories
+# against deps that haven't changed.
+
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/cargo-deny.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,74 @@
+# cargo-deny config. Run locally with `cargo deny check`.
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Restrict the dep graph to the platforms we actually publish binaries for
+# (see release.yml). Drops UEFI/WASM-only transitive deps like `r-efi`
+# (LGPL-2.1-or-later) so we don't need to allow their licenses.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+yanked = "warn"
+# Each ignore must have a reason field so the next contributor can judge
+# whether the entry is still load-bearing. Re-evaluate when the upstream
+# dep moves off the flagged package, or when a more severe advisory is
+# filed.
+ignore = [
+    # --- unmaintained (no vulnerability) ---
+    { id = "RUSTSEC-2025-0141", reason = "bincode 2.x is unmaintained but used transitively via lindera → lance; no safe upgrade exists." },
+    { id = "RUSTSEC-2021-0153", reason = "encoding crate is unmaintained but pulled in via lindera → lance." },
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but pulled in via many proc-macro consumers; no drop-in replacement." },
+
+    # --- rustls-webpki 0.102.x advisories pinned by serenity → tokio-tungstenite 0.21 → tokio-rustls 0.25 → rustls 0.22 ---
+    # Fixes are in rustls-webpki 0.103.x, which requires rustls 0.23. serenity
+    # 0.12.5 (latest) is locked to the older rustls stack, so we can't upgrade
+    # without serenity itself moving. None of these advisories are reachable
+    # from this codebase's usage (no CRLs, no name constraints in Discord TLS).
+    # Drop these once serenity ships a release on rustls 0.23.
+    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102.x CRL distribution-point matching; transitive via serenity → tokio-tungstenite 0.21." },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102.x URI name-constraint acceptance; transitive via serenity → tokio-tungstenite 0.21." },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102.x wildcard-name constraint acceptance; transitive via serenity → tokio-tungstenite 0.21." },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.x CRL parsing panic; transitive via serenity → tokio-tungstenite 0.21." },
+]
+
+[licenses]
+# Permissive SPDX identifiers actually present in the resolved graph for
+# the targets above. Re-survey with `cargo deny list --layout license`
+# before widening.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "bzip2-1.0.6",
+]
+confidence-threshold = 0.93
+
+[bans]
+# Duplicate-version warnings are too noisy in real Rust workspaces (every
+# transitively-pulled `syn`/`bitflags`/`hashbrown` version trips it).
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

Adds [cargo-deny](https://embarkstudios.github.io/cargo-deny/) with a tuned `deny.toml` and a dedicated GitHub Actions workflow that runs on PRs touching Cargo metadata, on push to main, and on a weekly schedule. The weekly run catches newly-filed RUSTSEC advisories against deps that haven't otherwise changed.

Adapts the config from sister repo `fluo10/sapphire-journal` (#253) to this repo's actual dep graph — the allowlist, target list, and ignore set were re-derived from a real `cargo deny list --layout license` survey here.

Closes #149.

### `deny.toml` highlights

- **Target filtering** — `[graph] targets` restricts analysis to the four platforms in `release.yml` (Linux x86_64/aarch64, macOS aarch64, Windows x86_64). Filters out UEFI-only transitive deps like `r-efi` (LGPL-2.1-or-later) so they don't need globally allowing.
- **License allowlist** — explicit enumeration of permissive SPDX IDs actually present in the resolved graph. Differences from sapphire-journal:
  - **+** `bzip2-1.0.6` (libbz2-rs-sys — Rust port of bzip2)
  - **−** `OFL-1.1`, `NCSA`, `BSD-1-Clause` (not present in this repo's graph under the target filter)
  - **−** `GPL-3.0-or-later` / `Ubuntu-font-1.0` exceptions — `sapphire-call-desktop` ships under `MIT OR Apache-2.0` and there is no bundled font here
- **`multiple-versions = "allow"`** — duplicate-version noise is unavoidable in real Rust workspaces; CVEs are what we actually care about

### Ignored advisories

All seven entries have a `reason` field explaining the dependency chain. Re-evaluate when upstreams move or when a more severe advisory is filed.

**Unmaintained (no vulnerability):**

| ID | Crate | Path |
|---|---|---|
| RUSTSEC-2025-0141 | bincode 2.x | lindera → lance |
| RUSTSEC-2021-0153 | encoding | lindera → lance |
| RUSTSEC-2024-0436 | paste | many proc-macro consumers |

**rustls-webpki 0.102.x vulnerabilities — known limitation, please review:**

| ID | Summary |
|---|---|
| RUSTSEC-2026-0049 | CRL distribution-point matching |
| RUSTSEC-2026-0098 | URI name-constraint acceptance |
| RUSTSEC-2026-0099 | Wildcard-name constraint acceptance |
| RUSTSEC-2026-0104 | CRL parsing panic |

All four come through `serenity 0.12.5` (latest) → `tokio-tungstenite 0.21` → `tokio-rustls 0.25` → `rustls 0.22` → `rustls-webpki 0.102`. Fixes are in `rustls-webpki 0.103.x`, which requires `rustls 0.23` — serenity is locked to the older stack, so we can't upgrade without serenity itself moving. None of these advisories are reachable from this codebase's actual Discord TLS usage (no CRLs, no name constraints). Drop the ignores once serenity ships on rustls 0.23.

If you'd rather not ignore vulnerabilities even when unreachable, the alternative is filing a follow-up issue to replace serenity, and leaving these advisories failing the build until then.

### Verified locally

```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

## Test plan

- [ ] CI `cargo-deny` job passes on this PR
- [ ] Confirm the scheduled run fires on Monday 06:00 UTC after merge
- [ ] If a future PR adds a dep with a new SPDX identifier, confirm the check fails with a useful diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)