### PR TITLE
fix(mcp-client): use fire-and-forget for `notifications/initialized`

### DIFF
--- a/src/mcp_client/mod.rs
+++ b/src/mcp_client/mod.rs
@@ -232,16 +232,16 @@ impl McpClient {
         );
 
         // Send initialized notification (no id, no response expected).
+        // Must use `notify` — `request` would block reading stdout for a
+        // response that the spec says will never arrive.
         let notification = json!({
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         });
-        let req_handler = self.server_request_handler();
-        let notif_handler = self.notification_handler();
         let transport = self.transport.read().await.clone();
-        let _ = transport
-            .request(&notification, &req_handler, &notif_handler)
-            .await;
+        if let Err(e) = transport.notify(&notification).await {
+            warn!("MCP '{}': initialized notification failed: {e:#}", self.name);
+        }
 
         Ok(())
     }

--- a/src/mcp_client/transport.rs
+++ b/src/mcp_client/transport.rs
@@ -43,6 +43,13 @@ pub trait McpTransport: Send + Sync {
         on_notification: &NotificationHandler,
     ) -> Result<Value>;
 
+    /// Send a JSON-RPC notification (no `id`, no response expected).
+    ///
+    /// Notifications must not go through [`request`], which blocks waiting
+    /// for a matching response that never arrives — over stdio that hangs
+    /// the whole startup path.
+    async fn notify(&self, body: &Value) -> Result<()>;
+
     /// Gracefully shut down the transport (close connection / kill child).
     async fn shutdown(&self) -> Result<()>;
 }
@@ -204,6 +211,15 @@ impl McpTransport for HttpTransport {
         }
     }
 
+    async fn notify(&self, body: &Value) -> Result<()> {
+        let session_id = self.session_id.lock().await.clone();
+        self.build_request(body, &session_id)
+            .send()
+            .await
+            .context("Failed to send notification to MCP server")?;
+        Ok(())
+    }
+
     async fn shutdown(&self) -> Result<()> {
         // HTTP transport is stateless per-request; nothing to shut down.
         Ok(())
@@ -340,6 +356,18 @@ impl McpTransport for StdioTransport {
                 debug!("stdio message (unrecognized): {data}");
             }
         }
+    }
+
+    async fn notify(&self, body: &Value) -> Result<()> {
+        let mut stdin = self.stdin.lock().await;
+        let mut line = serde_json::to_string(body)?;
+        line.push('\n');
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .context("Failed to write notification to MCP server stdin")?;
+        stdin.flush().await?;
+        Ok(())
     }
 
     async fn shutdown(&self) -> Result<()> {


### PR DESCRIPTION
## Summary
- Sending the post-handshake `notifications/initialized` through `McpTransport::request` blocks forever on stdio: the request loop reads lines from the child's stdout waiting for a response keyed by `id = null`, but MCP servers never respond to notifications.
- HTTP transports escaped this because the POST returned with no body and the function moved on.
- The hang only surfaced once an stdio MCP server actually completed its handshake — the agent logged `MCP '<name>': connected` and then went silent (no further MCP tool listing, no Matrix sync) because `create_mcp_tools` never returned, freezing the entire post-`default_tool_set` startup path.

## Fix
- Add a `notify` method to the `McpTransport` trait for fire-and-forget JSON-RPC notifications.
- `StdioTransport::notify` writes the line to stdin and flushes; `HttpTransport::notify` POSTs and drops the response body.
- `McpClient::connect` now uses `notify` for `notifications/initialized` (the only notification we emit). Any error is logged as a `warn!` rather than swallowed.

## Test plan
- [x] `cargo build -p sapphire-agent` passes.
- [x] Reproduced on local systemd unit: before the fix, `journalctl --user -u sapphire-agent.service` stopped emitting anything immediately after `MCP 'fluo10s-journal': connected`. After the fix, the log continues with `found 13 tools`, `Channels active: matrix, discord`, and ongoing Matrix sync.
- [ ] Confirm no regression for HTTP-transport MCP servers (the `notify` impl returns immediately on a body-less response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)